### PR TITLE
Fix typo in CSS Custom Properties example

### DIFF
--- a/content/en/guide/v10/whats-new.md
+++ b/content/en/guide/v10/whats-new.md
@@ -109,7 +109,7 @@ Sometimes it's the little things that make a huge difference. With the recent ad
 
 ```jsx
 function Foo(props) {
-  return <div> style={{ '--theme-color': 'blue' }}>{props.children}</div>;
+  return <div style={{ '--theme-color': 'blue' }}>{props.children}</div>;
 }
 ```
 


### PR DESCRIPTION
Div tag was closed prematurely, which also resulted in a non-functioning
example, when run in REPL.