### PR TITLE
fix: use `findByText` on `screen`

### DIFF
--- a/content/en/guide/v10/preact-testing-library.md
+++ b/content/en/guide/v10/preact-testing-library.md
@@ -96,7 +96,7 @@ test('should increment counter", async () => {
 
   fireEvent.click(screen.getByText('Increment'));
 
-  await findByText('Current value: 6'); // waits for changed element
+  await screen.findByText('Current value: 6'); // waits for changed element
   
   expect(screen.getByText("Current value: 6")).toBeInTheDocument(); // passes
 });


### PR DESCRIPTION
I assume this was left over from the previous API where `findByText` was destructured from the `render` return value.