### PR TITLE
Update acronym to match the more common definition

### DIFF
--- a/content/en/guide/v10/getting-started.md
+++ b/content/en/guide/v10/getting-started.md
@@ -68,7 +68,7 @@ For more information on HTM, check out its [documentation][htm].
 
 [Preact CLI] is an off-the-shelf solution for building Preact applications that is optimized for modern web development. It's built on standard tooling projects like Webpack, Babel and PostCSS. Preact CLI does not require any configuration or prior knowledge to get started, and this simplicity makes it the most popular way to use Preact.
 
-As the name implies, Preact CLI is a **c**ommand-**li**ne tool that can be run in the terminal on your machine. Using it, you can create a new application by running the `create` command:
+As the name implies, Preact CLI is a **c**ommand-**l**ine **i**nterface that can be run in the terminal on your machine. Using it, you can create a new application by running the `create` command:
 
 ```bash
 npx preact-cli create default my-project


### PR DESCRIPTION
I noticed this acronym, while clever, isn't the widely held definition for CLI. Per Wikipedia: https://en.wikipedia.org/wiki/Command-line_interface