### PR TITLE
docs: Adds `paths` to recommendation for TS config

### DIFF
--- a/content/en/guide/v10/getting-started.md
+++ b/content/en/guide/v10/getting-started.md
@@ -231,12 +231,19 @@ export default {
 ## TypeScript preact/compat configuration
 
 Your project could need support for the wider React ecosystem.  To make your application
-compile, you'll need to disable type checking on your `node_modules` like this.  This way,
-your alias will work properly when libraries import React.
+compile, you might need to disable type checking on your `node_modules` and add paths to the types
+like this.  This way, your alias will work properly when libraries import React.
 
 ```json
 {
-  ...
-  "skipLibCheck": true,
+  "compilerOptions": {
+    ...
+    "skipLibCheck": true,
+    "baseUrl": "./",
+    "paths": {
+      "react": ["./node_modules/preact/compat/"],
+      "react-dom": ["./node_modules/preact/compat/"]
+    }
+  }
 }
 ```

--- a/content/en/guide/v10/typescript.md
+++ b/content/en/guide/v10/typescript.md
@@ -70,6 +70,26 @@ In your `.babelrc`:
 
 Rename your `.jsx` files to `.tsx` for TypeScript to correctly parse your JSX.
 
+## TypeScript preact/compat configuration
+
+Your project could need support for the wider React ecosystem.  To make your application
+compile, you might need to disable type checking on your `node_modules` and add paths to the types
+like this.  This way, your alias will work properly when libraries import React.
+
+```json
+{
+  "compilerOptions": {
+    ...
+    "skipLibCheck": true,
+    "baseUrl": "./",
+    "paths": {
+      "react": ["./node_modules/preact/compat/"],
+      "react-dom": ["./node_modules/preact/compat/"]
+    }
+  }
+}
+```
+
 ## Typing components
 
 There are different ways to type components in Preact. Class components have generic type variables to ensure type safety. TypeScript sees a function as functional component as long as it returns JSX. There are multiple solutions to define props for functional components.


### PR DESCRIPTION
Re: https://github.com/preactjs/preact/issues/2748 & https://github.com/preactjs/preact/issues/3547, `"paths"` seemingly is becoming more and more required in order to solve type discrepancies between Preact and React.

Also duplicates the information from the 'Getting Started' page to the TS page, as the info was otherwise a bit fragmented which is less than ideal.