### PR TITLE
Rewrite compat page

### DIFF
--- a/content/de/index.md
+++ b/content/de/index.md
@@ -11,7 +11,7 @@ toc: false
         <logo height="1.5em" title="Preact" text inverted>Preact</logo>
     </h1>
     <p>Schnelle 3kB-Alternative zu React mit der gleichen ES6-API.</p>
-    <p>
+    <p class="intro-buttons">
         <a href="/guide/v10/getting-started" class="home-button">Fang an</a>
         <span class="home-button-sep">&nbsp; • &nbsp;</span>
         <a href="/guide/v10/switching-to-preact" class="home-button">Wechsle zu Preact</a>

--- a/content/en/guide/v10/differences-to-react.md
+++ b/content/en/guide/v10/differences-to-react.md
@@ -143,7 +143,7 @@ function App(props) {
 [preact/compat] ships with specialised components that are not necessary for every app. These include
 
 - [PureComponent](/guide/v10/switching-to-preact#purecomponent): Only updates if `props` and `state` have changed
-- [memo](/guide/v10/switching-to-preact#memo): Similar in spirit to `PureComponent` but allows to use a custom comparer function
+- [memo](/guide/v10/switching-to-preact#memo): Similar in spirit to `PureComponent` but allows to use a custom comparison function
 - [forwardRef](/guide/v10/switching-to-preact#forwardRef): Supply a `ref` to a specified child component.
 - [Portals](/guide/v10/switching-to-preact#portals): Continues rendering the current tree into a different DOM container
 - [Suspense](/guide/v10/switching-to-preact#suspense): **experimental** Allows to display fallback content in case the tree is not ready

--- a/content/en/guide/v10/differences-to-react.md
+++ b/content/en/guide/v10/differences-to-react.md
@@ -142,14 +142,14 @@ function App(props) {
 
 [preact/compat] ships with specialised components that are not necessary for every app. These include
 
-- `PureComponent`: Only updates if `props` and `state` have changed
-- `memo`: Similar in spirit to `PureComponent` but allows to use a custom comparer function
-- `forwardRef`: Supply a `ref` to a specified child component.
-- `Portals`: Continues rendering the current tree into a different DOM container
-- `Suspense`: **experimental** Allows to display fallback content in case the tree is not ready
-- `lazy`: **experimental** Lazy load async code and mark a tree as ready/not ready accordingly.
+- [PureComponent](/guide/v10/switching-to-preact#purecomponent): Only updates if `props` and `state` have changed
+- [memo](/guide/v10/switching-to-preact#memo): Similar in spirit to `PureComponent` but allows to use a custom comparer function
+- [forwardRef](/guide/v10/switching-to-preact#forwardRef): Supply a `ref` to a specified child component.
+- [Portals](/guide/v10/switching-to-preact#portals): Continues rendering the current tree into a different DOM container
+- [Suspense](/guide/v10/switching-to-preact#suspense): **experimental** Allows to display fallback content in case the tree is not ready
+- [lazy](/guide/v10/switching-to-preact#suspense): **experimental** Lazy load async code and mark a tree as ready/not ready accordingly.
 
 [Project Goals]: /about/project-goals
 [hyperscript]: https://github.com/dominictarr/hyperscript
-[preact/compat]: #features-exclusive-to-preactcompat
+[preact/compat]: /guide/v10/switching-to-preact
 [GlobalEventHandlers]: https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers

--- a/content/en/guide/v10/switching-to-preact.md
+++ b/content/en/guide/v10/switching-to-preact.md
@@ -43,11 +43,11 @@ render(<Foo value="3" />, dom);
 render(<Foo value="3" />, dom);
 ```
 
-> Note that the advantage of `PureComponent` only pays off when then render is expensive. For simple children trees it can be quicker to just do the render compared to the overhead of comparing props.
+> Note that the advantage of `PureComponent` only pays off when then render is expensive. For simple children trees it can be quicker to just do the `render` compared to the overhead of comparing props.
 
 ## memo
 
-`memo` is equivalen to functional components as `PureComponent` is to classes. It uses the same comparison function under the hood, but allows you to specify your own specialized function optimized for your use case.
+`memo` is equivalent to functional components as `PureComponent` is to classes. It uses the same comparison function under the hood, but allows you to specify your own specialized function optimized for your use case.
 
 ```jsx
 import { memo } from 'preact/compat';
@@ -122,7 +122,7 @@ function App() {
 
 ## Suspense (experimental)
 
-The main idea behind `Suspense` is to allow sections of your UI to display some sort of loading content while components further down the tree are still loading. A common use case for this is code-splitting where you'll need to load a component from the network before you can render it.
+The main idea behind `Suspense` is to allow sections of your UI to display some sort of placeholder content while components further down the tree are still loading. A common use case for this is code-splitting where you'll need to load a component from the network before you can render it.
 
 ```jsx
 import { Suspense, lazy } from `preact/compat`;

--- a/content/en/guide/v10/switching-to-preact.md
+++ b/content/en/guide/v10/switching-to-preact.md
@@ -6,10 +6,9 @@ description: 'Everything you need to know to switch from React to Preact.'
 
 # Switching to Preact (from React)
 
-There are two different approaches to switch from React to Preact:
+`preact/compat` is our compatibility layer that allows you to leverage the many libraries of the React ecosystem and use them with Preact. This is the recommended way to try out Preact if you have an existing React app.
 
-1. Install the `preact-compat` alias
-2. Switch your imports to `preact` and remove incompatible code
+This lets you continue writing React/ReactDOM code without any changes to your workflow or codebase. `preact/compat` adds somewhere around 2kb to your bundle size, but has the advantage of supporting the vast majority of existing React modules you might find on npm. The `preact/compat` package provides all the necessary tweaks on top of Preact's core to make it work just like `react` and `react-dom`, in a single module.
 
 ---
 
@@ -17,279 +16,127 @@ There are two different approaches to switch from React to Preact:
 
 ---
 
-## Easy: `preact-compat` Alias
+## Setting up compat
 
-Switching to Preact can be as easy as installing and aliasing `preact-compat` in for `react` and `react-dom`.
-This lets you continue writing React/ReactDOM code without any changes to your workflow or codebase.
-`preact-compat` adds somewhere around 2kb to your bundle size, but has the advantage of supporting
-the vast majority of existing React modules you might find on npm.  The `preact-compat` package provides
-all the necessary tweaks on top of Preact's core to make it work just like `react` and `react-dom`, in a single module.
+To set up `preact/compat` you need to alias `react` and `react-dom` to `preact/compat`. The [Getting Started](/guide/v10/getting-started#aliasing-react-to-preact) page goes into detail on how aliasing is configured in various bundlers.
 
-The process for installation is two steps.
-First, you must install preact and preact-compat (they are separate packages):
+## PureComponent
 
-```sh
-npm i -S preact preact-compat
-```
+The `PureComponent` class works similarily to `Component`. The difference is that `PureComponent` will skip rendering when the new props are equal to the old ones. To do this we compare the old and new props via a shallow comparison where we check each props property for referential equality. This can speed up applications a lot by avoiding unnecessary re-renders. It works by adding a default `shouldComponentUpdate` lifecycle hook.
 
-With those dependencies installed, configure your build system to alias React imports so they point to Preact instead.
+```jsx
+import { render } from 'preact';
+import { PureComponent } from 'preact/compat';
 
-
-### How to Alias preact-compat
-
-Now that you have your dependencies installed, you'll need to configure your build system
-to redirect any imports/requires looking for `react` or `react-dom` with `preact-compat`.
-
-#### Aliasing via Webpack
-
-Simply add the following [resolve.alias](https://webpack.js.org/configuration/resolve/#resolvealias)
-configuration to your `webpack.config.js`:
-
-```json
-{
-  "resolve": {
-    "alias": {
-      "react": "preact-compat",
-      "react-dom": "preact-compat"
-    }
+class Foo extends PureComponent {
+  render(props) {
+    console.log("render")
+    return <div />
   }
 }
+
+const dom = document.getElementById('root');
+render(<Foo value="3" />, dom);
+// Logs: "render"
+
+// Render a second time, doesn't log anything
+render(<Foo value="3" />, dom);
 ```
 
-#### Aliasing via Parcel
+> Note that the advantage of `PureComponent` only pays off when then render is expensive. For simple children trees it can be quicker to just do the render compared to the overhead of comparing props.
 
-Parcel supports defining module aliases right in your `package.json` under an `"aliases"` key:
+## memo
 
-```json
-{
-  "alias": {
-    "react": "preact-compat",
-    "react-dom": "preact-compat"
-  }
+`memo` is equivalen to functional components as `PureComponent` is to classes. It uses the same comparison function under the hood, but allows you to specify your own specialized function optimized for your use case.
+
+```jsx
+import { memo } from 'preact/compat';
+
+function MyComponent(props) {
+  return <div>Hello {props.name}</div>
 }
-```
 
-#### Aliasing via Browserify
+// Usage with default comparison function
+const Memoed = memo(MyComponent);
 
-If you're using Browserify, aliases can be defined by adding the [aliasify](https://www.npmjs.com/package/aliasify) transform.
-
-First, install the transform:  `npm i -D aliasify`
-
-Then, in your `package.json`, tell aliasify to redirect react imports to preact-compat:
-
-```json
-{
-  "aliasify": {
-    "aliases": {
-      "react": "preact-compat",
-      "react-dom": "preact-compat"
-    }
-  }
-}
-```
-
-A common use-case for preact-compat is to support React-compatible third-party modules. When using Browserify, remember to configure the [Aliasify](https://www.npmjs.com/package/aliasify) transform to be **global** via the `--global-transform` [Browserify option](https://github.com/browserify/browserify).
-
-
-#### Aliasing Manually
-
-If you're not using a build system or want to permanently switch to `preact-compat`,
-you can also find & replace all the imports/requires in your codebase much like an alias does:
-
-> **find:**    `(['"])react(-dom)?\1`
->
-> **replace:** `$1preact-compat$1`
-
-In this case though, you might find it more compelling to switch directly to `preact` itself, rather than relying on `preact-compat`.
-Preact's core is quite fully featured, and many idiomatic React codebases can actually be switched straight to `preact` with little effort.
-That approach is covered in the next section.
-
-#### Aliasing in Node using module-alias
-
-For SSR purposes, if you are not using a bundler like webpack to build your server side code, you can use the [module-alias](https://www.npmjs.com/package/module-alias) package to replace react with preact.
-
-```sh
-npm i -S module-alias
-```
-
-`patchPreact.js`:
-```js
-var path = require('path')
-var moduleAlias = require('module-alias')
-
-moduleAlias.addAliases({
-  'react': 'preact-compat/dist/preact-compat.min',
-  'react-dom': 'preact-compat/dist/preact-compat.min',
-  'create-react-class': path.resolve(__dirname, './create-preact-class')
+// Usage with custom comparison function
+const Memoed2 = memo(MyComponent, (prevProps, nextProps) => {
+  // Only re-render when `name' changes
+  return prevProps.name === nextProps.name;
 })
 ```
 
-`create-preact-class.js`:
-```js
-import { createClass } from 'preact-compat/dist/preact-compat.min'
-export default createClass
+> The comparison function is different from `shouldComponentUpdate` in that it checks if the two props objects are **equal**, whereas `shouldComponentUpdate` checks if they are different.
+
+## forwardRef
+
+In some cases when writing a component you want to allow the user to get hold of a specific reference further down the tree. With `forwardRef` you can sort-of "forward" the `ref` property:
+
+```jsx
+import { createRef, render } from 'preact';
+import { forwardRef } from 'preact/compat';
+
+const MyComponent = forwardRef((props, ref) => {
+  return <div ref={ref}>Hello world</div>;
+})
+
+// Usage: `ref` will hold the reference to the inner `div` instead of
+// `MyComponent`
+const ref = createRef();
+render(<MyComponent ref={ref} />, dom)
 ```
 
-If you are using the new `import` syntax on your server with Babel, writing these lines above your other imports will not work since Babel moves all imports to the top of a module.  In that case, save the above code as `patchPreact.js`, then import it at the top of your file (`import './patchPreact'`). You can read more on `module-alias` usage [here](https://www.npmjs.com/package/module-alias).
+This component is most useful for library authors.
 
+## Portals
 
-It is also possible to alias directly in node without the `module-alias` package. This relies on internal properties of Node's module system, so proceed with caution.  To alias manually:
+In rare circumstances you may want to continue rendering into a different DOM node. The target DOM node **must** be present before attempting to render into it.
 
-```js
-// patchPreact.js
-var React = require('react')
-var ReactDOM = require('react-dom')
-var ReactDOMServer = require('react-dom/server')
-var CreateReactClass = require('create-react-class')
-var Preact = require('preact-compat/dist/preact-compat.min')
-var Module = module.constructor
-Module._cache[require.resolve('react')].exports = Preact
-Module._cache[require.resolve('react-dom')].exports = Preact
-Module._cache[require.resolve('create-react-class')].exports.default = Preact.createClass
+```html
+<html>
+  <body>
+    <!-- App is rendered here -->
+    <div id="app"></div>
+    <!-- Modals should be rendered here -->
+    <div id="modals"></div>
+  </body>
+</html>
 ```
 
-### Build & Test
+```jsx
+import { createPortal } from 'preact/compat';
+import MyModal from './MyModal';
 
-**You're done!**
-Now when you run your build, all your React imports will be instead importing `preact-compat` and your bundle will be much smaller.
-It's always a good idea to run your test suite and of course load up your app to see how it's working.
-
-
----
-
-
-## Optimal: Switch to Preact
-
-You don't have to use `preact-compat` in your own codebase in order to migrate from React to Preact.
-Preact's API is nearly identical to React's, and many React codebases can be migrated with little or no changes needed.
-
-Generally, the process of switching to Preact involves a few steps:
-
-### 1. Install Preact
-
-This one is simple: you'll need to install the library in order to use it!
-
-```sh
-npm install --save preact  # or: npm i -S preact
-```
-
-### 2. JSX Pragma: transpile to `h()`
-
-> **Background:** While the [JSX] language extension is independent from React, popular
-> transpilers like [Babel] and [Bublé] default to converting JSX to `React.createElement()` calls.
-> There are historical reasons for this, but it's worth understanding that the function calls JSX
-> transpiles to are actually a pre-existing technology called [Hyperscript]. Preact pays homage
-> to this and attempts to promote a better understanding of the simplicity of JSX by using `h()`
-> as its [JSX Pragma].
->
-> **TL;DR:** We need to switch `React.createElement()` out for preact's `h()`
-
-In JSX, the "pragma" is the name of a function that handles creating each element:
-
-> `<div />` transpiles to `h('div')`
->
-> `<Foo />` transpiles to `h(Foo)`
->
-> `<a href="/">Hello</a>` to `h('a', { href:'/' }, 'Hello')`
-
-In each example above, `h` is the function name we declared as the JSX Pragma.
-
-
-#### Via Babel
-
-If you're using Babel, you can set the JSX Pragma in your `.babelrc` or `package.json` (whichever you prefer):
-
-```json
-{
-  "plugins": [
-    ["transform-react-jsx", { "pragma": "h" }]
-  ]
+function App() {
+  const container = document.getElementById('modals');
+  return (
+    <div>
+      I'm app
+      {createPortal(<MyModal />, container)}
+    </div>
+  )
 }
 ```
 
+> Keep in mind that due to Preact reusing the browser's event system, events won't bubble up through a Portal container to the other tree.
 
-#### Via Comments
+## Suspense (experimental)
 
-If you're working in an online editor powered by Babel (such as JSFiddle or Codepen),
-you can set the JSX Pragma by defining a comment near the top of your code:
+The main idea behind `Suspense` is to allow sections of your UI to display some sort of loading content while components further down the tree are still loading. A common use case for this is code-splitting where you'll need to load a component from the network before you can render it.
 
-`/** @jsx h */`
+```jsx
+import { Suspense, lazy } from `preact/compat`;
 
+const SomeComponent = lazy(() => import('./SomeComponent'));
 
-#### Via Bublé
-
-[Bublé] ships with JSX support by default.  Just set the `jsx` option:
-
-`buble({ jsx: 'h' })`
-
-
-### 3. Update any Legacy Code
-
-While Preact strives to be API-compatible with React, portions of the interface are intentionally not included.
-The most noteworthy of these is `createClass()`. Opinions vary wildly on the subject of classes and OOP, but
-it's worth understanding that JavaScript classes are used internally in VDOM libraries to represent component types,
-which is important when dealing with the nuances of managing component lifecycles.
-
-If your codebase is heavily reliant on `createClass()`, you still have a great option:
-Laurence Dorman maintains a [standalone `createClass()` implementation](https://github.com/ld0rman/preact-classless-component)
-that works directly with preact and is only a few hundred bytes.
-Alternatively, you can automatically convert your `createClass()` calls to ES Classes using [preact-codemod](https://github.com/vutran/preact-codemod) by Vu Tran.
-
-Another difference worth noting is that Preact only supports Function Refs by default.
-String refs are deprecated in React and will be removed shortly, since they introduce a surprising amount of complexity for little gain.
-If you want to keep using String refs, [this tiny linkedRef function](https://gist.github.com/developit/63e7a81a507c368f7fc0898076f64d8d)
-offers a future-proofed version that still populates `this.refs.$$` like String Refs did.  The simplicity of this tiny wrapper around
-Function Refs also helps illustrate why Function Refs are now the preferred choice going forward.
-
-
-### 4. Simplify Root Render
-
-Since React 0.13, `render()` has been provided by the `react-dom` module.
-Preact does not use a separate module for DOM rendering, since it is focused solely on being a great DOM renderer.
-So, the last step in converting your codebase to Preact is switching `ReactDOM.render()` to preact's `render()`:
-
-```diff
-- ReactDOM.render(<App />, document.getElementById('app'));
-+ render(<App />, document.body);
+// Usage
+<Suspense fallback={<div>loading...</div>}>
+  <Foo>
+    <SomeComponent />
+  </Foo>
+</Suspense>
 ```
 
-It's also worth noting that Preact's `render()` is non-destructive, so rendering into `<body>` is perfectly fine (encouraged, even).
-This is possible because Preact does not assume it controls the entire root element you pass it.  The second argument to `render()`
-is actually `parent` - meaning it's a DOM element to render _into_.  If you would like to re-render from the root (perhaps for Hot
-Module Replacement), `render()` accepts an element to replace as a third argument:
+In this example the UI will display the `loading...` text until `SomeComponent` is loaded and the Promise is resolved.
 
-```js
-// initial render:
-render(<App />, document.body);
-
-// update in-place:
-render(<App />, document.body, document.body.lastElementChild);
-```
-
-In the above example, we're relying on the last child being our previously rendered root.
-While this works in many cases (jsfiddles, codepens, etc), it's best to have more control.
-This is why `render()` returns the root element: you pass it as the third argument to re-render in-place.
-The following example shows how to re-render in response to Webpack's Hot Module Replacement updates:
-
-```js
-// root holds our app's root DOM Element:
-let root;
-
-function init() {
-  root = render(<App />, document.body, root);
-}
-init();
-
-// example: Re-render on Webpack HMR update:
-if (module.hot) module.hot.accept('./app', init);
-```
-
-The full technique can be seen in [preact-boilerplate](https://github.com/developit/preact-boilerplate/blob/master/src/index.js#L6-L18).
-
-
-[babel]: https://babeljs.io
-[bublé]: https://buble.surge.sh
-[JSX]: https://facebook.github.io/jsx/
-[JSX Pragma]: http://www.jasonformat.com/wtf-is-jsx/
-[preact-boilerplate]: https://github.com/developit/preact-boilerplate
-[hyperscript]: https://github.com/dominictarr/hyperscript
+> This feature is experimental and may contain bugs. We have included it as an early preview to increase testing visibility. We don't recommend using it in production.

--- a/content/en/index.md
+++ b/content/en/index.md
@@ -11,9 +11,8 @@ description: 'Preact is a fast 3kB alternative to React with the same modern API
         <logo height="1.5em" title="Preact" text inverted>Preact</logo>
     </h1>
     <p>Fast 3kB alternative to React with the same modern API.</p>
-    <p>
+    <p class="intro-buttons">
         <a href="/guide/v10/getting-started" class="home-button">Get Started</a>
-        <span class="home-button-sep">&nbsp; &nbsp; &nbsp;</span>
         <a href="/guide/v10/switching-to-preact" class="home-button">Switch to Preact</a>
     </p>
     <p>

--- a/content/es/index.md
+++ b/content/es/index.md
@@ -11,7 +11,7 @@ toc: false
         <logo height="1.5em" title="Preact" text inverted>Preact</logo>
     </h1>
     <p>Una alternativa veloz a React en 3kB con la misma API de ES6.</p>
-    <p>
+    <p class="intro-buttons">
         <a href="/guide/v10/getting-started" class="home-button">Primeros pasos</a>
         <span class="home-button-sep">&nbsp; • &nbsp;</span>
         <a href="/guide/v10/switching-to-preact" class="home-button">Cambiar a Preact</a>

--- a/content/fr/index.md
+++ b/content/fr/index.md
@@ -10,7 +10,7 @@ toc: false
         <logo height="1.5em" title="Preact" text inverted>Preact</logo>
     </h1>
     <p>Alternative légère et rapide à React avec le même API en seulement 3Ko.</p>
-    <p>
+    <p class="intro-buttons">
         <a href="/guide/v10/getting-started" class="home-button">Commencer</a>
         <span class="home-button-sep">&nbsp; • &nbsp;</span>
         <a href="/guide/v10/switching-to-preact" class="home-button">Passer à preact</a>

--- a/content/it/index.md
+++ b/content/it/index.md
@@ -11,7 +11,7 @@ toc: false
         <logo height="1.5em" title="Preact" text inverted>Preact</logo>
     </h1>
     <p>Un alternativa veloce e leggera 3Kb a React con le stesse moderne API.</p>
-    <p>
+    <p class="intro-buttons">
         <a href="/guide/v10/getting-started" class="home-button">Primi Passi</a>
         <span class="home-button-sep">&nbsp; &nbsp; &nbsp;</span>
         <a href="/guide/v10/switching-to-preact" class="home-button">Passare a Preact</a>

--- a/content/pt-br/index.md
+++ b/content/pt-br/index.md
@@ -11,7 +11,7 @@ toc: false
         <logo height="1.5em" title="Preact" text inverted>Preact</logo>
     </h1>
     <p>Uma alternativa ao React com apenas 3kB e a mesma API ES6.</p>
-    <p>
+    <p class="intro-buttons">
         <a href="/guide/v10/getting-started" class="home-button">Como começar</a>
         <span class="home-button-sep">&nbsp; • &nbsp;</span>
         <a href="/guide/v10/switching-to-preact" class="home-button">Mudando para Preact</a>

--- a/content/tr/index.md
+++ b/content/tr/index.md
@@ -11,7 +11,7 @@ toc: false
         <logo height="1.5em" title="Preact" text inverted>Preact</logo>
     </h1>
     <p>Aynı modern API ile React'e hızlı ve 3kB'lık alternatif.</p>
-    <p>
+    <p class="intro-buttons">
         <a href="/guide/v10/getting-started" class="home-button">Başlangıç</a>
         <span class="home-button-sep">&nbsp; &nbsp; &nbsp;</span>
         <a href="/guide/v10/switching-to-preact" class="home-button">Preact'e Geçiş</a>

--- a/content/zh/index.md
+++ b/content/zh/index.md
@@ -11,7 +11,7 @@ toc: false
         <logo height="1.5em" title="Preact" text inverted>Preact</logo>
     </h1>
     <p>React 的 3kb 轻量化方案，拥有同样的 ES6 API</p>
-    <p>
+    <p class="intro-buttons">
         <a href="/guide/v10/getting-started" class="home-button">如何开始</a>
         <span class="home-button-sep">&nbsp; • &nbsp;</span>
         <a href="/guide/v10/switching-to-preact" class="home-button">切换到 preact</a>

--- a/src/style/index.less
+++ b/src/style/index.less
@@ -213,22 +213,28 @@ main .markup {
 		}
 	}
 
+	.intro-buttons {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+
+		@media (min-width: 600px) {
+			flex-direction: row-reverse;
+			justify-content: center;
+			align-items: initial;
+		}
+
+		.home-button + .home-button {
+			margin-top: 1.3rem;
+
+			@media (min-width: 600px) {
+				margin-top: 0;
+			}
+		}
+	}
+
 	.home-button {
 		margin: 0 1rem;
-	}
-
-	.home-button-sep {
-		display: none;
-	}
-
-	@media (max-width: 600px) {
-		.home-button-sep {
-			display: block;
-			height: 0;
-			width: auto;
-			margin-bottom: 1.3em;
-			overflow: hidden;
-		}
 	}
 
 	.home-demo {


### PR DESCRIPTION
This PR rewrites the page about `preact/compat` or otherwise known as `Switching to Preact`. That was the last page which still referenced `preact-compat`.