### PR TITLE
Fix bug in v10 upgrade guide example.

### DIFF
--- a/content/en/guide/v10/upgrade-guide.md
+++ b/content/en/guide/v10/upgrade-guide.md
@@ -188,12 +188,12 @@ In Preact X the state of a component will no longer be mutated synchronously. Th
 this.state = { counter: 0 };
 
 // Preact 8.x
-this.setState({ counter: this.state.counter++ });
+this.setState({ counter: ++this.state.counter });
 
 // Preact X
 this.setState(prevState => {
   // Alternatively return `null` here to abort the state update
-  return { counter: prevState.counter++ };
+  return { counter: ++prevState.counter };
 });
 ```
 

--- a/content/en/guide/v10/upgrade-guide.md
+++ b/content/en/guide/v10/upgrade-guide.md
@@ -188,12 +188,12 @@ In Preact X the state of a component will no longer be mutated synchronously. Th
 this.state = { counter: 0 };
 
 // Preact 8.x
-this.setState({ counter: ++this.state.counter });
+this.setState({ counter: this.state.counter + 1 });
 
 // Preact X
 this.setState(prevState => {
   // Alternatively return `null` here to abort the state update
-  return { counter: ++prevState.counter };
+  return { counter: prevState.counter + 1 };
 });
 ```
 


### PR DESCRIPTION
Moved the ++ to the front of counter variables.