### PR TITLE
Minor Design UX improvements

### DIFF
--- a/content/guide/api-reference.md
+++ b/content/guide/api-reference.md
@@ -5,7 +5,7 @@ permalink: '/guide/api-reference'
 
 # API Reference
 
-## `Preact.Component`
+## Preact.Component
 
 `Component` is a base class that you will usually subclass to create stateful Preact components.
 

--- a/src/style/index.less
+++ b/src/style/index.less
@@ -11,7 +11,7 @@ html, body {
 	padding: 0;
 	margin: 0;
 	background: #FFF;
-	font: 15px/1.8 system-ui, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+	font: 16px/1.65 system-ui, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
 	font-weight: 400;
 	color: #444;
 	-webkit-font-smoothing: antialiased;
@@ -39,13 +39,13 @@ a.white {
 
 pre, code {
 	font-family: 'source-code-pro', Menlo, Consolas, Monaco, 'Andale Mono', 'Courier New', monospace;
-	font-size: 13px;
+	font-size: .9rem;
 }
 
 pre.highlight {
 	position: relative;
 	border: none;
-	margin-bottom: 40px;
+	margin-bottom: 2.5rem;
 	padding: 0 !important;
 	line-height: 1.5;
 
@@ -82,7 +82,7 @@ content-region {
 
 	& > main {
 		min-height: 95%;
-		padding-top: 56px;
+		padding-top: @header-height;
 	}
 }
 

--- a/src/style/index.less
+++ b/src/style/index.less
@@ -24,13 +24,8 @@ html, body {
 }
 
 a {
-	color: #2f6daa;
+	color: @color-link;
 	text-decoration: none;
-
-	&:hover, &:active, &:focus {
-		text-decoration: underline;
-		color: darken(#2f6daa, 15%);
-	}
 }
 
 a.white {

--- a/src/style/markdown.less
+++ b/src/style/markdown.less
@@ -1,9 +1,14 @@
 .markup, .markdown {
-	& > *:first-child {
-		margin-top: 0;		// !important
+	& > * ~ * {
+		margin-top: 1.25rem;
 	}
-	& > *:last-child {
-		margin-bottom: 0;	// !important
+
+	p a {
+		background: linear-gradient(currentColor, currentColor);
+		text-shadow: 3px 0 #fff, 2px 0 #fff, 1px 0 #fff, -1px 0 #fff, -2px 0 #fff, -3px 0 #fff;
+		background-position: center bottom;
+		background-size: 100% 0.09rem;
+		background-repeat: no-repeat;
 	}
 
 	a.anchor {
@@ -48,8 +53,7 @@
 	}
 
 	h2 {
-		font-size: 24px;
-		border-bottom: 1px solid #ccc;
+		font-size: 1.8rem;
 		color: black;
 	}
 
@@ -68,10 +72,6 @@
 	h6 {
 		color: #777;
 		font-size: 14px;
-	}
-
-	p, blockquote, ul, ol, dl, li, table, pre {
-		margin: 20px 0;
 	}
 
 	ul, ol {
@@ -158,9 +158,10 @@
 	}
 
 	blockquote {
-		border-left: 4px solid #ddd;
-		padding: 0 15px;
-		color: #777;
+		border-left: .3rem solid @blockquote-border;
+		padding: .75rem 1rem;
+		background: @blockquote-bg;
+		color: #333;
 	}
 	blockquote > :first-child {
 		margin-top: 0;

--- a/src/style/markdown.less
+++ b/src/style/markdown.less
@@ -161,7 +161,7 @@
 		border-left: .3rem solid @blockquote-border;
 		padding: .75rem 1rem;
 		background: @blockquote-bg;
-		color: #333;
+		color: #444;
 	}
 	blockquote > :first-child {
 		margin-top: 0;

--- a/src/style/markdown.less
+++ b/src/style/markdown.less
@@ -3,7 +3,9 @@
 		margin-top: 1.25rem;
 	}
 
-	p a {
+	p a,
+	ul a,
+	ol a {
 		background: linear-gradient(currentColor, currentColor);
 		text-shadow: 3px 0 #fff, 2px 0 #fff, 1px 0 #fff, -1px 0 #fff, -2px 0 #fff, -3px 0 #fff;
 		background-position: center bottom;

--- a/src/style/variables.less
+++ b/src/style/variables.less
@@ -1,4 +1,4 @@
-@header-height: 3.75rem; // 56px
+@header-height: 3.5rem; // 56px
 @header-mobile-breakpoint: 37.5rem; // 600px
 
 @color-link: #2f6daa;

--- a/src/style/variables.less
+++ b/src/style/variables.less
@@ -1,2 +1,6 @@
 @header-height: 3.75rem; // 56px
 @header-mobile-breakpoint: 37.5rem; // 600px
+
+@color-link: #2f6daa;
+@blockquote-border: #5aa8ff;
+@blockquote-bg: #ebf6ff;

--- a/src/style/variables.less
+++ b/src/style/variables.less
@@ -1,2 +1,2 @@
-@header-height: 56px;
-@header-mobile-breakpoint: 600px;
+@header-height: 3.75rem; // 56px
+@header-mobile-breakpoint: 37.5rem; // 600px


### PR DESCRIPTION
This PR makes minor changes to the css to make our site easier to read.

- Increase font size from `15px` to `16px`. It's not much but makes the font easier to read on my screen.
- Increase `h2` size to make it easier to scan for the eyes
- Change text link styles to be more upbeat and visually more distinct from their surroundings
- Make blockquotes more visually appealing by using colors. This better differentiates them from the body text and hints to the user in a visual way that it may contain some useful information

The changes are best illustrated via a screenshot.

Before:

![preact-typo-before](https://user-images.githubusercontent.com/1062408/60792037-2f5e7880-a165-11e9-8460-92745d960600.png)

After:

![preact-typo-after](https://user-images.githubusercontent.com/1062408/60792044-31c0d280-a165-11e9-9f4f-a54195bedfc1.png)
