### PR TITLE
Fix typos in tutorial

### DIFF
--- a/content/en/tutorial/01-vdom.md
+++ b/content/en/tutorial/01-vdom.md
@@ -139,7 +139,7 @@ for now it's important to know that HTML elements like `<p>` are just one of
 _two_ types of Virtual DOM elements. The other type is a Component, which is
 a Virtual DOM element where the type is a function instead of a string like `p`.
 
-Components are the building block of Virtual DOM applications. For now, we'll
+Components are the building blocks of Virtual DOM applications. For now, we'll
 create a very simple component by moving our JSX into a function, which will be
 rendered for us so we don't need to write that last `render()` line anymore:
 

--- a/content/en/tutorial/03-components.md
+++ b/content/en/tutorial/03-components.md
@@ -5,8 +5,8 @@ title: Components
 solvable: true
 ---
 
-As we aluded to in part one of this tutorial, the key building block
-in Virtual DOM applications is the Component. A Component is self-contained
+As we alluded to in part one of this tutorial, the key building block
+in Virtual DOM applications is the Component. A Component is a self-contained
 piece of an application that can be rendered as part of the Virtual DOM
 tree just like an HTML element. You can think of a Component like a function
 call: both are mechanisms that allow code reuse and indirection.
@@ -89,7 +89,7 @@ render(<MediaPlayer playing={true} />, document.body)
 
 > **Remember:** `{curly}` braces in JSX let us jump back into plain JavaScript.
 > Here we're using a [ternary] expression to show different buttons based on
-> on the value of a `playing` prop.
+> the value of the `playing` prop.
 
 
 ### Component Children

--- a/content/en/tutorial/04-state.md
+++ b/content/en/tutorial/04-state.md
@@ -45,7 +45,7 @@ class MyButton extends Component {
 ```
 
 Clicking the button calls `this.setState()`, which causes Preact to
-call the class' `render()` method again. Now that`this.state.clicked`
+call the class' `render()` method again. Now that `this.state.clicked`
 is `true`, the `render()` method returns a Virtual DOM tree containing
 the text "Clicked" instead of "No clicks yet", causing Preact to update
 the button's text in the DOM.
@@ -84,7 +84,7 @@ will return the exact same Array each time.
 > }
 > ```
 >
-> This is called callsite ordering, and it's the reason why hooks must
+> This is called call site ordering, and it's the reason why hooks must
 > always be called in the same order within a component, and cannot be
 > called conditionally or within loops.
 
@@ -125,7 +125,7 @@ chapter. We'll need to store a `count` number in state, and increment its value
 by `1` when a button is clicked.
 
 Since we used a function component in the previous chapter, it may be easiest to
-use Hooks, though you can pick whichever method of storing state you prefer.
+use hooks, though you can pick whichever method of storing state you prefer.
 
 
 <solution>

--- a/content/en/tutorial/05-refs.md
+++ b/content/en/tutorial/05-refs.md
@@ -30,17 +30,17 @@ anything:
 ```js
 import { createRef } from 'preact'
 
-// Create a ref:
+// create a ref:
 const ref = createRef('initial value')
 // { current: 'initial value' }
 
-// Read a ref's current value:
+// read a ref's current value:
 ref.current === 'initial value'
 
-// Update a ref's current value:
+// update a ref's current value:
 ref.current = 'new value'
 
-// Pass refs around:
+// pass refs around:
 console.log(ref) // { current: 'new value' }
 ```
 
@@ -52,13 +52,13 @@ we can use the ref's current value to access and modify the HTML element:
 ```jsx
 import { createRef } from 'preact';
 
-// Create a ref:
+// create a ref:
 const input = createRef()
 
-// Pass the ref as a prop on a Virtual DOM element:
+// pass the ref as a prop on a Virtual DOM element:
 render(<input ref={input} />, document.body)
 
-// Access the associated DOM element:
+// access the associated DOM element:
 input.current // an HTML <input> element
 input.current.focus() // focus the input!
 ```

--- a/content/en/tutorial/06-context.md
+++ b/content/en/tutorial/06-context.md
@@ -101,11 +101,11 @@ authentication state (whether the user is logged in or not).
 To do this, we can create a context to hold the information, which
 we'll call `AuthContext`. The value for AuthContext will be an object
 with a `user` property containing our signed-in user, along with
-`login(user)` and `logout()` methods to modify that state.
+a `setUser` method to modify that state.
 
 ```jsx
 import { createContext } from 'preact'
-import { useState, useContext } from 'preact/hooks'
+import { useState, useMemo, useContext } from 'preact/hooks'
 
 const AuthContext = createContext()
 
@@ -155,10 +155,10 @@ context providers can be nested to "override" their value within a Virtual DOM
 subtree. Imagine a web-based email app, where various parts of the user interface
 are shown based on URL paths:
 
-> `/inbox`: show the inbox
-> `/inbox/compose`: show inbox and a new message
-> `/settings`: show settings
-> `/settings/forwarding`: show forwarding settings
+> - `/inbox`: show the inbox
+> - `/inbox/compose`: show inbox and a new message
+> - `/settings`: show settings
+> - `/settings/forwarding`: show forwarding settings
 
 We can create a `<Route path="..">` component that renders a Virtual DOM tree
 only when the current path matches a given path segment. To simplify defining
@@ -167,6 +167,7 @@ within its subtree to exclude the part of the path that was matched.
 
 ```jsx
 import { createContext } from 'preact'
+import { useContext } from 'preact/hooks'
 
 const Path = createContext(location.pathname)
 

--- a/content/en/tutorial/07-side-effects.md
+++ b/content/en/tutorial/07-side-effects.md
@@ -76,7 +76,7 @@ Class components can also define side effects, by implementing any of
 the available [lifecycle methods] provided by Preact. Here are a
 few of the most commonly used lifecycle methods:
 
-| Lifecycle Method | When it runs: |
+| Lifecycle method | When it runs: |
 |:-----------------|:--------------|
 | `componentWillMount` | just before a component is first rendered
 | `componentDidMount` | after a component is first rendered
@@ -106,10 +106,10 @@ export default class App extends Component {
   render(props, state) {
     const { user } = state;
 
-    // If we haven't received data yet, show a loading indicator:
+    // if we haven't received data yet, show a loading indicator:
     if (!user) return <div>Loading...</div>
 
-    // We have data! Show the username we got back from the API:
+    // we have data! show the username we got back from the API:
     return (
       <div>
         <h2>Hello, {user.username}!</h2>

--- a/content/en/tutorial/08-keys.md
+++ b/content/en/tutorial/08-keys.md
@@ -8,7 +8,7 @@ solvable: true
 In chapter one, we saw how Preact uses a Virtual DOM to calculate what
 changed between two trees described by our JSX, then applies those
 changes to the HTML DOM to update pages. This works well for most
-scenarios, but occasionally requires that Preact "guess" about how
+scenarios, but occasionally requires that Preact "guesses" how
 the shape of the tree has changed between two renders.
 
 The most common scenario where Preact's guess is likely to be different
@@ -259,7 +259,7 @@ export default function ToDos() {
 ```
 
 Remember: if you genuinely can't find a stable key, it's better to omit
-the `key` prop entirely than it to use an index as a key.
+the `key` prop entirely than to use an index as a key.
 
 
 ## Try it!

--- a/content/en/tutorial/09-error-handling.md
+++ b/content/en/tutorial/09-error-handling.md
@@ -6,7 +6,7 @@ solvable: true
 ---
 
 JavaScript is a flexible interpreted language, which means it's possible (and even easy)
-encounter errors at runtime. Whether the result of an unexpected scenario or a mistake
+to encounter errors at runtime. Whether the result of an unexpected scenario or a mistake
 in code we've written, it's important to be able to monitor errors and implement some form
 of recovery or graceful error handling.
 

--- a/content/en/tutorial/10-links.md
+++ b/content/en/tutorial/10-links.md
@@ -6,7 +6,7 @@ solvable: false
 
 You've completed the Preact tutorial!
 
-Feel free to play around a more with the demo code.
+Feel free to play around a bit more with the demo code.
 
 ### Next Steps
 
@@ -47,7 +47,7 @@ export default function ToDos() {
 
   // every time todos changes...
   useEffect(() => {
-    // ... save the list to localStorage:
+    // ...save the list to localStorage:
     localStorage.todos = JSON.stringify(todos)
     // (try reloading the page to see saved todos!)
   }, [todos])

--- a/content/en/tutorial/index.md
+++ b/content/en/tutorial/index.md
@@ -8,7 +8,7 @@ solvable: false
 
 Have you ever wondered what Preact is all about, or how it works?
 
-Maybe you've been creating awesome websites using Wordpress, designing
+Maybe you've been creating awesome websites using WordPress, designing
 graphics with D3, or building helpful interactive forms with jQuery.
 At some point, the JavaScript you've written became complex enough that
 it was difficult to manage - remembering which file controls part of a


### PR DESCRIPTION
Nice tutorial!

Chapters 5 and 7: I lowercased the comments for consistency.

Side notes (didn't do anything about these):

- The word "Component" is capitalized inconsistently. Just saying because it bothered me a bit (🙈).
- Semicolons are used inconsistently in the code blocks. (Noticed this only halfway through the tutorial so not a big deal. 😄)
- The underlining of the `<abbr>` in chapter 6 is almost invisible in dark mode (see the last word in the screenshot):
  ![](https://user-images.githubusercontent.com/2226144/154860583-6ab5a65c-3f8c-47b1-9914-7d200be7931b.png)