### PR TITLE
Make table of contents always visible

### DIFF
--- a/src/components/controllers/page/index.js
+++ b/src/components/controllers/page/index.js
@@ -4,6 +4,7 @@ import cx from '../../../lib/cx';
 import ContentRegion from '../../content-region';
 import config from '../../../config';
 import style from './style';
+import Toc from './table-of-content';
 
 const EMPTY = {};
 
@@ -67,29 +68,6 @@ export default class Page extends Component {
 						onLoad={this.onLoad}
 					/>
 				</div>
-			</div>
-		);
-	}
-}
-
-
-class Toc extends Component {
-	toggle = e => {
-		this.setState({ open: !this.state.open });
-		return false;
-	};
-
-	open = () => this.setState({ open: true });
-
-	render({ items }, { open }) {
-		return (
-			<div class={cx(style.toc, !(items && items.length>1) && style.disabled)} open={open}>
-				<a class={style.toggle} onClick={this.toggle} title="Table of Contents">🔗</a>
-				<nav tabIndex="0" onFocus={this.open}>
-					{ items.map( ({ text, level, id }) => (
-						<a href={'#' + id}>{ text }</a>
-					)) }
-				</nav>
 			</div>
 		);
 	}

--- a/src/components/controllers/page/index.js
+++ b/src/components/controllers/page/index.js
@@ -52,15 +52,18 @@ export default class Page extends Component {
 		let layout = `${meta.layout || 'default'}Layout`,
 			name = getContent(route);
 		if (name!==current) loading = true;
+
+		let hasToc = toc && meta.toc!==false;
+
 		return (
-			<div class={cx(style.page, style[layout])}>
+			<div class={cx(style.page, style[layout], hasToc && style.withToc)}>
 				<progress-bar showing={loading} />
-				{ name!='index' && meta.show_title!==false && (
+				{name!='index' && meta.show_title!==false && (
 					<h1 class={style.title}>{ meta.title || route.title }</h1>
-				) }
-				{ toc && meta.toc!==false && (
+				)}
+				{hasToc && (
 					<Toc items={toc} />
-				) }
+				)}
 				<div class={style.inner}>
 					<ContentRegion
 						name={name}

--- a/src/components/controllers/page/style.less
+++ b/src/components/controllers/page/style.less
@@ -9,8 +9,12 @@
 	}
 
 	:global .markup {
-		padding: 50px 0;
 		overflow: visible;
+		padding: 1em 0;
+
+		@media (min-width: 800px) {
+			padding: 3.125em 0;
+		}
 
 		& > *,
 		.full-width > *,

--- a/src/components/controllers/page/style.less
+++ b/src/components/controllers/page/style.less
@@ -2,11 +2,9 @@
 
 .page {
 	position: relative;
-	overflow: hidden;
-
-	@media (min-width: 800px) {
-		padding-left: 0vw;
-	}
+	max-width: 100rem;
+	margin-left: auto;
+	margin-right: auto;
 
 	:global .markup {
 		overflow: visible;
@@ -56,16 +54,28 @@
 
 	.inner {
 		position: relative;
-		overflow: hidden;
 		min-height: 200px;
 	}
 }
 
 .withToc {
-	@media (min-width: 800px) {
-		margin-left: 18rem;
+	.title {
+		@media (min-width: 800px) {
+			margin-left: @sidebar-width;
+		}
+
+		@media (min-width: 1600px) {
+			margin-left: auto;
+			margin-right: auto;
+		}
 	}
-	@media (min-width: 1300px) {
-		margin-left: 0;
+
+	.inner {
+		@media (min-width: 800px) {
+			padding-left: @sidebar-width;
+		}
+		@media (min-width: 1600px) {
+			padding-left: 0;
+		}
 	}
 }

--- a/src/components/controllers/page/style.less
+++ b/src/components/controllers/page/style.less
@@ -96,14 +96,10 @@
 	}
 
 	.title {
-		margin: 0 -1em;
-		padding: .5em;
-		background: #22262e;
-		color: #f2777a;
-		text-shadow: 0 0 2px rgba(0,0,0,0.7);
-		font-size: 3em;
+		margin: 1rem 0 0 0;
+		padding: .5em .5em 0;
+		font-size: 4rem;
 		font-weight: 200;
-		box-shadow: inset 0 0 20px rgba(0,0,0,0.4);
 		text-align: center;
 	}
 

--- a/src/components/controllers/page/style.less
+++ b/src/components/controllers/page/style.less
@@ -56,3 +56,12 @@
 		min-height: 200px;
 	}
 }
+
+.withToc {
+	@media (min-width: 800px) {
+		margin-left: 18rem;
+	}
+	@media (min-width: 1300px) {
+		margin-left: 0;
+	}
+}

--- a/src/components/controllers/page/style.less
+++ b/src/components/controllers/page/style.less
@@ -4,6 +4,10 @@
 	position: relative;
 	overflow: hidden;
 
+	@media (min-width: 800px) {
+		padding-left: 0vw;
+	}
+
 	:global .markup {
 		padding: 50px 0;
 		overflow: visible;
@@ -29,69 +33,6 @@
 		pre.highlight {
 			border-radius: 0;
 			padding: 20px 0;
-		}
-	}
-
-	.toc {
-		display: inline-block;
-		position: fixed;
-		right: -5px;
-		top: @header-height + 10px;
-		transform: translateX(100%);
-		opacity: 0.8;
-		z-index: 100;
-		transition: all 250ms ease;
-		outline: none;
-
-		&.disabled {
-			display: none;
-		}
-
-		.toggle {
-			position: absolute;
-			left: -45px;
-			top: 10px;
-			width: 48px;
-			height: 40px;
-			background: #FAFAFA;
-			box-shadow: 0 1px 6px rgba(0,0,0,0.3);
-			border: none;
-			border-radius: 3px;
-			font-size: 20px;
-			line-height: 40px;
-			text-align: left;
-			text-indent: 12px;
-			color: #FFF;
-			cursor: pointer;
-			z-index: 1;
-
-			&:hover {
-				background: #FFF;
-			}
-		}
-
-		&[open] {
-			transform: skew(0,0);
-			opacity: 1;
-		}
-
-		nav {
-			position: relative;
-			padding: 20px;
-			background: #fff;
-			box-shadow: 0 2px 7px rgba(0,0,0,0.3);
-			border-radius: 2px;
-			overflow: hidden;
-			z-index: 2;
-
-			a {
-				display: block;
-				border: none;
-
-				&:hover {
-					text-decoration: underline;
-				}
-			}
 		}
 	}
 

--- a/src/components/controllers/page/table-of-content.js
+++ b/src/components/controllers/page/table-of-content.js
@@ -47,13 +47,15 @@ export default class Toc extends Component {
 	render({ items }, { open }) {
 		return (
 			<div class={cx(style.toc, !(items && items.length>1) && style.disabled)} data-open={open}>
-				<button class={style.toggle} onClick={this.toggle} value="table of contents">{'<>'}</button>
-				<nav tabIndex="0" onFocus={this.open}>
-					{items.map(({ text, level, id }) => {
-						let activeCss = this.state.active===id ? style.linkActive : undefined;
-						return <a href={'#' + id} class={cx(style.link, activeCss, style['level-' + level])}>{text}</a>;
-					})}
-				</nav>
+				<div class={style.inner}>
+					<button class={style.toggle} onClick={this.toggle} value="table of contents">{'<>'}</button>
+					<nav tabIndex="0" onFocus={this.open}>
+						{items.map(({ text, level, id }) => {
+							let activeCss = this.state.active===id ? style.linkActive : undefined;
+							return <a href={'#' + id} class={cx(style.link, activeCss, style['level-' + level])}>{text}</a>;
+						})}
+					</nav>
+				</div>
 			</div>
 		);
 	}

--- a/src/components/controllers/page/table-of-content.js
+++ b/src/components/controllers/page/table-of-content.js
@@ -1,0 +1,59 @@
+import { h, Component } from 'preact';
+import cx from '../../../lib/cx';
+import style from './table-of-contents.less';
+
+export default class Toc extends Component {
+	toggle = () => {
+		this.setState({ open: !this.state.open });
+		return false;
+	};
+
+	open = () => this.setState({ open: true });
+
+	componentDidMount() {
+		if ('IntersectionObserver' in window) {
+			let config = {
+				root: null,
+				threshold: 1,
+				rootMargin: '0px'
+			};
+
+			this.observer = new IntersectionObserver(entries => {
+				let active = [];
+				entries.forEach(entry => {
+					let id = entry.target.getAttribute('id');
+					let link = this.props.items.find(link => link.id === id);
+					if (link && entry.isIntersecting && entry.intersectionRatio >= 0.75) {
+						active.push(id);
+					}
+				});
+
+				if (active.length > 0) {
+					this.setState({ active: active[0] });
+				}
+			}, config);
+
+			Array.prototype.slice.call(document.querySelectorAll('content-region h2'))
+				.forEach(heading => this.observer.observe(heading));
+		}
+	}
+
+	componentWillUnmount() {
+		if (this.observer) {
+			this.observer.disconnect();
+		}
+	}
+
+	render({ items }, { open }) {
+		return (
+			<div class={cx(style.toc, !(items && items.length>1) && style.disabled)} open={open}>
+				<button class={style.toggle} onClick={this.toggle}>Table of Contents🔗</button>
+				<nav tabIndex="0" onFocus={this.open}>
+					{items.map(({ text, level, id }) => (
+						<a href={'#' + id} class={this.state.active===id ? style.active : undefined}><span class={style.linkInner}>{ text }</span></a>
+					))}
+				</nav>
+			</div>
+		);
+	}
+}

--- a/src/components/controllers/page/table-of-content.js
+++ b/src/components/controllers/page/table-of-content.js
@@ -47,7 +47,7 @@ export default class Toc extends Component {
 	render({ items }, { open }) {
 		return (
 			<div class={cx(style.toc, !(items && items.length>1) && style.disabled)} open={open}>
-				<button class={style.toggle} onClick={this.toggle}>Table of Contents🔗</button>
+				<button class={style.toggle} onClick={this.toggle} value="table of contents">{'<>'}</button>
 				<nav tabIndex="0" onFocus={this.open}>
 					{items.map(({ text, level, id }) => {
 						let activeCss = this.state.active===id ? style.linkActive : undefined;

--- a/src/components/controllers/page/table-of-content.js
+++ b/src/components/controllers/page/table-of-content.js
@@ -33,7 +33,7 @@ export default class Toc extends Component {
 				}
 			}, config);
 
-			Array.from(document.querySelectorAll('content-region h2'))
+			Array.from(document.querySelectorAll('content-region h2, content-region h3, content-region h4'))
 				.forEach(heading => this.observer.observe(heading));
 		}
 	}

--- a/src/components/controllers/page/table-of-content.js
+++ b/src/components/controllers/page/table-of-content.js
@@ -46,7 +46,7 @@ export default class Toc extends Component {
 
 	render({ items }, { open }) {
 		return (
-			<div class={cx(style.toc, !(items && items.length>1) && style.disabled)} open={open}>
+			<div class={cx(style.toc, !(items && items.length>1) && style.disabled)} data-open={open}>
 				<button class={style.toggle} onClick={this.toggle} value="table of contents">{'<>'}</button>
 				<nav tabIndex="0" onFocus={this.open}>
 					{items.map(({ text, level, id }) => {

--- a/src/components/controllers/page/table-of-content.js
+++ b/src/components/controllers/page/table-of-content.js
@@ -33,7 +33,7 @@ export default class Toc extends Component {
 				}
 			}, config);
 
-			Array.prototype.slice.call(document.querySelectorAll('content-region h2'))
+			Array.from(document.querySelectorAll('content-region h2'))
 				.forEach(heading => this.observer.observe(heading));
 		}
 	}

--- a/src/components/controllers/page/table-of-content.js
+++ b/src/components/controllers/page/table-of-content.js
@@ -49,9 +49,10 @@ export default class Toc extends Component {
 			<div class={cx(style.toc, !(items && items.length>1) && style.disabled)} open={open}>
 				<button class={style.toggle} onClick={this.toggle}>Table of Contents🔗</button>
 				<nav tabIndex="0" onFocus={this.open}>
-					{items.map(({ text, level, id }) => (
-						<a href={'#' + id} class={this.state.active===id ? style.active : undefined}><span class={style.linkInner}>{ text }</span></a>
-					))}
+					{items.map(({ text, level, id }) => {
+						let activeCss = this.state.active===id ? style.linkActive : undefined;
+						return <a href={'#' + id} class={cx(style.link, activeCss)}>{text}</a>;
+					})}
 				</nav>
 			</div>
 		);

--- a/src/components/controllers/page/table-of-content.js
+++ b/src/components/controllers/page/table-of-content.js
@@ -51,7 +51,7 @@ export default class Toc extends Component {
 				<nav tabIndex="0" onFocus={this.open}>
 					{items.map(({ text, level, id }) => {
 						let activeCss = this.state.active===id ? style.linkActive : undefined;
-						return <a href={'#' + id} class={cx(style.link, activeCss)}>{text}</a>;
+						return <a href={'#' + id} class={cx(style.link, activeCss, style['level-' + level])}>{text}</a>;
 					})}
 				</nav>
 			</div>

--- a/src/components/controllers/page/table-of-contents.less
+++ b/src/components/controllers/page/table-of-contents.less
@@ -7,18 +7,17 @@
 	z-index: 20;
 
 	@media (min-width: 800px) {
-		& {
-			width: 20vw;
-			position: fixed;
-			padding-left: 1.5rem;
-			padding-top: 3rem;
-			top: @header-height / 2;
-			left: 0;
-			bottom: 0;
-			background: whitesmoke;
-			background: white;
-			border-left: .0625rem solid #eee;
-		}
+		width: 18em;
+		position: fixed;
+		padding-left: 1.5em;
+		padding-top: 1.5em;
+		top: @header-height;
+		left: 0;
+		bottom: 0;
+	}
+
+	@media (min-width: 1600px) {
+		left: 16vw;
 	}
 
 	&.disabled {

--- a/src/components/controllers/page/table-of-contents.less
+++ b/src/components/controllers/page/table-of-contents.less
@@ -24,7 +24,7 @@
 		display: none;
 	}
 
-	&[open] {
+	&[data-open] {
 		nav {
 			display: block;
 			visibility: visible;
@@ -88,7 +88,7 @@
 		box-shadow: 0 0 5px 5px lighten(@color-corner, 20%);
 	}
 
-	[open] & {
+	[data-open] & {
 		transform: rotate(90deg);
 	}
 }

--- a/src/components/controllers/page/table-of-contents.less
+++ b/src/components/controllers/page/table-of-contents.less
@@ -49,11 +49,12 @@
 		opacity: 0;
 
 		@media (min-width: 800px) {
+			position: absolute;
+			top: @header-height / 2;
 			transform: none;
 			display: block;
 			visibility: visible;
 			opacity: 1;
-			background: inherit;
 			padding: 2rem;
 		}
 	}
@@ -98,14 +99,11 @@
 	position: relative;
 	padding: .2em 0 .2em 1em;
 	color: @sidebar-link-color;
-
-	&::before,
-	&::after {
-		content: '';
-		.fadeOut;
-	}
+	transition: background .3s;
 
 	&::before {
+		.fadeOut;
+		content: '';
 		position: absolute;
 		top: 0;
 		left: 0;
@@ -113,21 +111,14 @@
 		width: .2em;
 		background: @color-brand;
 	}
-
-	&::after {
-		.fill();
-		background: @sidebar-active-bg;
-		z-index: -1;
-		transition: visibility .5s, opacity .5s
-	}
 }
 
 .linkActive {
 	color: @color-brand;
 	font-weight: bold;
+	background: @sidebar-active-bg;
 
-	&::before,
-	&::after {
+	&::before {
 		.fadeIn;
 	}
 }

--- a/src/components/controllers/page/table-of-contents.less
+++ b/src/components/controllers/page/table-of-contents.less
@@ -70,11 +70,10 @@
 	border-radius: 50%;
 	width: 3rem;
 	height: 3rem;
-	color: @color-brand;
+	color: white;
 	font-weight: bold;
-	background: whitesmoke;
+	background: @color-corner;
 	box-shadow: .125rem .125rem 5px rgba(0, 0, 0, 0.15);
-	border: .0625rem solid white;
 	padding: .7em;
 	cursor: pointer;
 	z-index: 25;
@@ -87,7 +86,7 @@
 	&:focus {
 		outline: none;
 		// Use box shadow to draw an outline because outline has no radius
-		box-shadow: 0 0 5px 5px lighten(@color-corner, 20%);
+		box-shadow: 0 0 5px 5px lighten(@color-brand, 20%);
 	}
 
 	[data-open] & {

--- a/src/components/controllers/page/table-of-contents.less
+++ b/src/components/controllers/page/table-of-contents.less
@@ -4,19 +4,21 @@
 	display: block;
 	position: relative;
 	z-index: 20;
-	overflow: auto;
 
 	@media (min-width: 800px) {
-		padding-top: 2rem;
-		width: 18rem;
-		position: fixed;
-		top: @header-height;
+		position: absolute;
 		left: 0;
+		top: 0;
 		bottom: 0;
 	}
 
-	@media (min-width: 1600px) {
-		left: 16vw;
+	.inner {
+		@media (min-width: 800px) {
+			position: sticky;
+			left: 0;
+			top: @header-height;
+			width: @sidebar-width;
+		}
 	}
 
 	&.disabled {
@@ -78,7 +80,7 @@
 	z-index: 25;
 	transition: transform .3s;
 
-	@media (min-width: 800px) {
+	@media (min-width: 50rem) {
 		display: none;
 	}
 

--- a/src/components/controllers/page/table-of-contents.less
+++ b/src/components/controllers/page/table-of-contents.less
@@ -122,3 +122,8 @@
 		.fadeIn;
 	}
 }
+
+.level-3 {
+	padding-left: 2.5rem;
+	margin-bottom: .5rem;
+}

--- a/src/components/controllers/page/table-of-contents.less
+++ b/src/components/controllers/page/table-of-contents.less
@@ -123,7 +123,25 @@
 	}
 }
 
+.level-2 + .level-3 {
+	margin-top: .5rem;
+}
 .level-3 {
 	padding-left: 2.5rem;
-	margin-bottom: .5rem;
 }
+.level-4 {
+	padding-left: 3.5rem;
+}
+
+.level-3 + .level-4 {
+	margin-top: .5rem;
+}
+.level-4 + .level-3 {
+	margin-top: .5rem;
+}
+
+.level-3 + .level-2,
+.level-4 + .level-2 {
+	margin-top: 1rem;
+}
+

--- a/src/components/controllers/page/table-of-contents.less
+++ b/src/components/controllers/page/table-of-contents.less
@@ -3,10 +3,10 @@
 .toc {
 	display: block;
 	position: relative;
-	padding-top: 2rem;
 	z-index: 20;
 
 	@media (min-width: 800px) {
+		padding-top: 2rem;
 		width: 18rem;
 		position: fixed;
 		padding-left: 1.5em;

--- a/src/components/controllers/page/table-of-contents.less
+++ b/src/components/controllers/page/table-of-contents.less
@@ -1,0 +1,108 @@
+@import '../../../style/helpers';
+
+.toc {
+	display: block;
+	outline: none;
+	padding-top: 2rem;
+	position: relative;
+	z-index: 20;
+
+	@media (min-width: 800px) {
+		& {
+			width: 20vw;
+			position: fixed;
+			padding-left: 1.5rem;
+			padding-top: 3rem;
+			top: @header-height / 2;
+			left: 0;
+			bottom: 0;
+			background: whitesmoke;
+			background: white;
+			border-left: .0625rem solid #eee;
+		}
+	}
+
+	&.disabled {
+		display: none;
+	}
+
+	.toggle {
+		display: block;
+		background: #22262e;
+		border: none;
+		border-radius: 3px;
+		color: #FFF;
+		padding: .7em;
+		cursor: pointer;
+		width: 100%;
+		text-transform: uppercase;
+		letter-spacing: .18em;
+
+		@media (min-width: 800px) {
+			display: none;
+		}
+	}
+
+	&[open] {
+		nav {
+			display: block;
+		}
+	}
+
+	nav {
+		// display: none;
+		position: absolute;
+		padding: 1.5rem 1.5rem 1.5rem .5rem;
+		left: 0;
+		right: 0;
+		background: #fff;
+		border-radius: 2px;
+		overflow: hidden;
+		z-index: 2;
+
+		@media (min-width: 800px) {
+			& {
+				display: block;
+				background: inherit;
+				padding: 2rem;
+			}
+		}
+
+		a {
+			display: block;
+			position: relative;
+			padding: .2rem 0 .2rem 1rem;
+			transition: background .5s;
+			color: #555;
+
+			&::before {
+				content: '';
+				visibility: hidden;
+				opacity: 0;
+			}
+		}
+
+		.linkInner {
+			// .link;
+		}
+	}
+}
+
+.toc nav .active {
+	background: #f6f6f6;
+	color: @color-brand;
+	font-weight: bold;
+
+	&::before {
+		content: '';
+		visibility: visible;
+		opacity: 1;
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: .2rem;
+		height: 100%;
+		background: @color-link;
+		background: @color-brand;
+	}
+}

--- a/src/components/controllers/page/table-of-contents.less
+++ b/src/components/controllers/page/table-of-contents.less
@@ -7,7 +7,7 @@
 	z-index: 20;
 
 	@media (min-width: 800px) {
-		width: 18em;
+		width: 18rem;
 		position: fixed;
 		padding-left: 1.5em;
 		padding-top: 1.5em;
@@ -24,47 +24,72 @@
 		display: none;
 	}
 
-	.toggle {
-		display: block;
-		background: #22262e;
-		border: none;
-		border-radius: 3px;
-		color: #FFF;
-		padding: .7em;
-		cursor: pointer;
-		width: 100%;
-		text-transform: uppercase;
-		letter-spacing: .18em;
-
-		@media (min-width: 800px) {
-			display: none;
-		}
-	}
-
 	&[open] {
 		nav {
 			display: block;
+			visibility: visible;
+			transform: translateY(0);
+			opacity: 1;
 		}
 	}
 
 	nav {
-		// display: none;
-		position: absolute;
+		visibility: hidden;
+		position: fixed;
+		top: @header-height;
+		bottom: 0;
 		padding: 1.5rem 1.5rem 1.5rem .5rem;
 		left: 0;
 		right: 0;
 		background: #fff;
 		border-radius: 2px;
 		overflow: hidden;
-		z-index: 2;
+		transform: translateY(100%);
+		transition: transform .3s, opacity .3s;
+		opacity: 0;
 
 		@media (min-width: 800px) {
-			& {
-				display: block;
-				background: inherit;
-				padding: 2rem;
-			}
+			transform: none;
+			display: block;
+			visibility: visible;
+			opacity: 1;
+			background: inherit;
+			padding: 2rem;
 		}
+	}
+}
+
+.toggle {
+	display: block;
+	position: fixed;
+	border: none;
+	bottom: 1rem;
+	right: 1rem;
+	border-radius: 50%;
+	width: 3rem;
+	height: 3rem;
+	color: @color-brand;
+	font-weight: bold;
+	background: whitesmoke;
+	box-shadow: .125rem .125rem 5px rgba(0, 0, 0, 0.15);
+	border: .0625rem solid white;
+	padding: .7em;
+	cursor: pointer;
+	z-index: 25;
+	transition: transform .3s;
+
+	@media (min-width: 800px) {
+		display: none;
+	}
+
+	&:focus {
+		outline: none;
+		// Use box shadow to draw an outline because outline has no radius
+		box-shadow: 0 0 5px 5px lighten(@color-corner, 20%);
+	}
+
+	[open] & {
+		transform: rotate(90deg);
 	}
 }
 

--- a/src/components/controllers/page/table-of-contents.less
+++ b/src/components/controllers/page/table-of-contents.less
@@ -4,13 +4,12 @@
 	display: block;
 	position: relative;
 	z-index: 20;
+	overflow: auto;
 
 	@media (min-width: 800px) {
 		padding-top: 2rem;
 		width: 18rem;
 		position: fixed;
-		padding-left: 1.5em;
-		padding-top: 1.5em;
 		top: @header-height;
 		left: 0;
 		bottom: 0;
@@ -49,13 +48,13 @@
 		opacity: 0;
 
 		@media (min-width: 800px) {
-			position: absolute;
-			top: @header-height / 2;
+			position: relative;
+			top: 0;
 			transform: none;
 			display: block;
 			visibility: visible;
 			opacity: 1;
-			padding: 2rem;
+			padding: 2rem 1rem 2rem 2rem;
 		}
 	}
 }
@@ -97,7 +96,7 @@
 .link {
 	display: block;
 	position: relative;
-	padding: .2em 0 .2em 1em;
+	padding: .2em .75em .2em 1em;
 	color: @sidebar-link-color;
 	transition: background .3s;
 
@@ -123,16 +122,16 @@
 	}
 }
 
-.level-2 + .level-3 {
-	margin-top: .5rem;
-}
 .level-3 {
-	padding-left: 2.5rem;
+	padding-left: 2rem;
 }
 .level-4 {
 	padding-left: 3.5rem;
 }
 
+.level-2 + .level-3 {
+	margin-top: .5rem;
+}
 .level-3 + .level-4 {
 	margin-top: .5rem;
 }

--- a/src/components/controllers/page/table-of-contents.less
+++ b/src/components/controllers/page/table-of-contents.less
@@ -2,9 +2,8 @@
 
 .toc {
 	display: block;
-	outline: none;
-	padding-top: 2rem;
 	position: relative;
+	padding-top: 2rem;
 	z-index: 20;
 
 	@media (min-width: 800px) {
@@ -67,42 +66,44 @@
 				padding: 2rem;
 			}
 		}
-
-		a {
-			display: block;
-			position: relative;
-			padding: .2rem 0 .2rem 1rem;
-			transition: background .5s;
-			color: #555;
-
-			&::before {
-				content: '';
-				visibility: hidden;
-				opacity: 0;
-			}
-		}
-
-		.linkInner {
-			// .link;
-		}
 	}
 }
 
-.toc nav .active {
-	background: #f6f6f6;
-	color: @color-brand;
-	font-weight: bold;
+.link {
+	display: block;
+	position: relative;
+	padding: .2em 0 .2em 1em;
+	color: @sidebar-link-color;
+
+	&::before,
+	&::after {
+		content: '';
+		.fadeOut;
+	}
 
 	&::before {
-		content: '';
-		visibility: visible;
-		opacity: 1;
 		position: absolute;
 		top: 0;
 		left: 0;
-		width: .2rem;
 		height: 100%;
-		background: @color-link;
+		width: .2em;
 		background: @color-brand;
+	}
+
+	&::after {
+		.fill();
+		background: @sidebar-active-bg;
+		z-index: -1;
+		transition: visibility .5s, opacity .5s
+	}
+}
+
+.linkActive {
+	color: @color-brand;
+	font-weight: bold;
+
+	&::before,
+	&::after {
+		.fadeIn;
 	}
 }

--- a/src/components/footer/style.less
+++ b/src/components/footer/style.less
@@ -27,4 +27,8 @@
 			margin-left: 10px;
 		}
 	}
+
+	a {
+		color: @color-brand;
+	}
 }

--- a/src/components/header/style.less
+++ b/src/components/header/style.less
@@ -7,7 +7,7 @@
 	width: 100%;
 	height: @header-height;
 	padding: 0;
-	background: #673AB8;
+	background: @color-brand;
 	// background: rgba(103,58,184,.98);
 	box-shadow: 0 0 5px rgba(0, 0, 0, 0.5);
 	z-index: 500;
@@ -377,7 +377,7 @@
 	height: 56px;
 	min-width: 80px;
 	overflow: visible;
-	background: #673AB8;
+	background: @color-brand;
 
 	@media (max-width: @header-mobile-breakpoint) {
 		flex-grow: 1;
@@ -398,12 +398,12 @@
 		background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 490 490" width="16" height="16"><path fill="none" stroke="%237447c5" stroke-width="36" stroke-linecap="round" d="m280,278a153,153 0 1,0-2,2l170,170m-91-117 110,110-26,26-110-110"/></svg>');
 		background-position: 10px center;
 		background-repeat: no-repeat;
-		background-color: darken(#673AB8, 7%) !important;
-		border: 1px solid lighten(#673AB8, 5%);
-		border-bottom-color: lighten(#673AB8, 10%);
+		background-color: darken(@color-brand, 7%) !important;
+		border: 1px solid lighten(@color-brand, 5%);
+		border-bottom-color: lighten(@color-brand, 10%);
 		border-radius: 5px;
 		box-shadow: inset 0 2px 5px rgba(0, 0, 0, 0.2);
-		color: #673AB8;
+		color: @color-brand;
 		font-size: 100%;
 		will-change: width;
 		transition: width 250ms ease;
@@ -414,7 +414,7 @@
 		}
 
 		&::-webkit-input-placeholder {
-			color: lighten(#673AB8, 5%);
+			color: lighten(@color-brand, 5%);
 		}
 
 		&:focus,
@@ -440,7 +440,7 @@
 	display: flex;
 	justify-content: center;
 	color: #fff;
-	background-color: #f2777a;
+	background-color: @color-corner;
 	height: @corner-size;
 	width: @corner-size;
 	position: absolute;
@@ -451,7 +451,7 @@
 
 	&:hover,
 	&:focus {
-		background-color: darken(#f2777a, 5%);
+		background-color: darken(@color-corner, 5%);
 		text-decoration: none;
 		color: #fff;
 	}

--- a/src/style/markdown.less
+++ b/src/style/markdown.less
@@ -6,11 +6,7 @@
 	p > a,
 	ul a,
 	ol a {
-		background: linear-gradient(currentColor, currentColor);
-		text-shadow: 3px 0 #fff, 2px 0 #fff, 1px 0 #fff, -1px 0 #fff, -2px 0 #fff, -3px 0 #fff;
-		background-position: center bottom;
-		background-size: 100% 0.09rem;
-		background-repeat: no-repeat;
+		.link;
 	}
 
 	a.anchor {

--- a/src/style/markdown.less
+++ b/src/style/markdown.less
@@ -7,6 +7,7 @@
 	ul a,
 	ol a {
 		.link;
+		color: @color-brand;
 	}
 
 	a.anchor {

--- a/src/style/mixins.less
+++ b/src/style/mixins.less
@@ -8,7 +8,6 @@
 
 .link() {
 	background: linear-gradient(currentColor, currentColor);
-	text-shadow: 3px 0 #fff, 2px 0 #fff, 1px 0 #fff, -1px 0 #fff, -2px 0 #fff, -3px 0 #fff;
 	background-position: center bottom;
 	background-size: 100% 0.09rem;
 	background-repeat: no-repeat;

--- a/src/style/mixins.less
+++ b/src/style/mixins.less
@@ -24,3 +24,13 @@
 		overflow: hidden;
 	}
 }
+
+.fadeOut() {
+	visibility: hidden;
+	opacity: 0;
+}
+
+.fadeIn() {
+	visibility: visible;
+	opacity: 1;
+}

--- a/src/style/mixins.less
+++ b/src/style/mixins.less
@@ -6,6 +6,14 @@
 	height: 100%;
 }
 
+.link() {
+	background: linear-gradient(currentColor, currentColor);
+	text-shadow: 3px 0 #fff, 2px 0 #fff, 1px 0 #fff, -1px 0 #fff, -2px 0 #fff, -3px 0 #fff;
+	background-position: center bottom;
+	background-size: 100% 0.09rem;
+	background-repeat: no-repeat;
+}
+
 .scroll() {
 	overflow: auto;
 	overflow-scrolling: touch;

--- a/src/style/variables.less
+++ b/src/style/variables.less
@@ -6,3 +6,4 @@
 @color-link: #2f6daa;
 @blockquote-border: #5aa8ff;
 @blockquote-bg: #ebf6ff;
+@sidebar-active-bg: #ebf6ff;

--- a/src/style/variables.less
+++ b/src/style/variables.less
@@ -6,4 +6,5 @@
 @color-link: #2f6daa;
 @blockquote-border: #5aa8ff;
 @blockquote-bg: #ebf6ff;
-@sidebar-active-bg: #ebf6ff;
+@sidebar-active-bg: #f6f6f6;
+@sidebar-link-color: #555;

--- a/src/style/variables.less
+++ b/src/style/variables.less
@@ -1,5 +1,6 @@
 @header-height: 3.5rem; // 56px
 @header-mobile-breakpoint: 37.5rem; // 600px
+@sidebar-width: 18rem;
 
 @color-brand: #673AB8;
 @color-corner: #f2777a;

--- a/src/style/variables.less
+++ b/src/style/variables.less
@@ -1,6 +1,8 @@
 @header-height: 3.5rem; // 56px
 @header-mobile-breakpoint: 37.5rem; // 600px
 
+@color-brand: #673AB8;
+@color-corner: #f2777a;
 @color-link: #2f6daa;
 @blockquote-border: #5aa8ff;
 @blockquote-bg: #ebf6ff;


### PR DESCRIPTION
This PR completely rewrites the table of contents area. It's now always visible on the left and will highlight the current heading. On mobile it's moved behind a toggle on the lower right corner of the screen. On top of that I slightly modified the heading styles and made all link colors use our brand color.

![preact-toc-desktop](https://user-images.githubusercontent.com/1062408/60920530-afd1c600-a298-11e9-97fb-c6c444bcd0b3.png)

![preact-toc-mobile](https://user-images.githubusercontent.com/1062408/60920551-bceeb500-a298-11e9-97e9-41574668f3ab.png)

