### PR TITLE
Correct code for Aliasing in Jest

### DIFF
--- a/content/en/guide/v10/getting-started.md
+++ b/content/en/guide/v10/getting-started.md
@@ -166,9 +166,9 @@ jest configuration:
 ```json
 {
   "moduleNameMapper": {
-    "react": "preact/compat",
-    "react-dom/test-utils": "preact/test-utils",
-    "react-dom": "preact/compat"
+    "^react$": "preact/compat",
+    "^react-dom/test-utils$": "preact/test-utils",
+    "^react-dom$": "preact/compat"
   }
 }
 ```


### PR DESCRIPTION
From [Jest documentation](https://jestjs.io/docs/en/configuration.html#modulenamemapper-objectstring-string):

> Note: If you provide module name without boundaries ^$ it may cause hard to spot errors. E.g. relay will replace all modules which contain relay as a substring in its name: relay, react-relay and graphql-relay will all be pointed to your stub.