### PR TITLE
Fix code markup on landing page

### DIFF
--- a/content/en/index.md
+++ b/content/en/index.md
@@ -106,8 +106,8 @@ function Counter() {
       Lightweight is a lot more fun when you don't have to sacrifice productivity to get there. Preact gets you productive right away. It even has a few bonus features:
     </p>
     <ul>
-      <li>`props`, `state` and `context` are passed to `render()`</li>
-      <li>Use standard HTML attributes like `class` and `for`</li>
+      <li><code>props</code>, <code>state</code> and <code>context</code> are passed to <code>render()</code></li>
+      <li>Use standard HTML attributes like <code>class</code> and <code>for</code></li>
       <li>Works with React DevTools right out of the box</li>
     </ul>
   </div>


### PR DESCRIPTION
> Markdown isn't supported within HTML blocks

I'm not sure whether this is actually correct/desirable, so haven't adjusted any other languages