### PR TITLE
Fix Snowpack config for aliasing

### DIFF
--- a/content/en/guide/v10/getting-started.md
+++ b/content/en/guide/v10/getting-started.md
@@ -212,7 +212,7 @@ To alias in [Snowpack](https://www.snowpack.dev/), you'll need to add a package 
 
 ```js
 // snowpack.config.mjs
-{
+export default {
   alias: {
     "react": "preact/compat",
     "react-dom/test-utils": "preact/test-utils",


### PR DESCRIPTION
Nothing much to add, the current configuration cannot be copied/pasted without manually adding `export default` and it can bring confusion.