### PR TITLE
Fix typos in web components example (ja)

### DIFF
--- a/content/ja/guide/v10/web-components.md
+++ b/content/ja/guide/v10/web-components.md
@@ -193,14 +193,14 @@ function TextSection({ heading, content }) {
 	);
 }
 
-registerElement(Foo, 'text-section', [], { shadow: true });
+register(TextSection, 'text-section', [], { shadow: true });
 ```
 
 使い方:
 
 ```html
 <text-section>
-  <slot name="heading">Nice heading</slot>
-  <slot name="content">Great content</slot>
+  <span slot="heading">Nice heading</span>
+  <span slot="content">Great content</span>
 </text-section>
 ```


### PR DESCRIPTION
Reflect PRs bellow in ja documents
https://github.com/preactjs/preact-www/pull/736
https://github.com/preactjs/preact-www/pull/751

```
registerElement -> register
Foo -> TextSection
<slot name=""> -> <span slot="">
```