### PR TITLE
fix: Correcting incorrect table of contents link generation

### DIFF
--- a/src/lib/content.js
+++ b/src/lib/content.js
@@ -158,8 +158,8 @@ function generateToc(markdown) {
 		// Note: character range in regex is roughly "word characters including accented" (eg: bublé)
 		const id = text
 			.toLowerCase()
-			.replace(/[\s-!()<>`'"&,]+/g, '-')
-			.replace(/(?:^-|-$)/g, '');
+			.replace(/[\s-!()<>`'",]+/g, '-')
+			.replace(/(?:^-|-$|[/&])/g, '');
 		toc.push({ text, id, level });
 	}
 	return toc;

--- a/src/lib/content.js
+++ b/src/lib/content.js
@@ -159,7 +159,7 @@ function generateToc(markdown) {
 		const id = text
 			.toLowerCase()
 			.replace(/[\s-!()<>`'",]+/g, '-')
-			.replace(/(?:^-|-$|[/&])/g, '');
+			.replace(/^-|-$|[/&]/g, '');
 		toc.push({ text, id, level });
 	}
 	return toc;


### PR DESCRIPTION
Fixes two sets of cases:

1. Sections with `/`
    * Example: TS preact/compat on [Getting Started](https://preactjs.com/guide/v10/getting-started)
    * The Issue: Link in ToC would be to `#typescript-preact/compat-configuration` when the element had an ID of `typescript-preactcompat-configuration`
    * Solution: Strip `/` from ToC links
2. Sections with `&`
    * Example: Controlled & uncontrolled components on [Forms](https://preactjs.com/guide/v10/forms)
    * The issue: Link in ToC would be to `#controlled-uncontrolled-components` when the element had an ID of `controlled--uncontrolled-components`
    * Solution: Strip `&` from ToC links only after the spaces have been substituted for hyphens