### PR TITLE
Add padding top to active link targets (headlines)

### DIFF
--- a/src/style/markdown.less
+++ b/src/style/markdown.less
@@ -373,6 +373,15 @@
 		vertical-align: super;
 		line-height: 0;
 	}
+
+	h1,
+	h2,
+	h3 {
+		&:target {
+			padding-top: @header-height;
+		}
+	}
+
 	* {
 		-webkit-print-color-adjust: exact;
 	}


### PR DESCRIPTION
When navigating to page sections, the selected headline is hidden by the header bar.
This PR adds a `:target` selector with some extra padding on top to keep them visible.

Example: **useState** https://preactjs.com/guide/v10/hooks/#usestate

without `:target` padding

<img src="https://user-images.githubusercontent.com/3640237/94906651-24e17a80-049f-11eb-8831-03246bfe0c1c.png" width="300">

with `:target` padding

<img src="https://user-images.githubusercontent.com/3640237/94906631-1b581280-049f-11eb-81ee-3182cb1595f4.png" width="300">