### PR TITLE
refactor: Adds a hover effect to the sidebar nav

### DIFF
--- a/src/components/controllers/page/sidebar-nav.module.less
+++ b/src/components/controllers/page/sidebar-nav.module.less
@@ -22,6 +22,10 @@
 	transition: font-weight 0.3s;
 	color: var(--color-sidebar-link);
 
+	&:hover {
+		background-color: fade(@color-brand, 50%);
+	}
+
 	&::before {
 		.fadeOut;
 		content: '';


### PR DESCRIPTION
Wasn't able to add this as a comment to the other PR in time, was putzing around with colors.

I really, really like the changes! However, with the tighter spacing in the sidebar I feel like a hover effect would improve the experience a bit. I found it a bit harder to discern which link I was hovering over compared to the old style.

Certainly can tweak colors. This is just the brand @ 50% opacity.

![temp](https://user-images.githubusercontent.com/33403762/187787970-ed4a2420-7bb8-4a94-8fa5-ad9807278ecd.png)

