### PR TITLE
refactor: Makes v8 warning banner sticky

### DIFF
--- a/src/components/controllers/page/index.js
+++ b/src/components/controllers/page/index.js
@@ -173,7 +173,7 @@ export default function Page({ route, prev, next }, ctx) {
 				<div class={style.inner}>
 					{isDocPage(url) && +store.state.docVersion !== AVAILABLE_DOCS[0] && (
 						<div class={style.oldDocsWarning}>
-							You are viewing the documentation for an older version of Preact.
+							You are viewing the documentation for an older version of Preact.{' '}
 							<a href={docsUrl}>Switch to the current version →</a>
 						</div>
 					)}

--- a/src/components/controllers/page/style.module.less
+++ b/src/components/controllers/page/style.module.less
@@ -62,6 +62,9 @@
 	padding: 0.75rem 1rem;
 	color: #444;
 	text-align: center;
+	position: sticky;
+	top: @header-and-banner-height;
+	z-index: 100; // Else code blocks would layer on top
 
 	a {
 		.link;

--- a/src/style/markdown.less
+++ b/src/style/markdown.less
@@ -376,6 +376,9 @@
 		&:target {
 			padding-top: @header-and-banner-height;
 		}
+		content-region[name*='v8'] &:target {
+			padding-top: calc(@header-and-banner-height + 3.25rem);
+		}
 	}
 
 	* {

--- a/src/style/markdown.less
+++ b/src/style/markdown.less
@@ -46,15 +46,6 @@
 		&:hover a.anchor {
 			text-decoration: none;
 		}
-
-		// fix anchor target positioning to account for fixed header
-		&:before {
-			content: '';
-			display: block;
-			position: absolute;
-			height: @header-and-banner-height;
-			margin: -@header-and-banner-height 0 0;
-		}
 	}
 
 	h1,
@@ -381,6 +372,7 @@
 	h4,
 	h5,
 	h6 {
+		// fix anchor target positioning to account for fixed header
 		&:target {
 			padding-top: @header-and-banner-height;
 		}


### PR DESCRIPTION
Saw someone again linking to the v8 docs today and thought a slightly more aggressive banner is appropriate, especially with v11 coming up.

This simply makes the warning banner sticky and places it below the header while the user scrolls the page. Hopefully this should catch users following outdated links to where the warning might not be immediately visible, [like here](https://preactjs.com/guide/v8/differences-to-react/#whats-included).

Before             |  After
:-------------------------:|:-------------------------:
![w/out sticky banner](https://user-images.githubusercontent.com/33403762/182754743-bd9d977e-3626-4a19-94d3-728bf131efc4.png)  |  ![w/ sticky banner](https://user-images.githubusercontent.com/33403762/182754773-ffe11073-95dc-40a6-923c-a79c1e82f771.png)
