### PR TITLE
Fix Webpack code splitting link in v8 progressive web apps section

### DIFF
--- a/content/de/guide/v8/progressive-web-apps.md
+++ b/content/de/guide/v8/progressive-web-apps.md
@@ -63,7 +63,7 @@ Während Preact einfach in einer PWA zu integrieren ist und reibungslos funktion
           <div class="_bubble" style="background-image: url(/assets/pwa-guide/code-splitting.svg);"></div>
         </div>
         <div class="list-detail">
-          <p class="_summary"><strong><a href="https://webpack.github.io/docs/code-splitting.html">Code-Splitting</a></strong>  teilt den Code auf, sodass man genau den Teil des Codes an den Nutzer ausliefern kann, den er für die angeforderte Seite benötigt. Den Rest der Seite bei Bedarf mithilfe von Lazy-loading aufzurufen, verbessert Ladezeiten immens. Dies wird auch über Webpack unterstützt.</p>
+          <p class="_summary"><strong><a href="https://webpack.js.org/guides/code-splitting/">Code-Splitting</a></strong>  teilt den Code auf, sodass man genau den Teil des Codes an den Nutzer ausliefern kann, den er für die angeforderte Seite benötigt. Den Rest der Seite bei Bedarf mithilfe von Lazy-loading aufzurufen, verbessert Ladezeiten immens. Dies wird auch über Webpack unterstützt.</p>
         </div>
     </li>
     <li class="list-item">

--- a/content/en/guide/v8/progressive-web-apps.md
+++ b/content/en/guide/v8/progressive-web-apps.md
@@ -63,7 +63,7 @@ While Preact is a drop-in that should work well for your PWA, it can also be use
           <div class="_bubble" style="background-image: url(/assets/pwa-guide/code-splitting.svg);"></div>
         </div>
         <div class="list-detail">
-          <p class="_summary"><strong><a href="https://webpack.github.io/docs/code-splitting.html">Code-splitting</a></strong> breaks up your code so you only ship what the user needs for a page. Lazy-loading the rest as needed improves page load times. Supported via Webpack.</p>
+          <p class="_summary"><strong><a href="https://webpack.js.org/guides/code-splitting/">Code-splitting</a></strong> breaks up your code so you only ship what the user needs for a page. Lazy-loading the rest as needed improves page load times. Supported via Webpack.</p>
         </div>
     </li>
     <li class="list-item">

--- a/content/es/guide/v8/progressive-web-apps.md
+++ b/content/es/guide/v8/progressive-web-apps.md
@@ -61,7 +61,7 @@ Así como Preact debería funcionar bien con tu PWA, también puede ser usado co
           <div class="_bubble" style="background-image: url(/assets/pwa-guide/code-splitting.svg);"></div>
         </div>
         <div class="list-detail">
-          <p class="_summary"><strong><a href="https://webpack.github.io/docs/code-splitting.html">Code-splitting</a></strong> parte tu código para que solo entregues lo que el usuario necesita en una página. Haciendo Lazy-loading del resto de la aplicación, mejorando el tiempo de carga. Soportado en Webpack.</p>
+          <p class="_summary"><strong><a href="https://webpack.js.org/guides/code-splitting/">Code-splitting</a></strong> parte tu código para que solo entregues lo que el usuario necesita en una página. Haciendo Lazy-loading del resto de la aplicación, mejorando el tiempo de carga. Soportado en Webpack.</p>
         </div>
     </li>
     <li class="list-item">

--- a/content/fr/guide/v8/progressive-web-apps.md
+++ b/content/fr/guide/v8/progressive-web-apps.md
@@ -65,7 +65,7 @@ En plus d'être une solution qui fonctionne bien pour votre PWA, Preact peut aus
           <div class="_bubble" style="background-image: url(/assets/pwa-guide/code-splitting.svg);"></div>
         </div>
         <div class="list-detail">
-          <p class="_summary"><strong><a href="https://webpack.github.io/docs/code-splitting.html">Le Code-splitting</a></strong> divise votre code de manière à ce que vous puissiez servir uniquement ce dont l'utilisateur a besoin pour une page. Charger le reste à la demande améliore le temps de chargement de la page. Ceci est supporté via Webpack.</p>
+          <p class="_summary"><strong><a href="https://webpack.js.org/guides/code-splitting/">Le Code-splitting</a></strong> divise votre code de manière à ce que vous puissiez servir uniquement ce dont l'utilisateur a besoin pour une page. Charger le reste à la demande améliore le temps de chargement de la page. Ceci est supporté via Webpack.</p>
         </div>
     </li>
     <li class="list-item">

--- a/content/pt-br/guide/v8/progressive-web-apps.md
+++ b/content/pt-br/guide/v8/progressive-web-apps.md
@@ -72,7 +72,7 @@ Mesmo o Preact devendo funcionar bem para seu PWA, ele também pode ser utilizad
           <div class="_bubble" style="background-image: url(/assets/pwa-guide/code-splitting.svg);"></div>
         </div>
         <div class="list-detail">
-          <p class="_summary"><strong><a href="https://webpack.github.io/docs/code-splitting.html">Code-splitting</a></strong> quebra seu código em pedacinhos para que o usuário receba só o que necessita para uma página. Utilizando _Lazy-loading_, carrega-se o resto quando necessário o que melhora o tempo de carregamento das páginas. Suportado via Webpack.</p>
+          <p class="_summary"><strong><a href="https://webpack.js.org/guides/code-splitting/">Code-splitting</a></strong> quebra seu código em pedacinhos para que o usuário receba só o que necessita para uma página. Utilizando _Lazy-loading_, carrega-se o resto quando necessário o que melhora o tempo de carregamento das páginas. Suportado via Webpack.</p>
         </div>
     </li>
     <li class="list-item">

--- a/content/tr/guide/v8/progressive-web-apps.md
+++ b/content/tr/guide/v8/progressive-web-apps.md
@@ -65,7 +65,7 @@ Preact, PWA'iniz için iyi çalışması gereken bir kütüphane olsa da, bir di
           <div class="_bubble" style="background-image: url(/assets/pwa-guide/code-splitting.svg);"></div>
         </div>
         <div class="list-detail">
-          <p class="_summary"><strong><a href="https://webpack.github.io/docs/code-splitting.html">Code-splitting</a></strong> kodunuzu parçalara ayırarak sadece kullanıcının ihtiyacı olan parçaların aktarılmasını sağlar. Geri kalanı lazy-loading ile ihtiyaç duyulduğunda aktarmak, sayfanın yüklenme süresini hızlandırır. Webpack ile desteklenir.</p>
+          <p class="_summary"><strong><a href="https://webpack.js.org/guides/code-splitting/">Code-splitting</a></strong> kodunuzu parçalara ayırarak sadece kullanıcının ihtiyacı olan parçaların aktarılmasını sağlar. Geri kalanı lazy-loading ile ihtiyaç duyulduğunda aktarmak, sayfanın yüklenme süresini hızlandırır. Webpack ile desteklenir.</p>
         </div>
     </li>
     <li class="list-item">

--- a/content/zh/guide/v8/progressive-web-apps.md
+++ b/content/zh/guide/v8/progressive-web-apps.md
@@ -66,7 +66,7 @@ Preact 是希望快速加载和交互的 [渐进式 Web 应用程序](https://de
           <div class="_bubble" style="background-image: url(/assets/pwa-guide/code-splitting.svg);"></div>
         </div>
         <div class="list-detail">
-          <p class="_summary"><strong><a href="https://webpack.github.io/docs/code-splitting.html">代码拆分</a></strong> 
+          <p class="_summary"><strong><a href="https://webpack.js.org/guides/code-splitting/">代码拆分</a></strong> 
             分解您的代码，以便只发送用户页面需要的代码。根据需要延迟加载其余部分可提高页面加载时间。这点通过 webpack 支持。
           </p>
         </div>


### PR DESCRIPTION
The code splitting link
`https://webpack.github.io/docs/code-splitting.html` doesn’t exist
anymore. The new link is `https://webpack.js.org/guides/code-splitting/`