### PR TITLE
Updating pt-br  and en version of getting started

### DIFF
--- a/content/en/guide/v10/getting-started.md
+++ b/content/en/guide/v10/getting-started.md
@@ -88,7 +88,7 @@ Now we're ready to start our application. To start a development server, run the
 cd my-project
 
 # Start a development server
-npm start
+npm run dev
 ```
 
 Once the server has started, it will print a local development URL to open in your browser.

--- a/content/pt-br/guide/v10/getting-started.md
+++ b/content/pt-br/guide/v10/getting-started.md
@@ -81,7 +81,7 @@ Agora estamos prontos para iniciar nosso aplicativo. Para iniciar o servidor de 
 cd my-project/
 
 # iniciar o servidor em dev
-npm start
+npm run dev
 ```
 
 Depois que o servidor estiver ativo, você poderá acessar seu aplicativo no URL que foi impresso no console. Agora você está pronto para desenvolver seu aplicativo!


### PR DESCRIPTION
Minor change in the CLI documentation : 'npm start' should be replaced by 'npm run dev' 