### PR TITLE
Add section: set up Preact+TypeScript with CLI

### DIFF
--- a/content/en/guide/v10/typescript.md
+++ b/content/en/guide/v10/typescript.md
@@ -15,6 +15,15 @@ When you use Preact in a TypeScript-aware editor (like VSCode), you can benefit 
 
 ---
 
+## Setting up new project
+
+Spinning up a new Preact app that uses TypeScript couldn't be more straightforward that it is thanks to [Preact CLI](https://github.com/preactjs/preact-cli). There's a dedicated [typescript template](https://github.com/preactjs-templates/typescript) that provides you with all necessary config so that you don't need to play with compiler options and can start coding right away.
+
+
+```
+npx preact-cli create typescript my-preact-typescript-project
+```
+
 ## TypeScript configuration
 
 TypeScript includes a full-fledged JSX compiler that you can use instead of Babel. Add the following configuration to your `tsconfig.json` to transpile JSX to Preact-compatible JavaScript:


### PR DESCRIPTION
Hi! I believe it would be beneficial for many beginners to include a section on how to set up a Preact project with TypeScript using Preact CLI.

I stumbled upon [TypeScript](https://preactjs.com/guide/v10/typescript) page today and was under impression that to set it up with Preact one needs to manually add `typescript` dependency and then play with compiler options. This resulted in much frustration, as it wasn't just as simple. Only after some digging I found out about dedicated typescript template of the CLI. I think adding such a section could save many people coming to Preact a lot of trouble.