### PR TITLE
Warn about `replaceNode` usage

### DIFF
--- a/content/de/guide/v8/api-reference.md
+++ b/content/de/guide/v8/api-reference.md
@@ -75,11 +75,15 @@ class MeineKomponente extends Component {
 
 ## `Preact.render()`
 
+> No
+
 `render(component, containerNode, [replaceNode])`
 
 Rendere eine Preact-Komponente in den `containerNode` DOM-Knoten. Gibt eine Referenz zum gerenderten DOM-Knoten aus.
 
 Wenn der optionale `replaceNode` DOM-Knoten gegeben ist und ein Child von `containerNode` ist, wird Preact dieses Element aktualisieren oder mit seinem Differenzierungsalgorithmus ersetzen. Andernfalls wird Preact das gerenderte Element zu `containerNode` hinzufügen.
+
+> ⚠️ Das `replaceNode`-Argument wird in der zukünftigen Preact `v11` Version entfernt. Es führt zu zu vielen Extrawürsten und Fehlern, die in anderen Teilen des Preact Codes berücksichtigt werden müssen. Dieser Teil der Dokumentation dient mehr zu historischen Zwecken, daher empfehlen wir die `render`-Funktion ohne dieses Argument zu benutzen.
 
 ```js
 import { render } from 'preact';

--- a/content/en/guide/v10/api-reference.md
+++ b/content/en/guide/v10/api-reference.md
@@ -70,6 +70,8 @@ render(<Foo />, document.getElementById('container'));
 
 If the optional `replaceNode` parameter is provided, it must be a child of `containerNode`. Instead of inferring where to start rendering, Preact will update or replace the passed element using its diffing algorithm.
 
+> ⚠️ The `replaceNode`-argument will be removed with Preact `v11`. It introduces too many edge cases and bugs which need to be accounted for in the rest of Preact's source code. We're leaving this section up for historical reasons, but we don't recommend anyone to use the third `replaceNode` argument.
+
 ```jsx
 // DOM tree before render:
 // <div id="container">


### PR DESCRIPTION
We've already removed the third parameter `replaceNode` to render in `v11`. Thought it'd be a good idea to hint at that in the current `v10` docs, so that users will avoid using it with `v10`.