### PR TITLE
Move "edit this page" button next to page title

### DIFF
--- a/src/components/controllers/page/index.js
+++ b/src/components/controllers/page/index.js
@@ -6,6 +6,7 @@ import style from './style';
 import Footer from '../../footer';
 import { useEffect, useState, useCallback } from 'preact/hooks';
 import Sidebar from './sidebar';
+import EditThisPage from '../../edit-button';
 
 const getContent = route => route.content || route.path;
 
@@ -68,6 +69,7 @@ export default function Page({ route }) {
 			<div class={style.outer}>
 				{hasToc && <Sidebar toc={toc} />}
 				<div class={style.inner}>
+					{name != 'index' && name != '404' && <EditThisPage />}
 					{name != 'index' && meta.show_title !== false && (
 						<h1 class={style.title}>{meta.title || route.title}</h1>
 					)}

--- a/src/components/edit-button/index.js
+++ b/src/components/edit-button/index.js
@@ -1,0 +1,22 @@
+import { useStore } from '../store-adapter';
+import style from './style.less';
+
+export default function EditThisPage() {
+	const store = useStore(['lang', 'url']);
+	const { url, lang } = store.state;
+	let path = url.replace(/\/$/, '') || '/index';
+	if (lang) path = `/lang/${lang}${path}`;
+	let editUrl = `https://github.com/preactjs/preact-www/tree/master/content${path}.md`;
+	return (
+		<div class={style.wrapper}>
+			<a
+				class={style.edit}
+				href={editUrl}
+				target="_blank"
+				rel="noopener noreferrer"
+			>
+				Edit this Page
+			</a>
+		</div>
+	);
+}

--- a/src/components/edit-button/style.less
+++ b/src/components/edit-button/style.less
@@ -6,17 +6,23 @@
 	max-width: @content-width;
 	margin-left: auto;
 	margin-right: auto;
+	padding-bottom: 1rem;
 }
 
 .edit {
 	position: absolute;
-	right: 1.25rem;
-	top: 1rem;
+	right: 0.8rem;
+	top: 0.8rem;
 	color: var(--color-link);
 	.link;
 	font-size: 0.9rem;
 
-	@media (min-width: 87.5rem) {
+	@media @sidebar-break {
+		right: 1.25rem;
+		top: 1rem;
+	}
+
+	@media (min-width: 74rem) {
 		right: 0;
 	}
 }

--- a/src/components/edit-button/style.less
+++ b/src/components/edit-button/style.less
@@ -1,0 +1,22 @@
+@import '~style/helpers';
+
+.wrapper {
+	position: relative;
+	width: 100%;
+	max-width: @content-width;
+	margin-left: auto;
+	margin-right: auto;
+}
+
+.edit {
+	position: absolute;
+	right: 1.25rem;
+	top: 1rem;
+	color: var(--color-link);
+	.link;
+	font-size: 0.9rem;
+
+	@media (min-width: 87.5rem) {
+		right: 0;
+	}
+}

--- a/src/components/footer/index.js
+++ b/src/components/footer/index.js
@@ -30,18 +30,12 @@ export default class Footer extends Component {
 	};
 
 	render({ lang, url = location.pathname }, { contrib }) {
-		let path = url.replace(/\/$/, '') || '/index';
-		if (lang) path = `/lang/${lang}${path}`;
-		let editUrl = `https://github.com/preactjs/preact-www/tree/master/content${path}.md`;
 		if (typeof document !== 'undefined' && document.documentElement)
 			document.documentElement.lang = lang;
 		return (
 			<footer class={style.footer}>
 				<div class={style.inner}>
 					<p>
-						<a href={editUrl} target="_blank" rel="noopener noreferrer">
-							Edit this Page
-						</a>
 						<label class={style.lang}>
 							Language:{' '}
 							<select value={lang || ''} onChange={this.setLang}>


### PR DESCRIPTION
This PR moves the `"Edit this Page"` button to where users will actually see it. Previously it was placed in the footer where it was easy to miss. FWIW: I didn't know we had such a feature before working on the docs site :sweat_smile: 

![preact-edit-button](https://user-images.githubusercontent.com/1062408/61802233-69e83680-ae30-11e9-8980-19bfd15ac63a.png)
