### PR TITLE
Dynamically label versions based on GitHub release

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -6,7 +6,7 @@ import Header from './header';
 import { storeCtx } from './store-adapter';
 import { getCurrentDocVersion } from '../lib/docs';
 
-let VERSION = '10';
+let VERSION = '10.0.0';
 
 if (PRERENDER) {
 	VERSION = require('../../package.json').dependencies.preact.replace('^', '');

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -6,11 +6,17 @@ import Header from './header';
 import { storeCtx } from './store-adapter';
 import { getCurrentDocVersion } from '../lib/docs';
 
+let VERSION = '10';
+
+if (PRERENDER) {
+	VERSION = require('../../package.json').dependencies.preact.replace('^', '');
+}
 export default class App extends Component {
 	store = createStore({
 		url: this.props.url || location.pathname,
 		lang: 'en',
 		docVersion: getCurrentDocVersion(location.pathname),
+		preactVersion: VERSION,
 		toc: null
 	});
 

--- a/src/components/doc-version/index.js
+++ b/src/components/doc-version/index.js
@@ -8,18 +8,34 @@ function onChange(e) {
 	route(url);
 }
 
+const AVAILABLE_DOCS = [10, 8];
+
 /**
  * Select box to switch the currently displayed docs version
  */
 export default function DocVersion() {
-	const { docVersion } = useStore(['docVersion']).state;
+	const { docVersion, preactVersion } = useStore([
+		'docVersion',
+		'preactVersion'
+	]).state;
+
+	// A simple `parseInt` works remarkeable well for getting the major version.
+	// It works with release tags, like "10.0.0-beta.2".
+	const major = parseInt(preactVersion, 10);
 
 	return (
 		<label class={style.root}>
 			Version:{' '}
 			<select value={docVersion} class={style.select} onChange={onChange}>
-				<option value="10">10.x (current)</option>
-				<option value="8">8.x</option>
+				{AVAILABLE_DOCS.map(v => {
+					const suffix =
+						v === major ? ' (current)' : v > major ? ' (next)' : '';
+					return (
+						<option value={v}>
+							{v}.x{suffix}
+						</option>
+					);
+				})}
 			</select>
 		</label>
 	);

--- a/src/components/header/gh-version.js
+++ b/src/components/header/gh-version.js
@@ -17,15 +17,14 @@ export default function ReleaseLink(props) {
 				url: URL
 			}))
 			.then(d => {
-				const newVersion = d.version[0] === 'v' ? d.version : `v${d.version}`;
-				store.update({ preactVersion: newVersion });
+				store.update({ preactVersion: d.version });
 				setUrl(d.url);
 			});
 	}, []);
 
 	return (
 		<a href={url} {...props}>
-			{preactVersion}
+			v{preactVersion}
 		</a>
 	);
 }

--- a/src/components/header/gh-version.js
+++ b/src/components/header/gh-version.js
@@ -2,25 +2,23 @@ import { h } from 'preact';
 import { useEffect, useState } from 'preact/hooks';
 import { fetchRelease } from '../../lib/github';
 import config from '../../config.json';
+import { useStore } from '../store-adapter';
 
-let VERSION = 'v10';
 const URL = 'https://github.com/' + config.repo;
 
-if (PRERENDER) {
-	VERSION = require('../../../package.json').dependencies.preact.replace('^','');
-}
-
 export default function ReleaseLink(props) {
-	const [version, setVersion] = useState();
+	const store = useStore(['preactVersion']);
+	const { version } = store.state;
 	const [url, setUrl] = useState(URL);
 	useEffect(() => {
 		fetchRelease(config.repo)
 			.catch(() => ({
-				version: VERSION,
+				version,
 				url: URL
 			}))
 			.then(d => {
-				setVersion(d.version[0] === 'v' ? d.version : `v${d.version}`);
+				const newVersion = d.version[0] === 'v' ? d.version : `v${d.version}`;
+				store.update({ version: newVersion });
 				setUrl(d.url);
 			});
 	}, []);

--- a/src/components/header/gh-version.js
+++ b/src/components/header/gh-version.js
@@ -8,12 +8,12 @@ const URL = 'https://github.com/' + config.repo;
 
 export default function ReleaseLink(props) {
 	const store = useStore(['preactVersion']);
-	const { version } = store.state;
+	const { preactVersion } = store.state;
 	const [url, setUrl] = useState(URL);
 	useEffect(() => {
 		fetchRelease(config.repo)
 			.catch(() => ({
-				version,
+				version: preactVersion,
 				url: URL
 			}))
 			.then(d => {

--- a/src/components/header/gh-version.js
+++ b/src/components/header/gh-version.js
@@ -18,14 +18,14 @@ export default function ReleaseLink(props) {
 			}))
 			.then(d => {
 				const newVersion = d.version[0] === 'v' ? d.version : `v${d.version}`;
-				store.update({ version: newVersion });
+				store.update({ preactVersion: newVersion });
 				setUrl(d.url);
 			});
 	}, []);
 
 	return (
 		<a href={url} {...props}>
-			{version}
+			{preactVersion}
 		</a>
 	);
 }


### PR DESCRIPTION
This PR appends `(current)` or `(next)` in the documentation dropdown depending on the latest GitHub release. It's a little nicer than having to do it manually :tada: 