### PR TITLE
add configuration file for size-plugin bot

### DIFF
--- a/.github/size-plugin.yml
+++ b/.github/size-plugin.yml
@@ -1,0 +1,3 @@
+size-files:
+- size-plugin-browser.json
+- size-plugin-ssr.json


### PR DESCRIPTION
By default [bot](https://github.com/kuldeepkeshwar/size-plugin-bot), assumes a commit results in a single build and look for a single stats to do its own stuff(comment on pr or update on push).

In case, a commit results in multiple builds ( e.g srr + browser) producing multiple stats, we can help [bot](https://github.com/kuldeepkeshwar/size-plugin-bot) with a configuration to understand the situation better 😊 and do its stuff more effectively 🙃