### PR TITLE
fix: Correcting table of contents link generation

### DIFF
--- a/src/lib/content.js
+++ b/src/lib/content.js
@@ -158,8 +158,8 @@ function generateToc(markdown) {
 		// Note: character range in regex is roughly "word characters including accented" (eg: bublé)
 		const id = text
 			.toLowerCase()
-			.replace(/[\s-!()<>`'",]+/g, '-')
-			.replace(/^-|-$|[/&]/g, '');
+			.replace(/[\s-!()<>`",]+/g, '-')
+			.replace(/^-|-$|[/&.[\]']/g, '');
 		toc.push({ text, id, level });
 	}
 	return toc;


### PR DESCRIPTION
Fixes three sets of cases:

1. Sections with `.`
    * Example: "Arguments in `Component.render()`" on [Differences to React](https://preactjs.com/guide/v10/differences-to-react)
    * The Issue: Link in ToC would be to `#arguments-in-component.render` when the element had an ID of `arguments-in-componentrender`
    * Solution: Strip `.` from ToC links
2. Sections with `[` and `]`
    * Example: "Getting `vnode.[property]` is deprecated" on [Debugging Preact Apps](https://preactjs.com/guide/v10/debugging)
    * The issue: Link in ToC would be to `#getting-vnode.[property]-is-deprecated` when the element had an ID of `getting-vnodeproperty-is-deprecated` (also suffers from issue 1)
    * Solution: Strip `[` and `]` from ToC links
2. Sections with `'`
    * Example: "Don't access `this.setState` synchronously" on [Upgrading from Preact 8.x](https://preactjs.com/guide/v10/upgrade-guide)
    * The issue: Link in ToC would be to `#don-t-access-this.state-synchronously` when the element had an ID of `dont-access-thisstate-synchronously` (also suffers from issue 1)
    * Solution: Don't replace `'` with a hyphen, instead, just remove it from ToC links