### PR TITLE
Fix a few spelling errors in English Preact v10 content

### DIFF
--- a/content/en/guide/v10/components.md
+++ b/content/en/guide/v10/components.md
@@ -84,7 +84,7 @@ In order to have the clock's time update every second, we need to know when `<Cl
 
 #### componentDidCatch
 
-There is one lifecycle method that deserves a special recognition and that is `componentDidCatch`. It's special because it allows you to handle any errors that happen during rendering. This includes errors that happend in a lifecycle hook but excludes any asynchronously thrown errors, like after a `fetch()` call.
+There is one lifecycle method that deserves a special recognition and that is `componentDidCatch`. It's special because it allows you to handle any errors that happen during rendering. This includes errors that happened in a lifecycle hook but excludes any asynchronously thrown errors, like after a `fetch()` call.
 
 When an error is caught we can use this lifecycle to react to any errors and display a nice error message or any other fallback content.
 

--- a/content/en/guide/v10/context.md
+++ b/content/en/guide/v10/context.md
@@ -5,7 +5,7 @@ description: 'Context allows you to pass props through intermediate components. 
 
 # Context
 
-Context allows you to pass a value to a child deep down the tree without having to pass it through every component inbetween via props. A very popular use case for this is theming. In a nutshell context can be thought of a way to do pup-sub-style updates in Preact.
+Context allows you to pass a value to a child deep down the tree without having to pass it through every component in-between via props. A very popular use case for this is theming. In a nutshell context can be thought of a way to do pup-sub-style updates in Preact.
 
 There are two different ways to use context: Via the newer `createContext` API and the legacy context API. The difference between the two is that the legacy one can't update a child when a component inbetween aborts rendering via `shouldComponentUpdate`. That's why we highly recommend to always use `createContext`.
 
@@ -47,7 +47,7 @@ function App() {
 
 ## Legacy Context API
 
-We include the legacy API mainly for backwards-compatibility reasons. It has been superseeded by the `createContext` API. The legacy API has known issues like blocking updates if there are components inbetween that return `false` in `shouldComponentUpdate`. If you nonetheless need to use it, keep reading.
+We include the legacy API mainly for backwards-compatibility reasons. It has been superseded by the `createContext` API. The legacy API has known issues like blocking updates if there are components in-between that return `false` in `shouldComponentUpdate`. If you nonetheless need to use it, keep reading.
 
 To pass down a custom variable through the context a component needs to have the `getChildContext` method. There you return the new values you want to store in the context. The context can be accessed via the second argument in function components or `this.context` in a class-based component.
 

--- a/content/en/guide/v10/differences-to-react.md
+++ b/content/en/guide/v10/differences-to-react.md
@@ -20,7 +20,7 @@ The reason Preact does not attempt to include every single feature of React is i
 
 The main difference when comparing Preact and React apps is that we don't ship our own Synthetic Event system. Preact uses the browser's native `addEventlistener` for event handling internally. See [GlobalEventHandlers] for a full list of DOM event handlers.
 
-For us it doesn't make sense as the browser's event system supports all features we need. A full custom event implementation would mean more maintainence overhead and a larger API surface area for us.
+For us it doesn't make sense as the browser's event system supports all features we need. A full custom event implementation would mean more maintenance overhead and a larger API surface area for us.
 
 The other main difference is that we follow a bit more closely the DOM specification. One example of that is that you can use `class` instead of `className`.
 
@@ -62,7 +62,7 @@ class Foo extends Component {
 }
 ```
 
-Both snippets render the exact same thing. It's just a matter of stylisic preference.
+Both snippets render the exact same thing. It's just a matter of stylistic preference.
 
 ### Raw HTML attribute/property names
 
@@ -116,7 +116,7 @@ In most Preact apps you'll encounter `h()`, but we support both in core, so it d
 
 ### No contextTypes needed
 
-The legacy `Context`-API requires Components to implement `contextTypes` or `childContextTypes` in React. With Preact we don't have that limitation and and all Components receive the all `context` entries drawn from `getChildContext()`.
+The legacy `Context`-API requires Components to implement `contextTypes` or `childContextTypes` in React. With Preact we don't have that limitation and all Components receive the all `context` entries drawn from `getChildContext()`.
 
 ## Features exclusive to `preact/compat`
 

--- a/content/en/guide/v10/getting-started.md
+++ b/content/en/guide/v10/getting-started.md
@@ -36,7 +36,7 @@ The only difference is that you cannot use JSX, because JSX needs to be transpil
 
 Writing raw `h` or `createElement` calls all the time is much less fun than using something JSX-like. JSX has the advantage of looking similar to HTML, which makes it easier to understand for many developers in our experience. It requires a built-step though, so we highly recommend an alternative called [htm].
 
-In a nutshell [htm] can be best decribed as: JSX-like syntax in plain JavaScript without a need for a transpiler. Instead of using a custom syntax it relies on native tagged template strings which were added to JavaScript a while back.
+In a nutshell [htm] can be best described as: JSX-like syntax in plain JavaScript without a need for a transpiler. Instead of using a custom syntax it relies on native tagged template strings which were added to JavaScript a while back.
 
 ```js
 import { h, Component, render } from 'https://unpkg.com/preact';
@@ -53,7 +53,7 @@ It's a very popular way of writing Preact apps and we highly recommend checking 
 
 ## Best practices powered with `preact-cli`
 
-The `preact-cli` project is a ready made solution to bundle Preact applications with the optimal bundler configuration that's best for modern web application. It's build on standard tooling projects like `webpack`, `babel` and `postcss`. Because of the simplicty this is the most popular way to use Preact among our users.
+The `preact-cli` project is a ready made solution to bundle Preact applications with the optimal bundler configuration that's best for modern web application. It's build on standard tooling projects like `webpack`, `babel` and `postcss`. Because of the simplicity this is the most popular way to use Preact among our users.
 
 As the name implies, `preact-cli` is a **c**ommand-**li**ne tool that can be run in the terminal on your machine. Install it globally by running:
 
@@ -83,11 +83,11 @@ cd my-project/
 npm run dev
 ```
 
-Once the server is up you can access your app at the url that was printed in the console. Now you're ready to develop your app!
+Once the server is up you can access your app at the URL that was printed in the console. Now you're ready to develop your app!
 
 ### Making a production build
 
-There comes a time when you need to deploy your app somewhere. The cli ships with a handy `build` command which will generate a highly optimized build.
+There comes a time when you need to deploy your app somewhere. The CLI ships with a handy `build` command which will generate a highly optimized build.
 
 ```bash
 npm run build
@@ -124,7 +124,7 @@ At some point you'll probably want to make use of the vast react ecosystem. Libr
 
 #### Aliasing in webpack
 
-To alias any package in webpack you need to add the the `resolve.alias` section
+To alias any package in webpack you need to add the `resolve.alias` section
 to your config. Depending on the configuration you're using this section may
 already be present, but missing the aliases for Preact.
 

--- a/content/en/guide/v10/hooks.md
+++ b/content/en/guide/v10/hooks.md
@@ -41,7 +41,7 @@ class Counter extends Component {
 }
 ```
 
-All the component does is render a div and a button to increment the counter. Let's rewrite it to be beased on hooks:
+All the component does is render a div and a button to increment the counter. Let's rewrite it to be based on hooks:
 
 ```jsx
 function Counter() {
@@ -155,7 +155,7 @@ const Counter = () => {
 
 ### useReducer
 
-The `useReducer` hook has a close resemblence to [redux](https://redux.js.org/). Compared to [useState](#usestateinitialstate) it's easier to use when you have complex state logic where the next state depends on the previous one.
+The `useReducer` hook has a close resemblance to [redux](https://redux.js.org/). Compared to [useState](#usestateinitialstate) it's easier to use when you have complex state logic where the next state depends on the previous one.
 
 ```jsx
 const initialState = 0;
@@ -189,7 +189,7 @@ In UI programming there is often some state or result that's expensive to calcul
 
 ### useMemo
 
-With the `useMemo` hook we can memoize the results of that computation and only recaculate it when one of the dependencies changes.
+With the `useMemo` hook we can memoize the results of that computation and only recalculate it when one of the dependencies changes.
 
 ```jsx
 const memoized = useMemo(
@@ -277,7 +277,7 @@ useEffect(() => {
 }, []);
 ```
 
-We'll start with a `Title` component which should reflect the title to the document, so that we can see it in the addressbar of our tab in our browser.
+We'll start with a `Title` component which should reflect the title to the document, so that we can see it in the address bar of our tab in our browser.
 
 ```jsx
 function PageTitle(props) {

--- a/content/en/guide/v10/linked-state.md
+++ b/content/en/guide/v10/linked-state.md
@@ -37,7 +37,7 @@ While this achieves much better runtime performance, it's still a lot of unneces
 
 Fortunately, there is a solution in the form of preact's [`linkState`](https://github.com/developit/linkstate) module.
 
-> Earlier versions of Preact had the `linkState()` function built-in; however, it has since been moved to a separate module. If you wish to restore the old behavior, see [this page](https://github.com/developit/linkstate#usage) for information about using the polyfill. 
+> Earlier versions of Preact had the `linkState()` function built-in; however, it has since been moved to a separate module. If you wish to restore the old behavior, see [this page](https://github.com/developit/linkstate#usage) for information about using the polyfill.
 
 Calling `linkState(this, 'text')` returns a handler function that, when passed an Event, uses its associated value to update the named property in your component's state.  Multiple calls to `linkState(component, name)` with the same `component` and `name` are cached, so there is essentially no performance penalty.
 

--- a/content/en/guide/v10/refs.md
+++ b/content/en/guide/v10/refs.md
@@ -7,7 +7,7 @@ description: 'References can be used to access raw DOM nodes that Preact has ren
 
 There will always be scenarios where you need a direct reference to the DOM-Element or Component that was rendered by Preact. Refs allow you to do just that.
 
-A typical usecase for it is measuring the actual size of a DOM node. While it's possible to get the reference to the component instance via `ref` we don't generally recommend it. It will create a hard coupling between a parent and a child which breaks the composability of the component model. In most cases it's more natural to just pass the callback as a prop instead of trying to call the method of a class component directly.
+A typical use case for it is measuring the actual size of a DOM node. While it's possible to get the reference to the component instance via `ref` we don't generally recommend it. It will create a hard coupling between a parent and a child which breaks the composability of the component model. In most cases it's more natural to just pass the callback as a prop instead of trying to call the method of a class component directly.
 
 ---
 

--- a/content/en/guide/v10/server-side-rendering.md
+++ b/content/en/guide/v10/server-side-rendering.md
@@ -5,7 +5,7 @@ description: 'Render your Preact application on the server to show content to us
 
 # Server-Side Rendering
 
-Server-Side Rendering (often abbreviated as "SSR") allows you to render your application to an HTML string that can be sent to the client to improve load time. Outside of that there are other scenarios, like testing, where ssr proves really useful.
+Server-Side Rendering (often abbreviated as "SSR") allows you to render your application to an HTML string that can be sent to the client to improve load time. Outside of that there are other scenarios, like testing, where SSR proves really useful.
 
 > Note: SSR is automtatically enabled with `preact-cli` :tada:
 

--- a/content/en/guide/v10/switching-to-preact.md
+++ b/content/en/guide/v10/switching-to-preact.md
@@ -227,7 +227,7 @@ you can set the JSX Pragma by defining a comment near the top of your code:
 
 While Preact strives to be API-compatible with React, portions of the interface are intentionally not included.
 The most noteworthy of these is `createClass()`. Opinions vary wildly on the subject of classes and OOP, but
-it's worth understanding that JavaScript classes are internally in VDOM libraries to represent component types,
+it's worth understanding that JavaScript classes are used internally in VDOM libraries to represent component types,
 which is important when dealing with the nuances of managing component lifecycles.
 
 If your codebase is heavily reliant on `createClass()`, you still have a great option:

--- a/content/en/guide/v10/tutorial.md
+++ b/content/en/guide/v10/tutorial.md
@@ -42,7 +42,7 @@ Congratulations, you've build your first Preact app!
 
 Rendering text is a start, but we want to make our app a little more interactive. We want to update it when data changes. :star2:
 
-Our endgoal is that we have an app where the user can enter a name and display it, when the form is submitted. For this we need to have something where we can store what we submitted. This is where [Components](/guide/v10/components) come into play.
+Our end goal is that we have an app where the user can enter a name and display it, when the form is submitted. For this we need to have something where we can store what we submitted. This is where [Components](/guide/v10/components) come into play.
 
 So let's turn our existing App into a [Components](/guide/v10/components):
 

--- a/content/en/guide/v10/upgrade-guide.md
+++ b/content/en/guide/v10/upgrade-guide.md
@@ -7,7 +7,7 @@ description: 'Upgrade your Preact 8.x application to Preact X'
 
 This document is intended to guide you through upgrading an existing Preact 8.x application to Preact X and is divided in 3 main sections
 
-Preact X brings many new exciting features such as `Fragments`, `hooks` and much improved compatibility with the react ecosystem. We tried to keep any breaking changes to the minimum possible, but couldn't eliminate all of them completely without compromising on our Feature set.
+Preact X brings many new exciting features such as `Fragments`, `hooks` and much improved compatibility with the React ecosystem. We tried to keep any breaking changes to the minimum possible, but couldn't eliminate all of them completely without compromising on our feature set.
 
 ---
 
@@ -17,7 +17,7 @@ Preact X brings many new exciting features such as `Fragments`, `hooks` and much
 
 ## Upgrading dependencies
 
-_Note: Throgout this guide we'll be using the `npm` client and the commands should be easily applicable to other package managers such as `yarn`._
+_Note: Throughout this guide we'll be using the `npm` client and the commands should be easily applicable to other package managers such as `yarn`._
 
 Let's begin! First install Preact X:
 
@@ -46,7 +46,7 @@ To guarantee a stable ecosystem for our users (especially for our enterprise use
 
 ### Compat has moved to core
 
-To make third-party react libraries work with Preact we ship a **compat**ibility layer that can be imported via `preact/compat`. It was previously available as a separate package, but to make coordination easier we've moved it into the core repository. So you'll need to change existing import or alias declarations from `preact-compat` to `preact/compat` (note the slash).
+To make third-party React libraries work with Preact we ship a **compat**ibility layer that can be imported via `preact/compat`. It was previously available as a separate package, but to make coordination easier we've moved it into the core repository. So you'll need to change existing import or alias declarations from `preact-compat` to `preact/compat` (note the slash).
 
 Be careful not to introduce any spelling errors here. A common one seems to be to write `compact` instead of `compat`. If you're having trouble with that, think of `compat` as the `compatibility` layer for react. That's where the name is coming from.
 
@@ -58,7 +58,7 @@ Due to the nature of the breaking changes, some existing libraries may cease to 
 
 #### preact-redux
 
-`preact-redux` is one of such libraries that hasn't been updated yet. The good news is that `preact/compat` is much more React-complient and works out of the box with the React bindings called `react-redux`. Switching to it will resolve the situation. Make sure that you've aliased `react` and `react-dom` to `preact/compat` in your bundler.
+`preact-redux` is one of such libraries that hasn't been updated yet. The good news is that `preact/compat` is much more React-compliant and works out of the box with the React bindings called `react-redux`. Switching to it will resolve the situation. Make sure that you've aliased `react` and `react-dom` to `preact/compat` in your bundler.
 
 1. Remove `preact-redux`
 2. Install `react-redux`
@@ -166,7 +166,7 @@ When a `vnode` has the property `dangerouslySetInnerHTML` set Preact will skip d
 
 ## Notes for library authors
 
-This section is intended for library authors who are maintaing packages to be used with Preact X. You can safely skip this section if you're not writing one.
+This section is intended for library authors who are maintaining packages to be used with Preact X. You can safely skip this section if you're not writing one.
 
 ### The `VNode` shape has changed
 


### PR DESCRIPTION
Correct a few spelling errors in English Preact v10 content and cases where
acronyms were not capitalized.