### PR TITLE
Adds Preact island

### DIFF
--- a/content/en/about/libraries-addons.md
+++ b/content/en/about/libraries-addons.md
@@ -37,6 +37,7 @@ A collection of modules built to work wonderfully with Preact.
 - :rowboat: [**preact-flyd**](https://github.com/xialvjun/preact-flyd): Use [flyd](https://github.com/paldepind/flyd) FRP streams in Preact + JSX
 - :speech_balloon: [**preact-i18nline**](https://github.com/download/preact-i18nline): Integrates the ecosystem around [i18n-js](https://github.com/everydayhero/i18n-js) with Preact via [i18nline](https://github.com/download/i18nline).
 - :diamond_shape_with_a_dot_inside: [**Capacitor**](https://capacitorjs.com/solution/preact): Turn your Preact app into a Native iOS/Android App and PWA.
+- 🏝: [**preact-island**](https://github.com/mwood23/preact-island): Run your Preact widget on any website with reactive props.
 
 ## GUI Toolkits
 


### PR DESCRIPTION
I wrote a small helper that helps you run a Preact app/component on any website. It's useful for widgets on CMS website or E-commerce pages. There's ways of injecting props into your component from the outside page that are reactive and cause rerenders of your component.