### PR TITLE
fix: Sidebar z-index

### DIFF
--- a/src/components/controllers/page/sidebar.less
+++ b/src/components/controllers/page/sidebar.less
@@ -66,7 +66,7 @@
 	bottom: 0;
 	left: 0;
 	right: 0;
-	z-index: 550;
+	z-index: 450;
 	height: 100%;
 	overflow-y: auto;
 	background: var(--color-sidebar-bg);


### PR DESCRIPTION
Currently the header gets slightly stuck behind the side bar. Go to https://preactjs.com/guide/v10/getting-started/ and then scroll down a bit. You won't be able to click on the PreactJS logo to go back to the home page as it's technically layered behind the side bar.

To fix this, I just took a chunk out of the side bar's z-index. This doesn't seem to conflict with anything and is probably the simplest solution. The [header's z-index is 500](https://github.com/preactjs/preact-www/blob/master/src/components/header/style.less#L11) so this will now be below it, as intended.