### PR TITLE
Remove global install instructions

### DIFF
--- a/content/en/guide/v10/getting-started.md
+++ b/content/en/guide/v10/getting-started.md
@@ -84,7 +84,7 @@ This will create a new application based on our [default template](https://githu
 
 > **Tip:** Any GitHub repository with a `template/` folder can be used as a custom template:
 >
-> `npx preact create <username>/<repository> <project-name>`
+> `npx preact-cli create <username>/<repository> <project-name>`
 
 ### Getting ready for development
 

--- a/content/en/guide/v10/getting-started.md
+++ b/content/en/guide/v10/getting-started.md
@@ -68,23 +68,23 @@ For more information on HTM, check out its [documentation][htm].
 
 [Preact CLI] is an off-the-shelf solution for building Preact applications that is optimized for modern web development. It's built on standard tooling projects like Webpack, Babel and PostCSS. Preact CLI does not require any configuration or prior knowledge to get started, and this simplicity makes it the most popular way to use Preact.
 
-As the name implies, Preact CLI is a **c**ommand-**li**ne tool that can be run in the terminal on your machine. Install it globally by running:
+As the name implies, Preact CLI is a **c**ommand-**li**ne tool that can be run in the terminal on your machine. It can be added to your current project by running:
 
 ```bash
-npm install -g preact-cli
+npm install --save-dev preact-cli
 ```
 
-After that, you'll have a new command in your terminal called `preact`. Using it, you can create a new application by running the `preact create` command:
+After that, you'll have a new command in your project called `preact`. Using it, you can create a new application by running the `preact create` command:
 
 ```bash
-preact create default my-project
+npx preact create default my-project
 ```
 
 This will create a new application based on our [default template](https://github.com/preactjs-templates/default). You will be asked for some information about your project, which will then be generated in the directory you specified (`my-project` in this case).
 
 > **Tip:** Any GitHub repository with a `template/` folder can be used as a custom template:
 >
-> `preact create <username>/<repository> <project-name>`
+> `npx preact create <username>/<repository> <project-name>`
 
 ### Getting ready for development
 

--- a/content/en/guide/v10/getting-started.md
+++ b/content/en/guide/v10/getting-started.md
@@ -77,7 +77,7 @@ npm install --save-dev preact-cli
 After that, you'll have a new command in your project called `preact`. Using it, you can create a new application by running the `preact create` command:
 
 ```bash
-npx preact create default my-project
+npx preact-cli create default my-project
 ```
 
 This will create a new application based on our [default template](https://github.com/preactjs-templates/default). You will be asked for some information about your project, which will then be generated in the directory you specified (`my-project` in this case).


### PR DESCRIPTION
Globally installing packages is not necessary at all and can lead to weird permission issues depending on where the global install directory is. This is a friction point for new users (we just got a report on slack). So this PR rewrites that to point to the local installation instead.