### PR TITLE
Fix wrong jsx option in render-to-string docs

### DIFF
--- a/content/en/guide/v10/server-side-rendering.md
+++ b/content/en/guide/v10/server-side-rendering.md
@@ -73,11 +73,11 @@ console.log(render(App, { pretty: true }));
 The JSX rendering mode is especially useful if you're doing any kind of snapshot testing. It renders the output as if it was written in JSX.
 
 ```jsx
-import render from 'preact-render-to-string';
+import render from 'preact-render-to-string/jsx';
 import { h } from 'preact';
 
 const App = <div data-foo={true} />;
 
-console.log(render(App, { jsx: true }));
+console.log(render(App));
 // Logs: <div data-foo={true} />
 ```


### PR DESCRIPTION
We're using a separate renderer for JSX.