### PR TITLE
Fix invalid HTML by wrapping <toc /> with a <div>

### DIFF
--- a/content/de/guide/v8/api-reference.md
+++ b/content/de/guide/v8/api-reference.md
@@ -7,7 +7,7 @@ permalink: '/guide/api-reference'
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/de/guide/v8/differences-to-react.md
+++ b/content/de/guide/v8/differences-to-react.md
@@ -11,7 +11,7 @@ Preact ist nicht darauf ausgelegt, jede einzelne Funktion von React zu übernehm
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/de/guide/v8/external-dom-mutations.md
+++ b/content/de/guide/v8/external-dom-mutations.md
@@ -7,7 +7,7 @@ permalink: '/guide/external-dom-mutations'
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/de/guide/v8/forms.md
+++ b/content/de/guide/v8/forms.md
@@ -11,7 +11,7 @@ Eingabemasken funktionieren in Preact fast genauso wie in React, allerdings gibt
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/de/guide/v8/getting-started.md
+++ b/content/de/guide/v8/getting-started.md
@@ -11,7 +11,7 @@ Diese Anleitung zeigt, wie man eine einfache tickende Uhr als Komponente erstell
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/de/guide/v8/linked-state.md
+++ b/content/de/guide/v8/linked-state.md
@@ -9,7 +9,7 @@ Ein Bereich, den Preact ausführlicher als React behandelt ist das Optimieren de
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/de/guide/v8/switching-to-preact.md
+++ b/content/de/guide/v8/switching-to-preact.md
@@ -12,7 +12,7 @@ Es gibt zwei verschiedene Herangehensweisen, wie man von React zu Preact wechsel
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/de/guide/v8/types-of-components.md
+++ b/content/de/guide/v8/types-of-components.md
@@ -14,7 +14,7 @@ Innerhalb dieser zwei Typen gibt es außerdem viele verschiedene Wege, Komponent
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/de/guide/v8/unit-testing-with-enzyme.md
+++ b/content/de/guide/v8/unit-testing-with-enzyme.md
@@ -9,7 +9,7 @@ React bietet ein `react-addons-test-utils`-Modul zum Testen von Komponenten an. 
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/en/guide/v10/api-reference.md
+++ b/content/en/guide/v10/api-reference.md
@@ -9,7 +9,7 @@ This page serves as a quick overview over all exported functions.
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/en/guide/v10/components.md
+++ b/content/en/guide/v10/components.md
@@ -11,7 +11,7 @@ There are two kinds of components in Preact, which we'll talk about in this guid
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/en/guide/v10/context.md
+++ b/content/en/guide/v10/context.md
@@ -11,7 +11,7 @@ There are two different ways to use context: Via the newer `createContext` API a
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/en/guide/v10/debugging.md
+++ b/content/en/guide/v10/debugging.md
@@ -13,7 +13,7 @@ We'll print a warning or an error whenever we detect something wrong like incorr
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/en/guide/v10/differences-to-react.md
+++ b/content/en/guide/v10/differences-to-react.md
@@ -12,7 +12,7 @@ The reason Preact does not attempt to include every single feature of React is i
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/en/guide/v10/external-dom-mutations.md
+++ b/content/en/guide/v10/external-dom-mutations.md
@@ -12,7 +12,7 @@ In Preact (and similarly in React), working with these types of libraries requir
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/en/guide/v10/forms.md
+++ b/content/en/guide/v10/forms.md
@@ -11,7 +11,7 @@ The main difference is that in most cases the `value` is not controlled by the D
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/en/guide/v10/getting-started.md
+++ b/content/en/guide/v10/getting-started.md
@@ -11,7 +11,7 @@ There are 3 popular options. If you're new to Preact, we recommend starting with
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/en/guide/v10/hooks.md
+++ b/content/en/guide/v10/hooks.md
@@ -15,7 +15,7 @@ There are two ways to import hooks: from `preact/hooks` or `preact/compat`.
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/en/guide/v10/options.md
+++ b/content/en/guide/v10/options.md
@@ -13,7 +13,7 @@ This API is primarily intended for tooling or library authors who wish to extend
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/en/guide/v10/refs.md
+++ b/content/en/guide/v10/refs.md
@@ -11,7 +11,7 @@ A typical use case for it is measuring the actual size of a DOM node. While it's
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/en/guide/v10/server-side-rendering.md
+++ b/content/en/guide/v10/server-side-rendering.md
@@ -11,7 +11,7 @@ Server-Side Rendering (often abbreviated as "SSR") allows you to render your app
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/en/guide/v10/switching-to-preact.md
+++ b/content/en/guide/v10/switching-to-preact.md
@@ -12,7 +12,7 @@ This lets you continue writing React/ReactDOM code without any changes to your w
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/en/guide/v10/tutorial.md
+++ b/content/en/guide/v10/tutorial.md
@@ -11,7 +11,7 @@ This guide walks through building a simple "ticking clock" component. More detai
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/en/guide/v10/unit-testing-with-enzyme.md
+++ b/content/en/guide/v10/unit-testing-with-enzyme.md
@@ -23,7 +23,7 @@ Preact differs from Enzyme with React.
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/en/guide/v10/upgrade-guide.md
+++ b/content/en/guide/v10/upgrade-guide.md
@@ -11,7 +11,7 @@ Preact X brings many new exciting features such as `Fragments`, `hooks` and much
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/en/guide/v10/web-components.md
+++ b/content/en/guide/v10/web-components.md
@@ -11,7 +11,7 @@ One thing to keep in mind is that Web Components don't replace Preact as they do
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/en/guide/v10/whats-new.md
+++ b/content/en/guide/v10/whats-new.md
@@ -11,7 +11,7 @@ In a nutshell Preact X is what we always wanted Preact to be: A tiny, fast and f
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/en/guide/v8/api-reference.md
+++ b/content/en/guide/v8/api-reference.md
@@ -8,7 +8,7 @@ permalink: '/guide/api-reference'
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/en/guide/v8/differences-to-react.md
+++ b/content/en/guide/v8/differences-to-react.md
@@ -11,7 +11,7 @@ The reason Preact does not attempt to include every single feature of React is i
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/en/guide/v8/forms.md
+++ b/content/en/guide/v8/forms.md
@@ -12,7 +12,7 @@ Forms in Preact work much the same as they do in React, except there is no suppo
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/en/guide/v8/getting-started.md
+++ b/content/en/guide/v8/getting-started.md
@@ -11,7 +11,7 @@ This guide walks through building a simple "ticking clock" component. More detai
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/en/guide/v8/linked-state.md
+++ b/content/en/guide/v8/linked-state.md
@@ -9,7 +9,7 @@ One area Preact takes a little further than React is in optimizing state changes
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/en/guide/v8/switching-to-preact.md
+++ b/content/en/guide/v8/switching-to-preact.md
@@ -12,7 +12,7 @@ There are two different approaches to switch from React to Preact:
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/en/guide/v8/types-of-components.md
+++ b/content/en/guide/v8/types-of-components.md
@@ -14,7 +14,7 @@ Within these two types, there are also a few different ways to implement compone
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/en/guide/v8/unit-testing-with-enzyme.md
+++ b/content/en/guide/v8/unit-testing-with-enzyme.md
@@ -23,7 +23,7 @@ Preact differs from Enzyme with React.
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/es/guide/v8/api-reference.md
+++ b/content/es/guide/v8/api-reference.md
@@ -7,7 +7,7 @@ permalink: '/guide/api-reference'
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/es/guide/v8/differences-to-react.md
+++ b/content/es/guide/v8/differences-to-react.md
@@ -11,7 +11,7 @@ La raz√≥n por la que Preact no intenta incluir absolutamente todas las caracter√
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/es/guide/v8/external-dom-mutations.md
+++ b/content/es/guide/v8/external-dom-mutations.md
@@ -9,7 +9,7 @@ A veces existe la necesidad de trabajar con librerías de terceros que esperan t
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/es/guide/v8/forms.md
+++ b/content/es/guide/v8/forms.md
@@ -11,7 +11,7 @@ Los Formularios en Preact funcionan de la misma manera que en React, excepto que
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/es/guide/v8/getting-started.md
+++ b/content/es/guide/v8/getting-started.md
@@ -16,7 +16,7 @@ Si recién está comenzando, le recomendamos ir con preact-cli.
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/es/guide/v8/linked-state.md
+++ b/content/es/guide/v8/linked-state.md
@@ -9,7 +9,7 @@ Hay un área de Preact que va un poco más allá que React a la hora de optimiza
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/es/guide/v8/switching-to-preact.md
+++ b/content/es/guide/v8/switching-to-preact.md
@@ -12,7 +12,7 @@ Hay dos formas distintas de moverse de React a Preact:
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/es/guide/v8/types-of-components.md
+++ b/content/es/guide/v8/types-of-components.md
@@ -14,7 +14,7 @@ Dentro de estos dos tipos, también hay diferentes maneras de implementar compon
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/es/guide/v8/unit-testing-with-enzyme.md
+++ b/content/es/guide/v8/unit-testing-with-enzyme.md
@@ -9,7 +9,7 @@ permalink: '/guide/unit-testing-with-enzyme'
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/fr/guide/v8/api-reference.md
+++ b/content/fr/guide/v8/api-reference.md
@@ -7,7 +7,7 @@ permalink: '/guide/api-reference'
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/fr/guide/v8/differences-to-react.md
+++ b/content/fr/guide/v8/differences-to-react.md
@@ -11,7 +11,7 @@ La raison pour laquelle Preact n'essaye pas d'inclure chaque fonctionnalité de 
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/fr/guide/v8/external-dom-mutations.md
+++ b/content/fr/guide/v8/external-dom-mutations.md
@@ -9,7 +9,7 @@ Parfois vous avez besoin de travailler avec des bibliothèques externes qui ont 
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/fr/guide/v8/forms.md
+++ b/content/fr/guide/v8/forms.md
@@ -11,7 +11,7 @@ Dans Preact, les formulaires fonctionnent globalement de la même façon que dan
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/fr/guide/v8/getting-started.md
+++ b/content/fr/guide/v8/getting-started.md
@@ -12,7 +12,7 @@ Dans ce guide, nous allons créer un simple composant d'horloge. Vous pouvez tro
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/fr/guide/v8/linked-state.md
+++ b/content/fr/guide/v8/linked-state.md
@@ -9,7 +9,7 @@ Un point sur lequel Preact va un peu plus loin que React est l'optimisation des 
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/fr/guide/v8/switching-to-preact.md
+++ b/content/fr/guide/v8/switching-to-preact.md
@@ -12,7 +12,7 @@ Il y a deux approches différentes pour passer de React à Preact :
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/fr/guide/v8/types-of-components.md
+++ b/content/fr/guide/v8/types-of-components.md
@@ -14,7 +14,7 @@ Entre ces deux types, il y a aussi plusieurs façons d'implémenter les composan
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/fr/guide/v8/unit-testing-with-enzyme.md
+++ b/content/fr/guide/v8/unit-testing-with-enzyme.md
@@ -9,7 +9,7 @@ React fournit un module `react-addons-test-utils` pour tester les composants, et
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/it/guide/v8/getting-started.md
+++ b/content/it/guide/v8/getting-started.md
@@ -11,7 +11,7 @@ In questa guida vedremo come creare un semplice componente "Orologio". Informazi
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/pt-br/guide/v10/api-reference.md
+++ b/content/pt-br/guide/v10/api-reference.md
@@ -9,7 +9,7 @@ Esta página serve como uma rápida visão geral de todas as funções exportada
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/pt-br/guide/v10/components.md
+++ b/content/pt-br/guide/v10/components.md
@@ -11,7 +11,7 @@ Existem dois tipos de componentes no Preact, sobre os quais falaremos neste guia
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/pt-br/guide/v10/context.md
+++ b/content/pt-br/guide/v10/context.md
@@ -11,7 +11,7 @@ Existem duas maneiras diferentes de usar o contexto: Através da API `createCont
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/pt-br/guide/v10/debugging.md
+++ b/content/pt-br/guide/v10/debugging.md
@@ -13,7 +13,7 @@ imprimiremos um aviso ou erro sempre que detectarmos algo errado, como aninhamen
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/pt-br/guide/v10/differences-to-react.md
+++ b/content/pt-br/guide/v10/differences-to-react.md
@@ -12,7 +12,7 @@ Preact não tenta incluir cada pequeno recurso do React em razão manter-se **pe
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/pt-br/guide/v10/external-dom-mutations.md
+++ b/content/pt-br/guide/v10/external-dom-mutations.md
@@ -8,7 +8,7 @@ description: 'Como integrar o Preact ao jQuery e outros snippets JavaScript que 
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/pt-br/guide/v10/forms.md
+++ b/content/pt-br/guide/v10/forms.md
@@ -11,7 +11,7 @@ A principal diferença é que, na maioria dos casos, o `valor 'não é controlad
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/pt-br/guide/v10/getting-started.md
+++ b/content/pt-br/guide/v10/getting-started.md
@@ -11,7 +11,7 @@ Se você está apenas começando, é altamente recomendável usar o [preact-cli]
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/pt-br/guide/v10/hooks.md
+++ b/content/pt-br/guide/v10/hooks.md
@@ -16,7 +16,7 @@ Existem duas maneiras de importá-las, você pode importá-las de
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/pt-br/guide/v10/refs.md
+++ b/content/pt-br/guide/v10/refs.md
@@ -11,7 +11,7 @@ Um caso de uso típico para medir o tamanho real de um nó DOM. Embora seja poss
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/pt-br/guide/v10/server-side-rendering.md
+++ b/content/pt-br/guide/v10/server-side-rendering.md
@@ -10,7 +10,7 @@ A renderização no servidor (geralmente abreviada como "SSR") permite renderiza
 > Nota: O SSR é ativado automaticamente com `preact-cli`: tada:
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/pt-br/guide/v10/switching-to-preact.md
+++ b/content/pt-br/guide/v10/switching-to-preact.md
@@ -12,7 +12,7 @@ Isso permite que você continue escrevendo o código React / ReactDOM sem nenhum
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/pt-br/guide/v10/tutorial.md
+++ b/content/pt-br/guide/v10/tutorial.md
@@ -11,7 +11,7 @@ Este guia mostra a construção de um simples componente "relógio". Informaçõ
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/pt-br/guide/v10/unit-testing-with-enzyme.md
+++ b/content/pt-br/guide/v10/unit-testing-with-enzyme.md
@@ -23,7 +23,7 @@ O Preact difere da Enzyme com o React.
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/pt-br/guide/v10/upgrade-guide.md
+++ b/content/pt-br/guide/v10/upgrade-guide.md
@@ -11,7 +11,7 @@ O Preact X traz muitos novos recursos interessantes, como `Fragments`,` hooks 'e
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/pt-br/guide/v10/web-components.md
+++ b/content/pt-br/guide/v10/web-components.md
@@ -11,7 +11,7 @@ Uma coisa a ter em mente é que os Web Components não substituem o Preact, pois
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/pt-br/guide/v10/whats-new.md
+++ b/content/pt-br/guide/v10/whats-new.md
@@ -11,7 +11,7 @@ Em poucas palavras, o Preact X é o que sempre quisemos que fosse: Uma bibliotec
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/pt-br/guide/v8/api-reference.md
+++ b/content/pt-br/guide/v8/api-reference.md
@@ -7,7 +7,7 @@ permalink: '/guide/api-reference'
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/pt-br/guide/v8/differences-to-react.md
+++ b/content/pt-br/guide/v8/differences-to-react.md
@@ -11,7 +11,7 @@ Preact não tenta incluir cada pequeno recurso do React em razão manter-se **pe
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/pt-br/guide/v8/external-dom-mutations.md
+++ b/content/pt-br/guide/v8/external-dom-mutations.md
@@ -7,7 +7,7 @@ permalink: '/guide/external-dom-mutations'
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/pt-br/guide/v8/forms.md
+++ b/content/pt-br/guide/v8/forms.md
@@ -11,7 +11,7 @@ Formul√°rios no Preact funcionam de forma muito parecida ao React, exceto por n√
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/pt-br/guide/v8/getting-started.md
+++ b/content/pt-br/guide/v8/getting-started.md
@@ -12,7 +12,7 @@ Esse guia assume que você tem algum tipo de build ES2015 configurado utilizando
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/pt-br/guide/v8/linked-state.md
+++ b/content/pt-br/guide/v8/linked-state.md
@@ -9,7 +9,7 @@ Uma área que o Preact leva um pouco mais além do que o React é na otimizaçã
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/pt-br/guide/v8/switching-to-preact.md
+++ b/content/pt-br/guide/v8/switching-to-preact.md
@@ -12,7 +12,7 @@ Há duas abordagens diferentes para mudar do React pro Preact:
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/pt-br/guide/v8/types-of-components.md
+++ b/content/pt-br/guide/v8/types-of-components.md
@@ -14,7 +14,7 @@ Dentro desses dois tipos, há também algumas maneiras diversas de implementar-s
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/pt-br/guide/v8/unit-testing-with-enzyme.md
+++ b/content/pt-br/guide/v8/unit-testing-with-enzyme.md
@@ -9,7 +9,7 @@ O `React` fornece um módulo `reag-addons-test-utils` para testar componentes, e
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/tr/guide/v8/api-reference.md
+++ b/content/tr/guide/v8/api-reference.md
@@ -7,7 +7,7 @@ permalink: '/guide/api-reference'
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/tr/guide/v8/differences-to-react.md
+++ b/content/tr/guide/v8/differences-to-react.md
@@ -11,7 +11,7 @@ Preact’ın React’ın her bir özelliğini içermemesinin nedeni, **küçük*
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/tr/guide/v8/external-dom-mutations.md
+++ b/content/tr/guide/v8/external-dom-mutations.md
@@ -9,7 +9,7 @@ Sometimes there is a need to work with third-party libraries that expect to be a
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/tr/guide/v8/forms.md
+++ b/content/tr/guide/v8/forms.md
@@ -10,7 +10,7 @@ Preact'deki formlar React'deki ile aynı işi yaparlar, fakat "static" (başlang
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/tr/guide/v8/getting-started.md
+++ b/content/tr/guide/v8/getting-started.md
@@ -11,7 +11,7 @@ This guide walks through building a simple "ticking clock" component. More detai
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/tr/guide/v8/linked-state.md
+++ b/content/tr/guide/v8/linked-state.md
@@ -9,7 +9,7 @@ State değişikliklerini optimize etmede, React’tan biraz daha kolaylık sağl
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/tr/guide/v8/switching-to-preact.md
+++ b/content/tr/guide/v8/switching-to-preact.md
@@ -12,7 +12,7 @@ Preact'tan React'a geçişte iki türlü yaklaşım vardır:
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/tr/guide/v8/types-of-components.md
+++ b/content/tr/guide/v8/types-of-components.md
@@ -14,7 +14,7 @@ Bu iki tür bileşeni uygulamak için birkaç farklı yöntem vardır.
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/tr/guide/v8/unit-testing-with-enzyme.md
+++ b/content/tr/guide/v8/unit-testing-with-enzyme.md
@@ -10,7 +10,7 @@ Preact bileşenlerini `enzyme` kullanarak test etmek, `preact-compat`'ın üzeri
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/zh/guide/v8/api-reference.md
+++ b/content/zh/guide/v8/api-reference.md
@@ -7,7 +7,7 @@ permalink: '/guide/api-reference'
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/zh/guide/v8/differences-to-react.md
+++ b/content/zh/guide/v8/differences-to-react.md
@@ -11,7 +11,7 @@ Preact 没尝试去包括 React 的每一个特性，是因为它想保持 **轻
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/zh/guide/v8/external-dom-mutations.md
+++ b/content/zh/guide/v8/external-dom-mutations.md
@@ -7,7 +7,7 @@ permalink: '/guide/external-dom-mutations'
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/zh/guide/v8/forms.md
+++ b/content/zh/guide/v8/forms.md
@@ -10,7 +10,7 @@ permalink: '/guide/forms'
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/zh/guide/v8/getting-started.md
+++ b/content/zh/guide/v8/getting-started.md
@@ -11,7 +11,7 @@ permalink: '/guide/getting-started'
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/zh/guide/v8/linked-state.md
+++ b/content/zh/guide/v8/linked-state.md
@@ -9,7 +9,7 @@ permalink: '/guide/linked-state'
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/zh/guide/v8/switching-to-preact.md
+++ b/content/zh/guide/v8/switching-to-preact.md
@@ -12,7 +12,7 @@ permalink: '/guide/switching-to-preact'
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/zh/guide/v8/types-of-components.md
+++ b/content/zh/guide/v8/types-of-components.md
@@ -14,7 +14,7 @@ Preact 中有两种组件：
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 

--- a/content/zh/guide/v8/unit-testing-with-enzyme.md
+++ b/content/zh/guide/v8/unit-testing-with-enzyme.md
@@ -9,7 +9,7 @@ React提供了`react-addons-test-utils`来测试组件，而Airbnb开发的`enzy
 
 ---
 
-<toc></toc>
+<div><toc></toc></div>
 
 ---
 


### PR DESCRIPTION
`marked` treats our web-components as inline blocks and will wrap them with a `<p>`-element, leading to invalid HTML. Wrapping the offending WCs with a `<div>` opts out of that behavior in `marked`'s parser.