### PR TITLE
Fix instructions to start dev server

### DIFF
--- a/content/en/cli/getting-started.md
+++ b/content/en/cli/getting-started.md
@@ -46,7 +46,7 @@ Now that your project is set up, you can `cd` into the newly-created directory a
 
 ```sh
 cd <app-name>
-npm start
+npm run dev
 ```
 
 Now open your editor and start editing! For most templates, the best place to start is `src/index.js` or `src/components/app/index.js`.

--- a/content/es/cli/getting-started.md
+++ b/content/es/cli/getting-started.md
@@ -46,7 +46,7 @@ Ahora que el proyecto está creado y configurado, hacer `cd` al directorio cread
 
 ```sh
 cd <app-name>
-npm start
+npm run dev
 ```
 
 Ahora abra su editor y comience a escribir. Para la mayoría de las plantillas, el mejor lugar para comenzar es `src/index.js` o `src/components/app/index.js`.

--- a/content/pt-br/cli/getting-started.md
+++ b/content/pt-br/cli/getting-started.md
@@ -46,7 +46,7 @@ Agora que seu projeto está configurado, você pode `cd` no diretório recém-cr
 
 ```sh
 cd <app-name>
-npm start
+npm run dev
 ```
 
 Agora abra seu editor e comece a editar! Para a maioria dos modelos, o melhor lugar para começar é `src/index.js` ou `src/components/app/index.js`.


### PR DESCRIPTION
The existing instruction to run the `start` script does not work as no
such script exists in "package.json".