### PR TITLE
fix: Replace dead PWA link with working reference

### DIFF
--- a/content/de/guide/v8/progressive-web-apps.md
+++ b/content/de/guide/v8/progressive-web-apps.md
@@ -5,7 +5,7 @@ permalink: '/guide/progressive-web-apps'
 
 # Progressive Web Apps
 
-Preact ist eine ausgezeichnete Wahl für [progressive Web Apps](https://developers.google.com/web/progressive-web-apps/), für die schnelles Laden und rasche Interaktivitätsmöglichkeiten erwünscht sind. [Preact CLI](https://github.com/preactjs/preact-cli) kodifiziert dies in einem schnellen Baukastenwerkzeug, dass von Grund auf eine PWA (Progressive Web App) mit einem [Lighthouse][LH]-Score von 100 schafft.
+Preact ist eine ausgezeichnete Wahl für [progressive Web Apps](https://web.dev/learn/pwa/), für die schnelles Laden und rasche Interaktivitätsmöglichkeiten erwünscht sind. [Preact CLI](https://github.com/preactjs/preact-cli) kodifiziert dies in einem schnellen Baukastenwerkzeug, dass von Grund auf eine PWA (Progressive Web App) mit einem [Lighthouse][LH]-Score von 100 schafft.
 
 [LH]: https://developers.google.com/web/tools/lighthouse/
 

--- a/content/en/guide/v10/progressive-web-apps.md
+++ b/content/en/guide/v10/progressive-web-apps.md
@@ -6,7 +6,7 @@ description: 'Progressive Web Apps (PWA) allow you to ship your app offline. The
 
 # Progressive Web Apps
 
-Preact is an excellent choice for [Progressive Web Apps](https://developers.google.com/web/progressive-web-apps/) that wish to load and become interactive quickly.  [Preact CLI](https://github.com/preactjs/preact-cli/) codifies this into an instant build tool that gives you a PWA with a 100 [Lighthouse][LH] score right out of the box.
+Preact is an excellent choice for [Progressive Web Apps](https://web.dev/learn/pwa/) that wish to load and become interactive quickly.  [Preact CLI](https://github.com/preactjs/preact-cli/) codifies this into an instant build tool that gives you a PWA with a 100 [Lighthouse][LH] score right out of the box.
 
 [LH]: https://developers.google.com/web/tools/lighthouse/
 

--- a/content/en/guide/v8/progressive-web-apps.md
+++ b/content/en/guide/v8/progressive-web-apps.md
@@ -5,7 +5,7 @@ permalink: '/guide/progressive-web-apps'
 
 # Progressive Web Apps
 
-Preact is an excellent choice for [Progressive Web Apps](https://developers.google.com/web/progressive-web-apps/) that wish to load and become interactive quickly.  [Preact CLI](https://github.com/preactjs/preact-cli/) codifies this into an instant build tool that gives you a PWA with a 100 [Lighthouse][LH] score right out of the box.
+Preact is an excellent choice for [Progressive Web Apps](https://web.dev/learn/pwa/) that wish to load and become interactive quickly.  [Preact CLI](https://github.com/preactjs/preact-cli/) codifies this into an instant build tool that gives you a PWA with a 100 [Lighthouse][LH] score right out of the box.
 
 [LH]: https://developers.google.com/web/tools/lighthouse/
 

--- a/content/es/guide/v8/progressive-web-apps.md
+++ b/content/es/guide/v8/progressive-web-apps.md
@@ -5,7 +5,7 @@ permalink: '/guide/progressive-web-apps'
 
 # Progressive Web Apps
 
-Preact es una excelente elección para [Progressive Web Apps](https://developers.google.com/web/progressive-web-apps/) que quieren cargar y ser interactivas rápidamente.
+Preact es una excelente elección para [Progressive Web Apps](https://web.dev/learn/pwa/) que quieren cargar y ser interactivas rápidamente.
 
 <ol class="list-view">
     <li class="list-item">

--- a/content/fr/guide/v8/progressive-web-apps.md
+++ b/content/fr/guide/v8/progressive-web-apps.md
@@ -7,7 +7,7 @@ permalink: '/guide/progressive-web-apps'
 
 ## Vue d'ensemble
 
-Preact est un excellent choix pour les [Progressive Web Apps](https://developers.google.com/web/progressive-web-apps/) qui souhaitent être chargée et devenir interactive rapidement. [Preact CLI](https://github.com/preactjs/preact-cli/) codifie cela dans un outil de build qui vous donne une PWA avec un score de 100 dans [Lighthouse][LH] directement.
+Preact est un excellent choix pour les [Progressive Web Apps](https://web.dev/learn/pwa/) qui souhaitent être chargée et devenir interactive rapidement. [Preact CLI](https://github.com/preactjs/preact-cli/) codifie cela dans un outil de build qui vous donne une PWA avec un score de 100 dans [Lighthouse][LH] directement.
 
 [LH]: https://developers.google.com/web/tools/lighthouse/
 

--- a/content/ja/guide/v10/progressive-web-apps.md
+++ b/content/ja/guide/v10/progressive-web-apps.md
@@ -6,7 +6,7 @@ description: 'Progressive Web Apps (PWA)はアプリケーションをオフラ�
 
 # Progressive Web Apps
 
-Preactはすぐにロードされ操作が可能になることを求められる[Progressive Web Apps](https://developers.google.com/web/progressive-web-apps/)に向いています。
+Preactはすぐにロードされ操作が可能になることを求められる[Progressive Web Apps](https://web.dev/learn/pwa/)に向いています。
 [Preact CLI](https://github.com/preactjs/preact-cli/)を使うと、[Lighthouse][LH]で100点を記録するPWAとそのビルド環境をすぐに構築できます。
 
 

--- a/content/pt-br/guide/v10/progressive-web-apps.md
+++ b/content/pt-br/guide/v10/progressive-web-apps.md
@@ -6,7 +6,7 @@ description: 'Os Progressive Web Apps (PWA) permitem enviar seu aplicativo offli
 
 # Progressive Web Apps
 
-O Preact é uma excelente opção para os [Progressive Web Apps](https://developers.google.com/web/progressive-web-apps/) que desejam carregar e se tornar interativos rapidamente. [Preact CLI](https://github.com/preactjs/preact-cli/) codifica isso em uma ferramenta de compilação instantânea que fornece um PWA com uma pontuação de 100 [Lighthouse][LH] imediatamente.
+O Preact é uma excelente opção para os [Progressive Web Apps](https://web.dev/learn/pwa/) que desejam carregar e se tornar interativos rapidamente. [Preact CLI](https://github.com/preactjs/preact-cli/) codifica isso em uma ferramenta de compilação instantânea que fornece um PWA com uma pontuação de 100 [Lighthouse][LH] imediatamente.
 
 [LH]: https://developers.google.com/web/tools/lighthouse/
 

--- a/content/pt-br/guide/v8/progressive-web-apps.md
+++ b/content/pt-br/guide/v8/progressive-web-apps.md
@@ -7,7 +7,7 @@ permalink: '/guide/progressive-web-apps'
 
 ## Visão Geral
 
-Preact é uma excelente escolha para [Progressive Web Apps](https://developers.google.com/web/progressive-web-apps/) que desejam carregar e tornarem-se interativos rapidamente.
+Preact é uma excelente escolha para [Progressive Web Apps](https://web.dev/learn/pwa/) que desejam carregar e tornarem-se interativos rapidamente.
 
 <ol class="list-view">
     <li class="list-item">

--- a/content/tr/guide/v8/progressive-web-apps.md
+++ b/content/tr/guide/v8/progressive-web-apps.md
@@ -7,7 +7,7 @@ permalink: '/guide/progressive-web-apps'
 
 ## Genel Bakış
 
-Preact, hızlı bir şekilde yüklenip etkileşimli hale gelmek isteyen [Progressive Web Apps](https://developers.google.com/web/progressive-web-apps/) için mükemmel bir seçimdir. [Preact CLI](https://github.com/preactjs/preact-cli/), size 100 [Lighthouse][LH] puanlı bir PWA yaratabileceğiniz bir araç sağlar.
+Preact, hızlı bir şekilde yüklenip etkileşimli hale gelmek isteyen [Progressive Web Apps](https://web.dev/learn/pwa/) için mükemmel bir seçimdir. [Preact CLI](https://github.com/preactjs/preact-cli/), size 100 [Lighthouse][LH] puanlı bir PWA yaratabileceğiniz bir araç sağlar.
 
 [LH]: https://developers.google.com/web/tools/lighthouse/
 

--- a/content/zh/guide/v8/progressive-web-apps.md
+++ b/content/zh/guide/v8/progressive-web-apps.md
@@ -7,7 +7,7 @@ permalink: '/guide/progressive-web-apps'
 
 ## 概述
  
-Preact 是希望快速加载和交互的 [渐进式 Web 应用程序](https://developers.google.com/web/progressive-web-apps/) 的绝佳选择。
+Preact 是希望快速加载和交互的 [渐进式 Web 应用程序](https://web.dev/learn/pwa/) 的绝佳选择。
 <ol class="list-view">
     <li class="list-item">
         <div class="list-header">


### PR DESCRIPTION
Google no longer maintains developer page describing/defining PWAs (existing link 404s)

Found hyperlink in google docs here: https://developers.google.com/codelabs/pwa-in-play?hl=en#0
which now points to web.dev article for definition: https://web.dev/learn/pwa/