### PR TITLE
Update lint error styles

### DIFF
--- a/src/components/code-editor/style.less
+++ b/src/components/code-editor/style.less
@@ -4,7 +4,7 @@
 
 	.lintError {
 		box-sizing: border-box;
-		background: #d86c74;
+		background: #c94b55;
 		color: #fff;
 		text-shadow: 0 0 1px rgba(0, 0, 0, 0.5);
 		padding: 0 2px 0.6rem;
@@ -14,8 +14,13 @@
 		line-height: 1.4;
 		animation: intro 150ms ease forwards 1;
 		transform-origin: 0 0;
+
 		pre {
 			margin: -1px 0 0.2rem;
+		}
+
+		div {
+			padding: 0 12px;
 		}
 
 		@keyframes intro {
@@ -141,8 +146,7 @@
 			}
 
 			.cm-error {
-				background: #f92672;
-				color: red;
+				border-bottom: 2px solid #c94b55;
 			}
 
 			.CodeMirror-activeline-background {


### PR DESCRIPTION
## Updated
- Lint error message box background color for better contrast ratio and added padding.
- Code error highlighting to underline instead of background color for better legibility.

![image](https://user-images.githubusercontent.com/21107799/91631263-fb43b800-e9f5-11ea-9c90-14c5a1824af5.png)

Fixes #528 