### PR TITLE
Correct spelling mistake for high-order-components to higher-ord…

### DIFF
--- a/content/en/guide/v10/hooks.md
+++ b/content/en/guide/v10/hooks.md
@@ -7,7 +7,7 @@ description: 'Hooks in Preact allow you to compose behaviours together and re-us
 
 Hooks is a new concept that allows you to compose state and side effects. They allow you to reuse stateful logic between components.
 
-If you've worked with Preact for a while you may be familiar with patterns like `render-props` and `high-order-components` that try to solve the same. But they've always made code harder to follow whereas with hooks you can neatly extract that logic and make it easy to unit test it independently.
+If you've worked with Preact for a while you may be familiar with patterns like `render-props` and `higher-order-components` that try to solve the same. But they've always made code harder to follow whereas with hooks you can neatly extract that logic and make it easy to unit test it independently.
 
 Due to their functional nature they can be used in functional components and avoid many pitfalls of the `this` keyword that's present in classes. Instead they rely on closures which makes them value-bound and eliminates a whole bag of bugs when it comes to async state updates.
 
@@ -238,7 +238,7 @@ function Foo() {
 
 ## useContext
 
-To access context in a functional component we can use the `useContext` hook, without any high-order or wrapper components. The first argument must be the context object that's created from a `createContext` call.
+To access context in a functional component we can use the `useContext` hook, without any higher-order or wrapper components. The first argument must be the context object that's created from a `createContext` call.
 
 ```jsx
 const Theme = createContext('light');

--- a/content/en/guide/v8/differences-to-react.md
+++ b/content/en/guide/v8/differences-to-react.md
@@ -26,7 +26,7 @@ For both Preact and [preact-compat], version compatibility is measured against t
 
 - [ES6 Class Components]
     - _classes provide an expressive way to define stateful components_
-- [High-Order Components]  
+- [Higher-Order Components]  
     - _components that return other components from `render()`, effectively wrappers_
 - [Stateless Pure Functional Components]  
     - _functions that receive `props` as arguments and return JSX/VDOM_
@@ -81,7 +81,7 @@ Preact and React have some more subtle differences:
 [Children]: https://facebook.github.io/react/docs/top-level-api.html#reactchildren
 [GlobalEventHandlers]: https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers
 [ES6 Class Components]: https://facebook.github.io/react/docs/reusable-components.html#es6-classes
-[High-Order Components]: https://medium.com/@dan_abramov/mixins-are-dead-long-live-higher-order-components-94a0d2f9e750
+[Higher-Order Components]: https://medium.com/@dan_abramov/mixins-are-dead-long-live-higher-order-components-94a0d2f9e750
 [Stateless Pure Functional Components]: https://facebook.github.io/react/docs/reusable-components.html#stateless-functions
 [destructuring]: http://www.2ality.com/2015/01/es6-destructuring.html
 [Linked State]: /guide/linked-state


### PR DESCRIPTION
I had read about Higher Order Components is React. Thus, I think it should be Higher Order Components 😊