### PR TITLE
Make doc "current" label static.

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -6,17 +6,11 @@ import Header from './header';
 import { storeCtx } from './store-adapter';
 import { getCurrentDocVersion } from '../lib/docs';
 
-let VERSION = '10.0.0';
-
-if (PRERENDER) {
-	VERSION = require('../../package.json').dependencies.preact.replace('^', '');
-}
 export default class App extends Component {
 	store = createStore({
 		url: this.props.url || location.pathname,
 		lang: 'en',
 		docVersion: getCurrentDocVersion(location.pathname),
-		preactVersion: VERSION,
 		toc: null
 	});
 

--- a/src/components/doc-version/index.js
+++ b/src/components/doc-version/index.js
@@ -14,22 +14,14 @@ const AVAILABLE_DOCS = [10, 8];
  * Select box to switch the currently displayed docs version
  */
 export default function DocVersion() {
-	const { docVersion, preactVersion } = useStore([
-		'docVersion',
-		'preactVersion'
-	]).state;
-
-	// A simple `parseInt` works remarkeable well for getting the major version.
-	// It works with release tags, like "10.0.0-beta.2".
-	const major = parseInt(preactVersion, 10);
+	const { docVersion } = useStore(['docVersion']).state;
 
 	return (
 		<label class={style.root}>
 			Version:{' '}
 			<select value={docVersion} class={style.select} onChange={onChange}>
 				{AVAILABLE_DOCS.map(v => {
-					const suffix =
-						v === major ? ' (current)' : v > major ? ' (next)' : '';
+					const suffix = v === 10 ? ' (current)' : '';
 					return (
 						<option value={v}>
 							{v}.x{suffix}

--- a/src/components/header/gh-version.js
+++ b/src/components/header/gh-version.js
@@ -2,29 +2,35 @@ import { h } from 'preact';
 import { useEffect, useState } from 'preact/hooks';
 import { fetchRelease } from '../../lib/github';
 import config from '../../config.json';
-import { useStore } from '../store-adapter';
 
 const URL = 'https://github.com/' + config.repo;
 
+let VERSION = '10.0.0';
+if (PRERENDER) {
+	VERSION = require('../../../package.json').dependencies.preact.replace(
+		'^',
+		''
+	);
+}
+
 export default function ReleaseLink(props) {
-	const store = useStore(['preactVersion']);
-	const { preactVersion } = store.state;
 	const [url, setUrl] = useState(URL);
+	const [version, setVersion] = useState(VERSION);
 	useEffect(() => {
 		fetchRelease(config.repo)
 			.catch(() => ({
-				version: preactVersion,
+				version: VERSION,
 				url: URL
 			}))
 			.then(d => {
-				store.update({ preactVersion: d.version });
+				setVersion(d.version);
 				setUrl(d.url);
 			});
 	}, []);
 
 	return (
 		<a href={url} {...props}>
-			v{preactVersion}
+			v{version}
 		</a>
 	);
 }


### PR DESCRIPTION
Pulling from GitHub leads to wrong results because of different release
lines. We don't really gain much by having this dynamic anyway.