### PR TITLE
Add jsx-runtime aliases to Getting Started

### DIFF
--- a/content/en/guide/v10/getting-started.md
+++ b/content/en/guide/v10/getting-started.md
@@ -145,8 +145,8 @@ const config = {
     "alias": { 
       "react": "preact/compat",
       "react-dom/test-utils": "preact/test-utils",
-      "react-dom": "preact/compat",
-     // Must be below test-utils
+      "react-dom": "preact/compat",     // Must be below test-utils
+      "react/jsx-runtime": "preact/jsx-runtime"
     },
   }
 }
@@ -162,7 +162,8 @@ an `alias` key.
   "alias": {
     "react": "preact/compat",
     "react-dom/test-utils": "preact/test-utils",
-    "react-dom": "preact/compat"
+    "react-dom": "preact/compat",
+    "react/jsx-runtime": "preact/jsx-runtime"
   },
 }
 ```
@@ -180,7 +181,8 @@ module.exports = {
     alias({
       entries: [
         { find: 'react', replacement: 'preact/compat' },
-        { find: 'react-dom', replacement: 'preact/compat' }
+        { find: 'react-dom', replacement: 'preact/compat' },
+        { find: 'react/jsx-runtime', replacement: 'preact/jsx-runtime' }
       ]
     })
   ]
@@ -197,7 +199,8 @@ These rewrites are configured using regular expressions in your Jest configurati
   "moduleNameMapper": {
     "^react$": "preact/compat",
     "^react-dom/test-utils$": "preact/test-utils",
-    "^react-dom$": "preact/compat"
+    "^react-dom$": "preact/compat",
+    "^react/jsx-runtime$": "preact/jsx-runtime"
   }
 }
 ```
@@ -211,7 +214,8 @@ To alias in [Snowpack](https://www.snowpack.dev/), you'll need to add a package 
 {
   alias: {
     "react": "preact/compat",
-    "react-dom": "preact/compat"
+    "react-dom": "preact/compat",
+    "react/jsx-runtime": "preact/jsx-runtime",
   }
 }
 ```

--- a/content/en/guide/v10/getting-started.md
+++ b/content/en/guide/v10/getting-started.md
@@ -208,10 +208,10 @@ These rewrites are configured using regular expressions in your Jest configurati
 
 #### Aliasing in Snowpack
 
-To alias in [Snowpack](https://www.snowpack.dev/), you'll need to add a package import alias to the `snowpack.config.json` file.
+To alias in [Snowpack](https://www.snowpack.dev/), you'll need to add a package import alias to the `snowpack.config.mjs` file.
 
 ```js
-// snowpack.config.json
+// snowpack.config.mjs
 {
   alias: {
     "react": "preact/compat",

--- a/content/en/guide/v10/getting-started.md
+++ b/content/en/guide/v10/getting-started.md
@@ -181,6 +181,7 @@ module.exports = {
     alias({
       entries: [
         { find: 'react', replacement: 'preact/compat' },
+        { find: 'react-dom/test-utils', replacement: 'preact/test-utils' },
         { find: 'react-dom', replacement: 'preact/compat' },
         { find: 'react/jsx-runtime', replacement: 'preact/jsx-runtime' }
       ]
@@ -214,6 +215,7 @@ To alias in [Snowpack](https://www.snowpack.dev/), you'll need to add a package 
 {
   alias: {
     "react": "preact/compat",
+    "react-dom/test-utils": "preact/test-utils",
     "react-dom": "preact/compat",
     "react/jsx-runtime": "preact/jsx-runtime",
   }


### PR DESCRIPTION
Adds jsx-runtime aliases to the relevant configuration files on the Getting Started page.
Rollup and Snowpack are noticeably missing the `preact/test-utils` alias - is this intentional or should they also be added?