### PR TITLE
Fix prerendering for search

### DIFF
--- a/src/components/header/search.js
+++ b/src/components/header/search.js
@@ -42,15 +42,7 @@ export default class Search extends Component {
 	}
 
 	componentDidMount() {
-		input = input || document.getElementById(this.id);
-
-		if (!input) {
-			input = document.createElement('input');
-			input.required = true;
-			input.id = this.id;
-			input.className = style.searchBox;
-			this.base.appendChild(input);
-
+		if (!docsearchInstance) {
 			this.load();
 		}
 	}
@@ -61,6 +53,13 @@ export default class Search extends Component {
 	}
 
 	render() {
-		return <div class={style.search} />;
+		return (
+			<div
+				class={style.search}
+				dangerouslySetInnerHTML={{
+					__html: `<input id=${this.id} class="${style.searchBox}" required>`
+				}}
+			/>
+		);
 	}
 }


### PR DESCRIPTION
This simplifies the searchBox setup and allows it to be prerendered, which prevents a fairly costly relayout in the header.