### PR TITLE
Fix word wrapping in donate corner

### DIFF
--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -132,6 +132,10 @@ const Corner = () => (
 		rel="noopener noreferrer"
 		class={style.corner}
 	>
-		<div class={style.cornerText}>Help Support Us !</div>
+		<div class={style.cornerText}>
+			Help
+			<br />
+			Support Us !
+		</div>
 	</a>
 );


### PR DESCRIPTION
The same issue is present on our current live site. Looks like nobody tested on Firefox :sweat_smile: See these screenshots:

before:
![preact-donate_before](https://user-images.githubusercontent.com/1062408/61180589-ffa5e980-a618-11e9-8c41-e1d07d85a2eb.png)

after:
![preact-donate_after](https://user-images.githubusercontent.com/1062408/61180591-059bca80-a619-11e9-8638-ee2c64c191a7.png)
