### PR TITLE
Add warning banner on old docs

### DIFF
--- a/src/components/controllers/page/index.js
+++ b/src/components/controllers/page/index.js
@@ -15,6 +15,7 @@ import {
 } from '../../../lib/prerender-data';
 import { isDocPage } from '../../../lib/docs';
 import { useStore } from '../../store-adapter';
+import { AVAILABLE_DOCS } from '../../doc-version';
 
 const getContentId = route => route.content || route.path;
 
@@ -127,13 +128,18 @@ export function usePage(route, lang) {
 }
 
 export default function Page({ route }, ctx) {
-	const store = useStore(['url', 'lang']);
+	const store = useStore(['url', 'lang', 'docVersion']);
 	const { loading, meta, content, html, current, isFallback } = usePage(
 		route,
 		store.state.lang
 	);
 	const urlState = store.state;
 	const url = useMemo(() => urlState.url, [current]);
+
+	const docsUrl = useMemo(
+		() => url.replace(/(v\d{1,2})/, `v${AVAILABLE_DOCS[0]}`),
+		[url]
+	);
 
 	const layout = `${meta.layout || 'default'}Layout`;
 	const name = getContentId(route);
@@ -166,6 +172,12 @@ export default function Page({ route }, ctx) {
 					show={hasSidebar}
 				/>
 				<div class={style.inner}>
+					{isDocPage(url) && +store.state.docVersion !== AVAILABLE_DOCS[0] && (
+						<div class={style.oldDocsWarning}>
+							You are viewing the documentation for an older version of Preact.
+							Switch to the <a href={docsUrl}>current version</a>.
+						</div>
+					)}
 					<Hydrator
 						boot={isReady}
 						component={EditThisPage}

--- a/src/components/controllers/page/style.less
+++ b/src/components/controllers/page/style.less
@@ -54,6 +54,18 @@
 	background: var(--color-page-bg);
 }
 
+.oldDocsWarning {
+	background: var(--color-warn-bg);
+	padding: 0.75rem 1rem;
+	color: #444;
+	text-align: center;
+
+	a {
+		.link;
+		color: @color-brand;
+	}
+}
+
 .withEdit {
 	margin-top: 2rem;
 }

--- a/src/components/doc-version/index.js
+++ b/src/components/doc-version/index.js
@@ -8,7 +8,7 @@ function onChange(e) {
 	route(url);
 }
 
-const AVAILABLE_DOCS = [10, 8];
+export const AVAILABLE_DOCS = [10, 8];
 
 /**
  * Select box to switch the currently displayed docs version


### PR DESCRIPTION
We've gotten a few messages on slacks or PRs that were made against the older version instead of the current docs. This PR adds a banner on old docs pointing users to the newest version.