### PR TITLE
Fix typos

### DIFF
--- a/content/en/guide/v10/api-reference.md
+++ b/content/en/guide/v10/api-reference.md
@@ -123,7 +123,7 @@ hydrate(<Foo />, document.getElementById('container'));
 
 `h(type, props, ...children)`
 
-Returns a Virtual DOM Element with the given `props`. Virtual DOM Elements are lightweight descriptions of a node in your application's UI heirarchy, essentially an object of the form `{ type, props }`.
+Returns a Virtual DOM Element with the given `props`. Virtual DOM Elements are lightweight descriptions of a node in your application's UI hierarchy, essentially an object of the form `{ type, props }`.
 
 After `type` and `props`, any remaining parameters are collected into a `children` Array.
 Children may be any of the following:

--- a/content/en/guide/v10/options.md
+++ b/content/en/guide/v10/options.md
@@ -7,7 +7,7 @@ description: 'Preact has several option hooks that allow you to attach callbacks
 
 Callbacks for plugins that can change Preact's rendering.
 
-Preact supports a number of different callbacks that can be used to observe or change each stage of the renderering process, commonly referred to as "Option Hooks" (not to be confused with [hooks](https://preactjs.com/guide/v10/hooks)). These are frequently used to extend the featureset of Preact itself, or to create specialized testing tools. All of our addons like `preact/hooks`, `preact/compat` and our devtools extension are based on these callbacks.
+Preact supports a number of different callbacks that can be used to observe or change each stage of the rendering process, commonly referred to as "Option Hooks" (not to be confused with [hooks](https://preactjs.com/guide/v10/hooks)). These are frequently used to extend the feature-set of Preact itself, or to create specialized testing tools. All of our addons like `preact/hooks`, `preact/compat` and our devtools extension are based on these callbacks.
 
 This API is primarily intended for tooling or library authors who wish to extend Preact.
 

--- a/content/en/guide/v10/switching-to-preact.md
+++ b/content/en/guide/v10/switching-to-preact.md
@@ -22,7 +22,7 @@ To set up `preact/compat` you need to alias `react` and `react-dom` to `preact/c
 
 ## PureComponent
 
-The `PureComponent` class works similarily to `Component`. The difference is that `PureComponent` will skip rendering when the new props are equal to the old ones. To do this we compare the old and new props via a shallow comparison where we check each props property for referential equality. This can speed up applications a lot by avoiding unnecessary re-renders. It works by adding a default `shouldComponentUpdate` lifecycle hook.
+The `PureComponent` class works similar to `Component`. The difference is that `PureComponent` will skip rendering when the new props are equal to the old ones. To do this we compare the old and new props via a shallow comparison where we check each props property for referential equality. This can speed up applications a lot by avoiding unnecessary re-renders. It works by adding a default `shouldComponentUpdate` lifecycle hook.
 
 ```jsx
 import { render } from 'preact';


### PR DESCRIPTION
I had noticed typos in some parts of the documentation. This PR fixes the following typos:
- `heirarchy` to `hierarchy` in `h() / createElement()` section.
- `renderering` to `rendering` in `Renderer Options` intro.
- `similarily` to `similar` in `PureComponent` section.