### PR TITLE
Fixes minor grammar error on Differences to React page

### DIFF
--- a/content/en/guide/v10/differences-to-react.md
+++ b/content/en/guide/v10/differences-to-react.md
@@ -24,10 +24,10 @@ For us it doesn't make sense as the browser's event system supports all features
 
 We've come across the following differences between React's synthetic event system and native browser events:
 
-- Events don't bubble through `<Portal>` components
+- Events don't bubble through `<Portal>` components.
 - The clear "x" button for `<input type="search">` does not fire an `input` event in IE11 - use `onSearch` instead.
-- Use `onInput` instead `onChange` for `<input>` elements (**only if `preact/compat` is not used**)
-- Use `onDblClick` instead of `onDoubleClick` (**only if `preact/compat` is not used**)
+- Use `onInput` instead of `onChange` for `<input>` elements (**only if `preact/compat` is not used**).
+- Use `onDblClick` instead of `onDoubleClick` (**only if `preact/compat` is not used**).
 
 The other main difference is that Preact follows the DOM specification more closely. An example of this is the ability to use `class` instead of `className`.
 


### PR DESCRIPTION
Hey team! I was reading the docs and saw a small grammar issue. I've corrected it for you now. Hope that helps!

Before:
```
Use `onInput` instead `onChange`
```

After:
```
Use `onInput` instead of `onChange`
```