### PR TITLE
Fix options.event description

### DIFF
--- a/content/en/guide/v10/options.md
+++ b/content/en/guide/v10/options.md
@@ -68,9 +68,9 @@ Invoked immediately after a vnode is rendered, once its DOM representation is co
 
 #### `options.event`
 
-**Signature:** `(event: Event) => void`
+**Signature:** `(event: Event) => any`
 
-Invoked just before a DOM event is handled by its associated Virtual DOM listener.
+Invoked just before a DOM event is handled by its associated Virtual DOM listener. When `options.event` is setted, the event which is event listener argument is replaced return value of `options.event`.
 
 #### `options.requestAnimationFrame`
 


### PR DESCRIPTION
Return value of `Options.event()` replaces event of event handler.
Therefore,  `Options.event()`  returns value.
https://github.com/preactjs/preact/blob/9038db5f6aa4d0e1203bc4a9f6423a4dcbf46962/src/diff/props.js#L160

https://github.com/preactjs/preact/pull/2381