### PR TITLE
Fixed typos in web components example

### DIFF
--- a/content/en/guide/v10/web-components.md
+++ b/content/en/guide/v10/web-components.md
@@ -175,14 +175,14 @@ function TextSection({ heading, content }) {
 	);
 }
 
-registerElement(Foo, 'text-section', [], { shadow: true });
+register(TextSection, 'text-section', [], { shadow: true });
 ```
 
 Usage:
 
 ```html
 <text-section>
-  <slot name="heading">Nice heading</slot>
-  <slot name="content">Great content</slot>
+  <span slot="heading">Nice heading</slot>
+  <span slot="content">Great content</slot>
 </text-section>
 ```


### PR DESCRIPTION
Fixed typos
```
registerElement -> register
Foo -> TextSection
<slot name=""> -> <span slot="">
```