### PR TITLE
Manually filter recent version by semver from github releases li…

### DIFF
--- a/src/components/header/gh-version.js
+++ b/src/components/header/gh-version.js
@@ -1,12 +1,30 @@
 import { h } from 'preact';
+import { useEffect, useState } from 'preact/hooks';
+import { fetchRelease } from '../../lib/github';
+import config from '../../config.json';
 
 const VERSION = '10.0.4';
 const URL = `https://github.com/preactjs/preact/releases/tag/${VERSION}`;
 
 export default function ReleaseLink(props) {
+	const [url, setUrl] = useState(URL);
+	const [version, setVersion] = useState(VERSION);
+
+	useEffect(() => {
+		fetchRelease(config.repo)
+			.catch(() => ({
+				version: VERSION,
+				url: URL
+			}))
+			.then(d => {
+				setVersion(d.version);
+				setUrl(d.url);
+			});
+	}, []);
+
 	return (
-		<a href={URL} {...props}>
-			v{VERSION}
+		<a href={url} {...props}>
+			v{version}
 		</a>
 	);
 }

--- a/src/components/header/gh-version.js
+++ b/src/components/header/gh-version.js
@@ -1,36 +1,12 @@
 import { h } from 'preact';
-import { useEffect, useState } from 'preact/hooks';
-import { fetchRelease } from '../../lib/github';
-import config from '../../config.json';
 
-const URL = 'https://github.com/' + config.repo;
-
-let VERSION = '10.0.0';
-if (PRERENDER) {
-	VERSION = require('../../../package.json').dependencies.preact.replace(
-		'^',
-		''
-	);
-}
+const VERSION = '10.0.4';
+const URL = `https://github.com/preactjs/preact/releases/tag/${VERSION}`;
 
 export default function ReleaseLink(props) {
-	const [url, setUrl] = useState(URL);
-	const [version, setVersion] = useState(VERSION);
-	useEffect(() => {
-		fetchRelease(config.repo)
-			.catch(() => ({
-				version: VERSION,
-				url: URL
-			}))
-			.then(d => {
-				setVersion(d.version);
-				setUrl(d.url);
-			});
-	}, []);
-
 	return (
-		<a href={url} {...props}>
-			v{version}
+		<a href={URL} {...props}>
+			v{VERSION}
 		</a>
 	);
 }

--- a/src/lib/github.js
+++ b/src/lib/github.js
@@ -15,17 +15,3 @@ export const repoInfo = memoize(repo =>
 			watchers_count: 9999
 		}))
 );
-
-export const fetchRelease = memoize(repo =>
-	fetch(`https://api.github.com/repos/${repo}/releases/latest`)
-		.then(checkStatus)
-		.then(r => r.json())
-		.then(d => ({
-			version: d.tag_name || 'unknown',
-			url: d.html_url || '#'
-		}))
-		.catch(() => ({
-			url: '#',
-			version: 'unknown'
-		}))
-);

--- a/src/lib/github.js
+++ b/src/lib/github.js
@@ -37,7 +37,7 @@ export const fetchRelease = memoize(repo =>
 		.then(checkStatus)
 		.then(r => r.json())
 		.then(d => {
-			const releases = d.sort((releaseA, releaseB) => {
+			const releases = (d || []).sort((releaseA, releaseB) => {
 				const a = parseVersion(releaseA.tag_name);
 				const b = parseVersion(releaseB.tag_name);
 
@@ -60,8 +60,8 @@ export const fetchRelease = memoize(repo =>
 			});
 
 			return {
-				version: releases[0].tag_name || 'unknown',
-				url: releases[0].html_url || '#'
+				version: releases.length ? releases[0].tag_name : 'unknown',
+				url: releases.length ? releases[0].html_url : '#'
 			};
 		})
 		.catch(() => ({

--- a/src/lib/github.js
+++ b/src/lib/github.js
@@ -15,3 +15,57 @@ export const repoInfo = memoize(repo =>
 			watchers_count: 9999
 		}))
 );
+
+const semverReg = /^.*?(\d+)\.(\d+)\.(\d+)(.*)?$/g;
+
+/**
+ * Parse semver version
+ * @param {string} version
+ */
+function parseVersion(version) {
+	semverReg.lastIndex = 0;
+	const m = semverReg.exec(version);
+	if (m) {
+		return [+m[1], +m[2], +m[3], m[4]].filter(x => x !== undefined);
+	}
+
+	return [0, 0, 0];
+}
+
+export const fetchRelease = memoize(repo =>
+	fetch(`https://api.github.com/repos/${repo}/releases`)
+		.then(checkStatus)
+		.then(r => r.json())
+		.then(d => {
+			const releases = d.sort((releaseA, releaseB) => {
+				const a = parseVersion(releaseA.tag_name);
+				const b = parseVersion(releaseB.tag_name);
+
+				// Major
+				if (a[0] > b[0]) return -1;
+				if (a[0] < b[0]) return 1;
+
+				// Minor
+				if (a[1] > b[1]) return -1;
+				if (a[1] < b[1]) return 1;
+
+				// Patch
+				if (a[2] && a.length === 3 > b[2]) return -1;
+				if (a[2] && a.length === 3 < b[2]) return 1;
+
+				// Pre-Releases
+				if (a.length > 3 && b.length === 3) return 1;
+				if (a.length === 3 && b.length > 3) return -1;
+				return a[3] - b[3];
+			});
+
+			return {
+				version: releases[0].tag_name || 'unknown',
+				url: releases[0].html_url || '#'
+			};
+		})
+		.catch(() => ({
+			url: '#',
+			version: 'unknown'
+		}))
+);


### PR DESCRIPTION
~~I'd love to have it dynamic, but to do that we'd need to query npm instead. GitHub doesn't support multiple release lines. So it's better to show the correct version statically than to show a wrong one.~~

Because GitHub doesn't support multiple release lines we would previously always pull the latest one by date. So in effect our version number would switch between the `8.x` and `10.x` release line. That's not what we want!

By suggestion from @cristianbote , this PR now changes that to load the release list and we'll find the most recent one ourselves from that.