### PR TITLE
Adds config to use preact/compat with Snowpack

### DIFF
--- a/content/en/guide/v10/getting-started.md
+++ b/content/en/guide/v10/getting-started.md
@@ -208,6 +208,20 @@ These rewrites are configured using regular expressions in your Jest configurati
 }
 ```
 
+#### Aliasing in Snowpack
+
+To alias in [Snowpack](https://www.snowpack.dev/), you'll need to add a package import alias to the `snowpack.config.json` file.
+
+```js
+// snowpack.config.json
+{
+  alias: {
+    "react": "preact/compat",
+    "react-dom": "preact/compat"
+  }
+}
+```
+
 [htm]: https://github.com/developit/htm
 [Preact CLI]: https://github.com/preactjs/preact-cli
 


### PR DESCRIPTION
Snowpack defines its own specific aliasing system which must be configued to use with preact/compat.