### PR TITLE
docs: Fix typo on the error handling tutorial page

### DIFF
--- a/content/en/tutorial/09-error-handling.md
+++ b/content/en/tutorial/09-error-handling.md
@@ -26,7 +26,7 @@ to render a fallback or alternative tree, which will "catch" the error and mark
 it as handled. Or, the method could simply log the error somewhere and allow it
 to continue unhandled (to crash).
 
-**getDerivedStateFromProps** is a static method that gets passed an `Error`,
+**getDerivedStateFromError** is a static method that gets passed an `Error`,
 and returns a state update object, which is applied to the component via
 `setState()`. Since this method always produces a state change that results
 in its component being re-rendered, it always marks errors as handled.


### PR DESCRIPTION
Thanks for the awesome tutorial.

I think the method here should be `getDerivedStateFromError`.