### PR TITLE
fix: Corrects padding to avoid header overlap

### DIFF
--- a/src/style/index.less
+++ b/src/style/index.less
@@ -90,7 +90,7 @@ div.highlight-container {
 
 	& > main {
 		min-height: 95%;
-		padding-top: calc(@header-height + 2.5rem); // 96px for banner
+		padding-top: @header-and-banner-height;
 		display: block; // Fix IE11 layout
 	}
 }

--- a/src/style/markdown.less
+++ b/src/style/markdown.less
@@ -382,7 +382,7 @@
 	h5,
 	h6 {
 		&:target {
-			padding-top: @header-height;
+			padding-top: @header-and-banner-height;
 		}
 	}
 

--- a/src/style/variables.less
+++ b/src/style/variables.less
@@ -1,4 +1,5 @@
 @header-height: 3.5rem; // 56px
+@header-and-banner-height: @header-height + 2.5rem; // 96px with banner
 @header-mobile-breakpoint: 50rem;
 @sidebar-width: 20rem;
 @sidebar-break: ~'(min-width: 900px)';


### PR DESCRIPTION
Bah, missed this in #835 and only after I said we don't need to extract this out to a variable as it's only used in one spot.

Ensures header doesn't overlap content headings