### PR TITLE
Docs: Update run command to match CLI

### DIFF
--- a/content/en/guide/v10/getting-started.md
+++ b/content/en/guide/v10/getting-started.md
@@ -80,7 +80,7 @@ Now we're ready to start our application. To fire up the development server run 
 cd my-project/
 
 # Start the devserver
-npm run dev
+npm run start
 ```
 
 Once the server is up you can access your app at the URL that was printed in the console. Now you're ready to develop your app!


### PR DESCRIPTION
Hiya!

When looking through the docs, I noticed that the start command doesn't match the output of the CLI.

CLI Version: `preact-cli 2.2.1`

Output after installing using command: `preact create simple test-site`:

```
To get started, cd into the new directory:
  cd new-site

To start a development live-reload server:
  npm run start

To create a production build (in ./build):
  npm run build

To start a production HTTP/2 server:
  npm run serve
```

The docs recommend using `npm run dev`, but after looking at the `package.json`, it seems like `npm run start` will run `npm run dev` if it's not for production. If this is done on purpose, please disregard this PR. I think this can be confusing for people new to Preact / dev since they're unsure if the inconsistency is on purpose or not. Thanks!