### PR TITLE
fix: Ensures sidebar is not cut off due to banner

### DIFF
--- a/src/components/controllers/page/sidebar.module.less
+++ b/src/components/controllers/page/sidebar.module.less
@@ -105,10 +105,10 @@
 	@media @sidebar-break {
 		@supports (position: sticky) {
 			position: sticky;
-			height: calc(100vh - @header-height);
+			height: calc(100vh - @header-and-banner-height);
 			overflow: auto;
 		}
-		top: @header-height;
+		top: @header-and-banner-height;
 		padding-bottom: 0;
 		width: 100%;
 	}


### PR DESCRIPTION
Sorry, yet another post-banner adjustment.

Corrects the top of the sidebar being covered a bit, see image below:

![sidebar](https://user-images.githubusercontent.com/33403762/156833424-81c98205-4e8b-4b2b-ba89-6a0883adf081.png)
