### PR TITLE
Update the current release version in header.

### DIFF
--- a/src/components/header/gh-version.js
+++ b/src/components/header/gh-version.js
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'preact/hooks';
 import { fetchRelease } from '../../lib/github';
 import config from '../../config.json';
 
-const VERSION = '10.0.4';
+const VERSION = '10.5.7';
 const URL = `https://github.com/preactjs/preact/releases/tag/${VERSION}`;
 
 export default function ReleaseLink(props) {


### PR DESCRIPTION
I opened the site in my browser today and got confused when I saw a version number from last year in the header, turns out I had JS turned off.