### PR TITLE
Renderer Options -> Option Hooks

### DIFF
--- a/content/en/guide/v10/options.md
+++ b/content/en/guide/v10/options.md
@@ -1,9 +1,9 @@
 ---
-name: Options
+name: Option Hooks
 description: 'Preact has several option hooks that allow you to attach callbacks to various stages of the diffing process.'
 ---
 
-# Renderer Options
+# Option Hooks
 
 Callbacks for plugins that can change Preact's rendering.
 

--- a/src/config.json
+++ b/src/config.json
@@ -408,7 +408,7 @@
 				{
 					"path": "/guide/v10/options",
 					"name": {
-						"en": "Options",
+						"en": "Option Hooks",
 						"de": "Optionen"
 					}
 				}


### PR DESCRIPTION
There are `Options`, `Option Hooks` and `Renderer Options`. 
IMHO, I think it is better to be unified into `Option Hooks`.