### PR TITLE
Fix References createRef docs example

### DIFF
--- a/content/en/guide/v10/refs.md
+++ b/content/en/guide/v10/refs.md
@@ -29,7 +29,7 @@ class Foo extends Component {
   }
   
   render() {
-    return <div ref={setRef}>foo</div>
+    return <div ref={this.ref}>foo</div>
   }
 }
 ```


### PR DESCRIPTION
The first example for `createRef` in the guide incorrectly uses nonexistent method `setRef` instead of `this.ref`