### PR TITLE
Fix example in content/en/guide/v10/typescript.md

### DIFF
--- a/content/en/guide/v10/typescript.md
+++ b/content/en/guide/v10/typescript.md
@@ -146,8 +146,8 @@ type ExpandableState = {
 
 // Bind generics to ExpandableProps and ExpandableState
 class Expandable extends Component<ExpandableProps, ExpandableState> {
-  constructor() {
-    super();
+  constructor(props: ExpandableProps) {
+    super(props);
     // this.state is an object with a boolean field `toggle`
     // due to ExpandableState
     this.state = {


### PR DESCRIPTION
I think it is necessary to pass `props` to `super()` in constructor of `Component` class.