### PR TITLE
refactor: Disable pointer cursor for sidebar category labels

### DIFF
--- a/src/components/controllers/page/sidebar-nav.module.less
+++ b/src/components/controllers/page/sidebar-nav.module.less
@@ -52,7 +52,6 @@
 	padding: 1rem 0 0.25rem 0;
 	width: 100%;
 	text-align: left;
-	cursor: pointer;
 	font-size: 1rem;
 	display: flex;
 	justify-content: space-between;


### PR DESCRIPTION
If one were to hover over category labels like "Introduction", "Essentials", "Debug & Test", etc. in the sidebar they'd get a pointer cursor despite these not being links or having any interactive mechanics. They're just plain labels, so default cursor is the correct state.