### PR TITLE
Fix netlify redirects

### DIFF
--- a/preact.config.js
+++ b/preact.config.js
@@ -104,7 +104,8 @@ export default function (config, env, helpers) {
 
 		netlifyPlugin(config, {
 			redirects: [
-				fs.readFileSync('src/_redirects', 'utf-8').trim()
+				'/content/* /content/* 200',
+				...fs.readFileSync('src/_redirects', 'utf-8').trim().split('\n')
 			]
 		});
 	}


### PR DESCRIPTION
- Each rule must be an item in the array.
- Add `content/` rewrite rule to make it serve `.md` files