### PR TITLE
Fix 'Run in REPL' not fixed while scrolling

### DIFF
--- a/src/components/code-block/index.js
+++ b/src/components/code-block/index.js
@@ -73,14 +73,16 @@ function HighlightedCodeBlock({ code, lang, ...props }) {
 	const htmlObj = useMemo(() => ({ __html: html }), [html]);
 
 	return (
-		<pre class={cx('highlight', props.class)}>
-			<code class={`language-${lang}`} dangerouslySetInnerHTML={htmlObj} />
+		<div class={cx('highlight-container', props.class)}>
+			<pre class="highlight">
+				<code class={`language-${lang}`} dangerouslySetInnerHTML={htmlObj} />
+			</pre>
 			{repl && (
 				<Link class="repl-link" href={`/repl?code=${encodeURIComponent(code)}`}>
 					Run in REPL
 				</Link>
 			)}
-		</pre>
+		</div>
 	);
 }
 

--- a/src/components/jumbotron/style.less
+++ b/src/components/jumbotron/style.less
@@ -25,7 +25,7 @@
 		}
 	}
 
-	+ :global(pre.highlight) {
+	+ :global(div.highlight-container) {
 		margin-left: 1rem;
 		margin-right: 1rem;
 		box-shadow: 0 5px 25px rgba(0, 0, 0, 0.5);

--- a/src/style/index.less
+++ b/src/style/index.less
@@ -52,14 +52,20 @@ code {
 	font-size: 0.9rem;
 }
 
-pre.highlight {
+div.highlight-container {
+	padding: 0 !important;
 	position: relative;
-	border: none;
 	margin-bottom: 2.5rem;
-	line-height: 1.5;
-	padding: 20px;
+
+	pre.highlight {
+		position: relative;
+		border: none;
+		line-height: 1.5;
+		padding: 20px;
+	}
 
 	a.repl-link {
+		font-size: 13px;
 		position: absolute;
 		right: 0;
 		top: 0;


### PR DESCRIPTION
## Original Issue

In the code blocks, the `Run in Repl` button did not stay fixed in top right corner while horizontally scrolling. This is especially more noticeable on mobile devices.

<img src="https://user-images.githubusercontent.com/21107799/94808447-c967ac00-040e-11eb-8a97-4fd2ca2db489.png" width="400">


### Changes in this fix
A container `<div>` was added to the code block with some style refactoring to keep the `Run in REPL` button fixed at the top right corner even while horizontally scrolling. From my tests, it is not breaking other code blocks (I may be wrong though)

<img src="https://user-images.githubusercontent.com/21107799/94808787-44c95d80-040f-11eb-96a7-3eff1d343308.png" width="500">


Fixes #530 
