### PR TITLE
Mention that preact cli handles alliasing

### DIFF
--- a/content/en/guide/v10/getting-started.md
+++ b/content/en/guide/v10/getting-started.md
@@ -133,7 +133,7 @@ To transpile JSX, you need a Babel plugin that converts it to valid JavaScript c
 
 At some point, you'll probably want to make use of the vast React ecosystem. Libraries and Components originally written for React work seamlessly with our compatibility layer. To make use of it, we need to point all `react` and `react-dom` imports to Preact. This step is called _aliasing._
 
-If You're using [Preact CLI]() This is automatically done for you.
+> **Note:** If You're using [Preact CLI], these aliases are automatically handled for you by default.
 
 #### Aliasing in webpack
 

--- a/content/en/guide/v10/getting-started.md
+++ b/content/en/guide/v10/getting-started.md
@@ -133,6 +133,8 @@ To transpile JSX, you need a Babel plugin that converts it to valid JavaScript c
 
 At some point, you'll probably want to make use of the vast React ecosystem. Libraries and Components originally written for React work seamlessly with our compatibility layer. To make use of it, we need to point all `react` and `react-dom` imports to Preact. This step is called _aliasing._
 
+If You're using [Preact CLI]() This is automatically done for you.
+
 #### Aliasing in webpack
 
 To alias any package in webpack, you need to add the `resolve.alias` section

--- a/content/en/guide/v10/getting-started.md
+++ b/content/en/guide/v10/getting-started.md
@@ -133,7 +133,7 @@ To transpile JSX, you need a Babel plugin that converts it to valid JavaScript c
 
 At some point, you'll probably want to make use of the vast React ecosystem. Libraries and Components originally written for React work seamlessly with our compatibility layer. To make use of it, we need to point all `react` and `react-dom` imports to Preact. This step is called _aliasing._
 
-> **Note:** If You're using [Preact CLI], these aliases are automatically handled for you by default.
+> **Note:** If you're using [Preact CLI], these aliases are automatically handled for you by default.
 
 #### Aliasing in webpack
 


### PR DESCRIPTION
When i was reading through the docs i was under the impression that i have to do the aliasing myself. 
It wasn't clear (nor is it clear from the preact CLI documentation) that this is done for you.

Maybe mentioning it in the CLI documentation as well wouldn't hurt.