### PR TITLE
Add Capacitor to the add-ons

### DIFF
--- a/content/en/about/libraries-addons.md
+++ b/content/en/about/libraries-addons.md
@@ -36,6 +36,7 @@ A collection of modules built to work wonderfully with Preact.
 - :thought_balloon: [**preact-socrates**](https://github.com/matthewmueller/preact-socrates): Preact plugin for [Socrates](http://github.com/matthewmueller/socrates)
 - :rowboat: [**preact-flyd**](https://github.com/xialvjun/preact-flyd): Use [flyd](https://github.com/paldepind/flyd) FRP streams in Preact + JSX
 - :speech_balloon: [**preact-i18nline**](https://github.com/download/preact-i18nline): Integrates the ecosystem around [i18n-js](https://github.com/everydayhero/i18n-js) with Preact via [i18nline](https://github.com/download/i18nline).
+- :diamond_shape_with_a_dot_inside: [**Capacitor**](https://capacitorjs.com/solution/preact): Turn your Preact app into a Native iOS/Android App and PWA.
 
 ## GUI Toolkits
 


### PR DESCRIPTION
👋 Hello there! This includes a link to CapacitorJS in the Libraries and Add-ons. 

Capacitor is a tool that can let developers take their preact app and create native ios and native android apps, without having to change anything to their code. 

We have a dedicated example page in our docs that covers how to enabled this in a preact app, but figured it would make sense to include this in preacts docs as well. 

Cheers 🍻 