### PR TITLE
fixes Slack README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Preact Documentation Website
 
 [![Build Status](https://travis-ci.org/preactjs/preact-www.svg?branch=master)](https://travis-ci.org/preactjs/preact-www)
-[![Preact Slack Community](https://preact-slack.now.sh/badge.svg)](https://chat.preactjs.com/)
+[![Preact Slack Community](https://img.shields.io/badge/slack-Preact%20Slack%20Community-blue?logo=slack)](https://chat.preactjs.com/)
 
 Built with [preact-cli](https://github.com/preactjs/preact-cli)
 


### PR DESCRIPTION
I've added a static Slack badge to the README since the current badge is broken. Shields.io allows you to customize the label, message, color, and logo using their badge generator, so this is just one option to consider.

<img width="417" alt="Screen Shot 2021-04-15 at 9 29 08 PM" src="https://user-images.githubusercontent.com/13806458/114967582-f40cd580-9e31-11eb-844d-e397eb4afdc7.png">

Badge url: https://img.shields.io/badge/slack-Preact%20Slack%20Community-blue?logo=slack

Badge generator: https://shields.io/

Fixes https://github.com/preactjs/preact-www/issues/725