### PR TITLE
fix link to #usecontext hook

### DIFF
--- a/content/en/guide/v10/context.md
+++ b/content/en/guide/v10/context.md
@@ -43,7 +43,7 @@ function App() {
 }
 ```
 
-> An easier way to use context is via the [useContext](/guide/v10/hooks#context) hook.
+> An easier way to use context is via the [useContext](/guide/v10/hooks#usecontext) hook.
 
 ## Legacy Context API
 

--- a/content/pt-br/guide/v10/context.md
+++ b/content/pt-br/guide/v10/context.md
@@ -43,7 +43,7 @@ function App() {
 }
 ```
 
-> Uma maneira mais fácil de usar o contexto é através do [useContext](/guide/v10/hooks#context) hook.
+> Uma maneira mais fácil de usar o contexto é através do [useContext](/guide/v10/hooks#usecontext) hook.
 
 ## Legacy Context API
 


### PR DESCRIPTION
The link to the useContext hook currently is set to `#context`, but should be `#usecontext`.

I also noticed that routing does not handle anchors correctly, i.e. the link `https://preactjs.com/guide/v10/hooks#usecontext` works when the page is initially loaded, but does not jump to the anchor after client side navigation happened (tested in Chrome and Firefox). Do you want me to create a ticket for that?