### PR TITLE
Replace Semi-Colon with Comma

### DIFF
--- a/content/en/guide/v10/hooks.md
+++ b/content/en/guide/v10/hooks.md
@@ -224,8 +224,8 @@ The `useCallback` hook can be used to ensure that the returned function will rem
 
 ```jsx
 const onClick = useCallback(
-  () => console.log(a, b);
-  [a, b],
+  () => console.log(a, b),
+  [a, b]
 );
 ```
 


### PR DESCRIPTION
I believe the semicolon was placed in error and was intended to be a comma.