### PR TITLE
Fix blockquote overflow on mobile

### DIFF
--- a/src/style/markdown.less
+++ b/src/style/markdown.less
@@ -201,6 +201,7 @@
 		background: var(--color-quote-bg);
 		color: var(--color-quote-text);
 		border-left: 0.3rem solid var(--color-quote-border);
+		overflow-x: auto;
 	}
 	blockquote > :first-child {
 		margin-top: 0;

--- a/src/style/markdown.less
+++ b/src/style/markdown.less
@@ -201,7 +201,7 @@
 		background: var(--color-quote-bg);
 		color: var(--color-quote-text);
 		border-left: 0.3rem solid var(--color-quote-border);
-		overflow-x: auto;
+		overflow: auto;
 	}
 	blockquote > :first-child {
 		margin-top: 0;


### PR DESCRIPTION
Since there is an `overflow: hidden` on many tags and classes such as `.markup`, overflowing things can get inaccessible on mobile pretty easily, and `overflow` needs to be manually set to `auto` in such cases.

Before the fix:
<img src="https://user-images.githubusercontent.com/43412083/138654613-41ab7e73-398c-489b-83ea-d4fbe382ade6.png" width=300>
(it is impossible to read/copy the entire URL in that "Tip" blockquote.)

After the fix:
<img src="https://user-images.githubusercontent.com/43412083/138654439-06f1398c-90b5-44de-90fb-fe66eee7b28f.png" width=300>
