### PR TITLE
add Kretes to the Integrations section

### DIFF
--- a/content/en/about/libraries-addons.md
+++ b/content/en/about/libraries-addons.md
@@ -37,6 +37,7 @@ A collection of modules built to work wonderfully with Preact.
 - :rowboat: [**preact-flyd**](https://github.com/xialvjun/preact-flyd): Use [flyd](https://github.com/paldepind/flyd) FRP streams in Preact + JSX
 - :speech_balloon: [**preact-i18nline**](https://github.com/download/preact-i18nline): Integrates the ecosystem around [i18n-js](https://github.com/everydayhero/i18n-js) with Preact via [i18nline](https://github.com/download/i18nline).
 - :diamond_shape_with_a_dot_inside: [**Capacitor**](https://capacitorjs.com/solution/preact): Turn your Preact app into a Native iOS/Android App and PWA.
+- :ice_cube: [**Kretes**](https://kretes.dev/docs/howtos/preact-setup/): Build full-stack TypeScript apps using Preact and Node.js
 
 ## GUI Toolkits
 


### PR DESCRIPTION
Hello, [Kretes](https://kretes.dev) is programming environment for building full-stack applications in TypeScript. The tool is inspired by Self/Smalltalk and built on top of VS Code.

The link shows how to use Preact in Kretes and also how to connect the UI layer with a REST endpoint (Node.js). The general idea is to show how to build a full-stack app in TypeScript using Preact.
