### PR TITLE
Add more polishing

### DIFF
--- a/content/en/guide/v10/api-reference.md
+++ b/content/en/guide/v10/api-reference.md
@@ -34,42 +34,7 @@ class MyComponent extends Component {
 }
 ```
 
-### Lifecycle methods
-
-> _**Tip:** If you've used HTML5 Custom Elements, this is similar to the `attachedCallback` and `detachedCallback` lifecycle methods._
-
-Preact invokes the following lifecycle methods if they are defined for a Component:
-
-| Lifecycle method            | When it gets called                              |
-|-----------------------------|--------------------------------------------------|
-| `componentWillMount`        | before the component gets mounted to the DOM     |
-| `componentDidMount`         | after the component gets mounted to the DOM      |
-| `componentWillUnmount`      | prior to removal from the DOM                    |
-| `componentWillReceiveProps` | before new props get accepted                    |
-| `shouldComponentUpdate`     | before `render()`. Return `false` to skip render |
-| `componentWillUpdate`       | before `render()`                                |
-| `componentDidUpdate`        | after `render()`                                 |
-
-All of the lifecycle methods and their parameters are shown in the following example component:
-
-```js
-import { Component } from 'preact';
-
-class MyComponent extends Component {
-	shouldComponentUpdate(nextProps, nextState) {}
-	componentWillReceiveProps(nextProps, nextState) {
-		this.props // Previous props
-		this.state // Previous state
-	}
-	componentWillMount() {}
-	componentDidMount() {}
-	componentDidUpdate(prevProps, prevState) {}
-	componentWillUnmount() {
-		this.props // Current props
-		this.state // Current state
-	}
-}
-```
+To learn more about components and how they can be used, head over to the [Components](guide/v10/components) page.
 
 ## render()
 

--- a/preact.config.js
+++ b/preact.config.js
@@ -103,10 +103,7 @@ export default function (config, env, helpers) {
 		}]));
 
 		netlifyPlugin(config, {
-			redirects: [
-				'/content/* /content/* 200',
-				...fs.readFileSync('src/_redirects', 'utf-8').trim().split('\n')
-			]
+			redirects: fs.readFileSync('src/_redirects', 'utf-8').trim().split('\n')
 		});
 	}
 }

--- a/src/_redirects
+++ b/src/_redirects
@@ -9,3 +9,4 @@
 /guide/extending-component /guide/v8/extending-component
 /guide/unit-testing-with-enzyme /guide/v8/unit-testing-with-enzyme
 /guide/progressive-web-apps /guide/v8/progressive-web-apps
+/content/* /content/*

--- a/src/components/controllers/page/index.js
+++ b/src/components/controllers/page/index.js
@@ -149,19 +149,21 @@ export default function Page({ route }) {
 					show={hasSidebar}
 				/>
 				<div class={style.inner}>
-					<Hydrator
-						boot={isReady}
-						component={EditThisPage}
-						show={canEdit}
-						isFallback={isFallback}
-					/>
-					<Hydrator
-						component={Title}
-						boot={isReady}
-						show={showTitle}
-						title={meta.title || route.title}
-					/>
-					<ContentRegion name={name} content={content} onLoad={onLoad} />
+					<div class={style.contentWrapper}>
+						<Hydrator
+							boot={isReady}
+							component={EditThisPage}
+							show={canEdit}
+							isFallback={isFallback}
+						/>
+						<Hydrator
+							component={Title}
+							boot={isReady}
+							show={showTitle}
+							title={meta.title || route.title}
+						/>
+						<ContentRegion name={name} content={content} onLoad={onLoad} />
+					</div>
 					<Footer />
 				</div>
 			</div>

--- a/src/components/controllers/page/style.less
+++ b/src/components/controllers/page/style.less
@@ -43,6 +43,7 @@
 
 	@media (max-width: 600px) {
 		font-size: 2em;
+		margin-top: 2rem;
 	}
 }
 

--- a/src/components/controllers/page/style.less
+++ b/src/components/controllers/page/style.less
@@ -87,3 +87,10 @@
 		}
 	}
 }
+
+.contentWrapper {
+	display: flex;
+	flex-grow: 1;
+	flex-direction: column;
+	min-height: calc(100vh - 12rem);
+}

--- a/src/components/edit-button/index.js
+++ b/src/components/edit-button/index.js
@@ -24,8 +24,8 @@ export default function EditThisPage({ show, isFallback }) {
 
 					{isFallback && (
 						<div class={style.fallback}>
-							<b>Error:</b> Could not find a translation for this page. You can
-							help us out by <a href={editUrl}>adding one here</a>.
+							Could not find a translation for this page. You can help us out by{' '}
+							<a href={editUrl}>adding one here</a>.
 						</div>
 					)}
 				</div>

--- a/src/components/edit-button/style.less
+++ b/src/components/edit-button/style.less
@@ -31,12 +31,12 @@
 }
 
 .fallback {
-	background: var(--color-error-bg);
+	background: var(--color-warn-bg);
 	padding: 0.75rem 1rem;
-	border-left: 0.3rem solid var(--color-error-border);
+	color: #444;
 
 	a {
 		.link;
-		color: var(--color-link);
+		color: @color-brand;
 	}
 }

--- a/src/style/index.less
+++ b/src/style/index.less
@@ -18,9 +18,7 @@
 	--color-quote-bg: #ebf6ff;
 	--color-quote-border: #5aa8ff;
 	--color-quote-text: #444;
-	--color-error-bg: #ffe3e3;
-	--color-error-border: #f44336;
-	--color-error-text: #444;
+	--color-warn-bg: #ffee5b;
 	--color-table-border: #ccc;
 	--color-table-even-bg: white;
 	--color-table-odd-bg: #f8f8f8;
@@ -53,9 +51,7 @@
 		--color-quote-bg: #29475f;
 		--color-quote-border: #3f6b9c;
 		--color-quote-text: #c5c5c5;
-		--color-error-bg: #5f2929;
-		--color-error-border: #f44336;
-		--color-error-text: #444;
+		--color-warn-bg: #f2d900;
 		--color-table-border: #575757;
 		--color-table-even-bg: #242424;
 		--color-table-odd-bg: #2f2f2f;
@@ -90,9 +86,7 @@ html.light {
 	--color-quote-bg: #ebf6ff;
 	--color-quote-border: #5aa8ff;
 	--color-quote-text: #444;
-	--color-error-bg: #ffe3e3;
-	--color-error-border: #f44336;
-	--color-error-text: #444;
+	--color-warn-bg: #ffee5b;
 	--color-table-border: #ccc;
 	--color-table-even-bg: white;
 	--color-table-odd-bg: #f8f8f8;
@@ -126,9 +120,7 @@ html.dark {
 	--color-quote-bg: #29475f;
 	--color-quote-border: #3f6b9c;
 	--color-quote-text: #c5c5c5;
-	--color-error-bg: #5f2929;
-	--color-error-border: #f44336;
-	--color-error-text: #444;
+	--color-warn-bg: #f2d900;
 	--color-table-border: #575757;
 	--color-table-even-bg: #242424;
 	--color-table-odd-bg: #2f2f2f;


### PR DESCRIPTION
This PR improves a few little things:

- Add `min-height` for content area so that it doesn't jump around that much
- Make "Missing Translation" box look more informing rather than an error
- Add more spacing around edit button on mobile so that it doesn't overlap the page title
- Content: Remove duplicate lifecycle section
- Redirects: Move all redirects into `_redirects` instead of having some in `preact.config.js` (my bad, sry)