### PR TITLE
Fixed typo in web-components slot example

### DIFF
--- a/content/en/guide/v10/web-components.md
+++ b/content/en/guide/v10/web-components.md
@@ -182,7 +182,7 @@ Usage:
 
 ```html
 <text-section>
-  <span slot="heading">Nice heading</slot>
-  <span slot="content">Great content</slot>
+  <span slot="heading">Nice heading</span>
+  <span slot="content">Great content</span>
 </text-section>
 ```


### PR DESCRIPTION
Replace closing `</slot>` tag with `</span>`