### PR TITLE
fix: add Lighthouse score proof link

### DIFF
--- a/content/en/cli.md
+++ b/content/en/cli.md
@@ -16,7 +16,7 @@ Preact CLI puts your project on the path to excellent performance. New projects 
 
 Preact CLI comes with the following features out of the box.
 
-- 100/100 Lighthouse score, right out of the box (proof).
+- 100/100 Lighthouse score, right out of the box ([proof](https://googlechrome.github.io/lighthouse/viewer/?gist=142af6838482417af741d966e7804346)).
 - Fully automatic code splitting for routes.
 - Transparently code-split any component with an async! prefix.
 - Differential javascript serving.


### PR DESCRIPTION
There are other links missing from [`/about/cli.md`](https://raw.githubusercontent.com/preactjs/preact-www/43ccc139116cd8b0387263186da3c4f280dc699c/content/en/about/cli.md), but this one stood out.