### PR TITLE
fix: Corrects content padding to avoid header overlap

### DIFF
--- a/src/style/markdown.less
+++ b/src/style/markdown.less
@@ -376,7 +376,10 @@
 
 	h1,
 	h2,
-	h3 {
+	h3,
+	h4,
+	h5,
+	h6 {
 		&:target {
 			padding-top: @header-height;
 		}


### PR DESCRIPTION
The padding to ensure the header didn't overlap content headings was limited to h1-h3, which meant on pages with deeper nested sections, like [Getting Started's aliases](https://preactjs.com/guide/v10/getting-started/#aliasing-in-webpack), the content heading would be hidden behind the header.

Just need to ensure the padding applies to all headings, not just h1-h3 (although we only use up to h4)