### PR TITLE
Fix wrong curly brace in References section

### DIFF
--- a/content/en/guide/v10/refs.md
+++ b/content/en/guide/v10/refs.md
@@ -101,7 +101,7 @@ class Foo extends Component {
       <div ref={this.ref}>
         Width: {width}, Height: {height}
       </div>
-    };
+    );
   }
 }
 ```

--- a/content/pt-br/guide/v10/refs.md
+++ b/content/pt-br/guide/v10/refs.md
@@ -101,7 +101,7 @@ class Foo extends Component {
       <div ref={this.ref}>
         Width: {width}, Height: {height}
       </div>
-    };
+    );
   }
 }
 ```


### PR DESCRIPTION
In the "Putting it all together" example, the return statement opening
parenthesis has been closed with a curly braces making the example
producing an error while in REPL.