### PR TITLE
cursor change from text select to default

### DIFF
--- a/src/components/jumbotron/style.less
+++ b/src/components/jumbotron/style.less
@@ -12,6 +12,7 @@
 	h1 {
 		color: #fff;
 		text-transform: uppercase;
+		pointer-events: none;
 
 		@media @sidebar-break {
 			padding: 1.5rem 0 0 0 !important;


### PR DESCRIPTION
main title seems to have a text selectable cursor, yet nothing can be selected.
this PR removes pointer events to avoid confusion