### PR TITLE
docs: Copy 'skipLibCheck' note on 'Getting Started' to TS page

### DIFF
--- a/content/en/guide/v10/typescript.md
+++ b/content/en/guide/v10/typescript.md
@@ -70,6 +70,19 @@ In your `.babelrc`:
 
 Rename your `.jsx` files to `.tsx` for TypeScript to correctly parse your JSX.
 
+### preact/compat configuration
+
+Your project could need support for the wider React ecosystem.  To make your application
+compile, you'll need to disable type checking on your `node_modules` like this.  This way,
+your alias will work properly when libraries import React.
+
+```json
+{
+  ...
+  "skipLibCheck": true,
+}
+```
+
 ## Typing components
 
 There are different ways to type components in Preact. Class components have generic type variables to ensure type safety. TypeScript sees a function as functional component as long as it returns JSX. There are multiple solutions to define props for functional components.


### PR DESCRIPTION
We have [this note on the 'Getting Started' page](https://preactjs.com/guide/v10/getting-started#typescript-preactcompat-configuration), but oddly it was missing from the actual Typescript page.

This is just a direct copy of that text.