### PR TITLE
Update 01-vdom.md

### DIFF
--- a/content/en/tutorial/01-vdom.md
+++ b/content/en/tutorial/01-vdom.md
@@ -119,7 +119,7 @@ can make it clearer what parts of your code are HTM/JSX elements, and what
 parts are plain JavaScript:
 
 ```js
-import html from 'htm/preact';
+import {html} from 'htm/preact';
 
 let maybeBig = Math.random() > .5 ? 'big' : 'small';
 

--- a/content/en/tutorial/01-vdom.md
+++ b/content/en/tutorial/01-vdom.md
@@ -119,7 +119,7 @@ can make it clearer what parts of your code are HTM/JSX elements, and what
 parts are plain JavaScript:
 
 ```js
-import {html} from 'htm/preact';
+import { html } from 'htm/preact';
 
 let maybeBig = Math.random() > .5 ? 'big' : 'small';
 


### PR DESCRIPTION
changed `import html` to `import {html}` because the current version was throwing an error displayed in the render area: "TypeError: _preact2.default is not a function"