### PR TITLE
Add a note to use DblClick when not using compat

### DIFF
--- a/content/en/guide/v10/differences-to-react.md
+++ b/content/en/guide/v10/differences-to-react.md
@@ -27,6 +27,7 @@ We've come across the following differences between React's synthetic event syst
 - Events don't bubble through `<Portal>` components
 - The clear "x" button for `<input type="search">` does not fire an `input` event in IE11 - use `onSearch` instead.
 - Use `onInput` instead `onChange` for `<input>` elements (**only if `preact/compat` is not used**)
+- Use `onDblClick` instead of `onDoubleClick` (**only if `preact/compat` is not used**)
 
 The other main difference is that Preact follows the DOM specification more closely. An example of this is the ability to use `class` instead of `className`.
 


### PR DESCRIPTION
Just putting this little gotcha out somewhere obvious, as this [Synthetic Event](https://reactjs.org/docs/events.html#mouse-events) sent me down a little rabbit hole today.
Interestingly, `onDoubleClick` _works_ on Safari 14 (but obviously not Chrome).

Using the [Native Event Handler](https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/ondblclick) seems like the most sensible  cross-browser solution.