### PR TITLE
Check if browser supports SW before using them

### DIFF
--- a/src/pwa.js
+++ b/src/pwa.js
@@ -3,17 +3,19 @@
 let hasInteracted, shouldReload;
 
 function sw() {
-	navigator.serviceWorker.getRegistration().then(reg => {
-		reg.onupdatefound = () => {
-			const w = reg.installing;
-			w.onstatechange = () => {
-				if (w.state === 'installed' && navigator.serviceWorker.controller) {
-					shouldReload = true;
-					if (!hasInteracted) location.reload();
-				}
+	if ('serviceWorker' in navigator) {
+		navigator.serviceWorker.getRegistration().then(reg => {
+			reg.onupdatefound = () => {
+				const w = reg.installing;
+				w.onstatechange = () => {
+					if (w.state === 'installed' && navigator.serviceWorker.controller) {
+						shouldReload = true;
+						if (!hasInteracted) location.reload();
+					}
+				};
 			};
-		};
-	});
+		});
+	}
 }
 
 if (!PRERENDER) {


### PR DESCRIPTION
Not all browsers support Service-Workers, so this PR checks for them before trying to use them. I've run into this in my local dev setup which doesn't use https.