### PR TITLE
Fix bad contrast of company logos in dark mode

### DIFF
--- a/src/components/we-are-using/index.js
+++ b/src/components/we-are-using/index.js
@@ -253,7 +253,6 @@ export default function WeAreUsing() {
 						rel="noopener noreferrer"
 					>
 						<img src={`/assets/we-are-using/${c.logo}`} alt={c.name} />
-						<span class={styles.name}>{c.name}</span>
 					</a>
 				</li>
 			))}

--- a/src/components/we-are-using/style.less
+++ b/src/components/we-are-using/style.less
@@ -48,8 +48,22 @@ html .root {
 		display: block;
 		margin: 0 auto 1rem;
 		opacity: 0.5;
-		filter: grayscale(1);
 		transition: all 250ms ease;
+
+		// Invert based on luminosity
+		@media (prefers-color-scheme: dark) {
+			filter: invert(0.862745) hue-rotate(180deg) grayscale(1);
+		}
+		:global(.dark) & {
+			filter: invert(0.862745) hue-rotate(180deg) grayscale(1);
+		}
+
+		@media (prefers-color-scheme: light) {
+			filter: grayscale(1);
+		}
+		:global(.light) & {
+			filter: grayscale(1);
+		}
 	}
 }
 

--- a/src/components/we-are-using/style.less
+++ b/src/components/we-are-using/style.less
@@ -35,10 +35,23 @@ html .root {
 		background: none !important;
 		padding: 1rem;
 
-		&:hover {
-			img {
-				filter: none;
-				opacity: 1;
+		&:hover img {
+			filter: grayscale(0);
+			opacity: 1;
+		}
+		
+		:global(.dark) &:hover img {
+			filter: invert(0) hue-rotate(0deg) grayscale(0)
+				drop-shadow(0 0 .5px #fff)
+				drop-shadow(0 5px 10px #000)
+				drop-shadow(0 0 20px rgba(255,255,255,0.5));
+		}
+		@media (prefers-color-scheme: dark) {
+			&:hover img {
+				filter: invert(0) hue-rotate(0deg) grayscale(0)
+					drop-shadow(0 0 .5px #fff)
+					drop-shadow(0 5px 10px #000)
+					drop-shadow(0 0 20px rgba(255,255,255,0.5));
 			}
 		}
 	}
@@ -49,6 +62,7 @@ html .root {
 		margin: 0 auto 1rem;
 		opacity: 0.6;
 		transition: all 250ms ease;
+		filter: grayscale(1);
 
 		// Invert based on luminosity
 		@media (prefers-color-scheme: dark) {
@@ -56,13 +70,7 @@ html .root {
 		}
 		:global(.dark) & {
 			filter: invert(0.862745) hue-rotate(180deg) grayscale(1);
-		}
-
-		@media (prefers-color-scheme: light) {
-			filter: grayscale(1);
-		}
-		:global(.light) & {
-			filter: grayscale(1);
+			opacity: 1;
 		}
 	}
 }

--- a/src/components/we-are-using/style.less
+++ b/src/components/we-are-using/style.less
@@ -47,7 +47,7 @@ html .root {
 		height: 4.5rem;
 		display: block;
 		margin: 0 auto 1rem;
-		opacity: 0.5;
+		opacity: 0.6;
 		transition: all 250ms ease;
 
 		// Invert based on luminosity


### PR DESCRIPTION
- Fix bad logo contrast in dark mode, thanks to some luminosity based grayscale wizardry I'm told @mathiasbynens is the one to thank for this trick :slightly_smiling_face: 
- Remove company names to make the grid appear less "noisy" visually.

Also played around with removing the `opacity: 0.5` on the logos, but without that the logos themselves introduce to many hard edges. It makes it harder (at least for me) to find a single thing to focus on, on the page. 

Before:

![Screenshot from 2020-03-04 19-17-08](https://user-images.githubusercontent.com/1062408/75909979-5df43680-5e4d-11ea-9d8d-c539fc528367.png)

After:

![Screenshot from 2020-03-04 19-19-04](https://user-images.githubusercontent.com/1062408/75910118-93008900-5e4d-11ea-9784-dd3689ad3d49.png)

