### PR TITLE
Opt-in into repl instead of always on

### DIFF
--- a/content/en/guide/v10/api-reference.md
+++ b/content/en/guide/v10/api-reference.md
@@ -53,6 +53,7 @@ To learn more about components and how they can be used, check out the [Componen
 Render a Virtual DOM Element into a parent DOM element `containerNode`. Does not return anything.
 
 ```jsx
+// --repl
 // DOM tree before render:
 // <div id="container"></div>
 
@@ -115,6 +116,7 @@ render(<App />, rootElement); // success
 If you've already pre-rendered or server-side-rendered your application to HTML, Preact can bypass most rendering work when loading in the browser. This can be enabled by switching from `render()` to `hydrate()`, which skips most diffing while still attaching event listeners and setting up your component tree. This works only when used in conjunction with [pre-rendering](/cli/pre-rendering) or [Server-Side Rendering](/guide/v10/server-side-rendering).
 
 ```jsx
+// --repl
 import { hydrate } from 'preact';
 
 const Foo = () => <div>foo</div>;
@@ -213,6 +215,7 @@ A special kind of component that can have children, but is not rendered as a DOM
 Fragments make it possible to return multiple sibling children without needing to wrap them in a DOM container:
 
 ```jsx
+// --repl
 import { Fragment, render } from 'preact';
 
 render(

--- a/content/en/guide/v10/components.md
+++ b/content/en/guide/v10/components.md
@@ -21,6 +21,9 @@ Functional components are plain functions that receive `props` as the first argu
 
 ```jsx
 // --repl
+import { render } from 'preact';
+
+// --repl-before
 function MyComponent(props) {
   return <div>My name is {props.name}.</div>;
 }

--- a/content/en/guide/v10/components.md
+++ b/content/en/guide/v10/components.md
@@ -45,6 +45,9 @@ Here we have a simple class component called `<Clock>` that displays the current
 
 ```jsx
 // --repl
+import { Component, render } from 'preact';
+
+// --repl-before
 class Clock extends Component {
 
   constructor() {
@@ -71,6 +74,8 @@ class Clock extends Component {
     return <span>{time}</span>;
   }
 }
+// --repl-after
+render(<Clock />, document.getElementById('app'));
 ```
 
 ### Lifecycle Methods
@@ -99,6 +104,8 @@ When an error is caught, we can use this lifecycle to react to any errors and di
 
 ```jsx
 // --repl
+import { Component, render } from 'preact';
+// --repl-before
 class Catcher extends Component {
   
   constructor() {
@@ -117,6 +124,8 @@ class Catcher extends Component {
     return props.children;
   }
 }
+// --repl-after
+render(<Catcher />, document.getElementById('app'));
 ```
 
 ## Fragments

--- a/content/en/guide/v10/components.md
+++ b/content/en/guide/v10/components.md
@@ -20,6 +20,7 @@ There are two kinds of components in Preact, which we'll talk about in this guid
 Functional components are plain functions that receive `props` as the first argument. The function name **must** start with an uppercase letter in order for them to work in JSX.
 
 ```jsx
+// --repl
 function MyComponent(props) {
   return <div>My name is {props.name}.</div>;
 }
@@ -40,6 +41,7 @@ Class components can have state and lifecycle methods. The latter are special me
 Here we have a simple class component called `<Clock>` that displays the current time:
 
 ```jsx
+// --repl
 class Clock extends Component {
 
   constructor() {
@@ -93,6 +95,7 @@ There is one lifecycle method that deserves a special recognition and that is `c
 When an error is caught, we can use this lifecycle to react to any errors and display a nice error message or any other fallback content.
 
 ```jsx
+// --repl
 class Catcher extends Component {
   
   constructor() {
@@ -118,6 +121,7 @@ class Catcher extends Component {
 A `Fragment` allows you to return multiple elements at once. They solve the limitation of JSX where every "block" must have a single root element. You'll often encounter them in combination with lists, tables or with CSS flexbox where any intermediate element would otherwise affect styling.
 
 ```jsx
+// --repl
 import { Fragment, render } from 'preact';
 
 function TodoItems() {

--- a/content/en/guide/v10/context.md
+++ b/content/en/guide/v10/context.md
@@ -20,6 +20,11 @@ There are two different ways to use context: Via the newer `createContext` API a
 First we need to create a context object we can pass around. This is done via the `createContext(initialValue)` function. It returns a `Provider` component that is used to set the context value and a `Consumer` one which retrieves the value from the context.
 
 ```jsx
+// --repl
+import { render, createContext } from 'preact';
+
+const SomeComponent = props => props.children;
+// --repl-before
 const Theme = createContext('light');
 
 function ThemedButton(props) {
@@ -41,6 +46,8 @@ function App() {
     </Theme.Provider>
   );
 }
+// --repl-after
+render(<App />, document.getElementById("app"));
 ```
 
 > An easier way to use context is via the [useContext](/guide/v10/hooks#usecontext) hook.
@@ -52,11 +59,16 @@ We include the legacy API mainly for backwards-compatibility reasons. It has bee
 To pass down a custom variable through the context, a component needs to have the `getChildContext` method. There you return the new values you want to store in the context. The context can be accessed via the second argument in function components or `this.context` in a class-based component.
 
 ```jsx
+// --repl
+import { render } from 'preact';
+
+const SomeOtherComponent = props => props.children;
+// --repl-before
 function ThemedButton(props, context) {
   return (
     <button {...props} class={'btn ' + context.theme}>
       Themed Button
-    </button>;
+    </button>
   );
 }
 
@@ -77,4 +89,6 @@ class App extends Component {
     );
   }
 }
+// --repl-after
+render(<App />, document.getElementById("app"));
 ```

--- a/content/en/guide/v10/forms.md
+++ b/content/en/guide/v10/forms.md
@@ -38,6 +38,9 @@ Generally, you should try to use _Controlled_ Components at all times.  However,
 Let's create a simple form to submit todo items. For this we create a `<form>`-Element and bind an event handler that is called whenever the form is submitted. We do a similar thing for the text input field, but note that we are storing the value in our class ourselves. You guessed it, we're using a _controlled_ input here. In this example it's very useful, because we need to display the input's value in another element.
 
 ```jsx
+// --repl
+import { render, Component } from "preact";
+// --repl-before
 class TodoForm extends Component {
   state = { value: '' };
 
@@ -61,6 +64,8 @@ class TodoForm extends Component {
     );
   }
 }
+// --repl-after
+render(<TodoForm />, document.getElementById("app"));
 ```
 
 ## Select Input
@@ -68,6 +73,10 @@ class TodoForm extends Component {
 A `<select>`-Element is a little more involved, but works similar to all other form controls:
 
 ```jsx
+// --repl
+import { render, Component } from "preact";
+
+// --repl-before
 class MySelect extends Component {
   state = { value: '' };
 
@@ -93,6 +102,8 @@ class MySelect extends Component {
     );
   }
 }
+// --repl-after
+render(<MySelect />, document.getElementById("app"));
 ```
 
 ## Checkboxes & Radio Buttons
@@ -106,6 +117,9 @@ So, instead of listening for a `input` event we should listen for a `click` even
 ### Checkbox Example
 
 ```jsx
+// --repl
+import { render, Component } from "preact";
+// --repl-before
 class MyForm extends Component {
   toggle = e => {
       let checked = !this.state.checked;
@@ -120,8 +134,11 @@ class MyForm extends Component {
           checked={checked}
           onClick={this.toggle}
         />
+        check this box
       </label>
     );
   }
 }
+// --repl-after
+render(<MyForm />, document.getElementById("app"));
 ```

--- a/content/en/guide/v10/hooks.md
+++ b/content/en/guide/v10/hooks.md
@@ -26,6 +26,9 @@ The easiest way to understand hooks is to compare them to equivalent class-based
 We'll use a simple counter component as our example, which renders a number and a button that increases it by one:
 
 ```jsx
+// --repl
+import { render, Component } from "preact";
+// --repl-before
 class Counter extends Component {
   state = {
     value: 0
@@ -38,17 +41,23 @@ class Counter extends Component {
   render(props, state) {
     return (
       <div>
-        Counter: {state.value}
+        <p>Counter: {state.value}</p>
         <button onClick={this.increment}>Increment</button>
       </div>
     );
   }
 }
+// --repl-after
+render(<Counter />, document.getElementById("app"));
 ```
 
 Now, here's an equivalent function component built with hooks:
 
 ```jsx
+// --repl
+import { useState, useCallback } from "preact/hooks";
+import { render } from "preact";
+// --repl-before
 function Counter() {
   const [value, setValue] = useState(0);
   const increment = useCallback(() => {
@@ -57,11 +66,13 @@ function Counter() {
 
   return (
     <div>
-      Counter: {value}
+      <p>Counter: {value}</p>
       <button onClick={increment}>Increment</button>
     </div>
   );
 }
+// --repl-after
+render(<Counter />, document.getElementById("app"));
 ```
 
 At this point they seem pretty similar, however we can further simplify the hooks version.
@@ -69,6 +80,10 @@ At this point they seem pretty similar, however we can further simplify the hook
 Let's extract the counter logic into a custom hook, making it easily reusable across components:
 
 ```jsx
+// --repl
+import { useState, useCallback } from "preact/hooks";
+import { render } from "preact";
+// --repl-before
 function useCounter() {
   const [value, setValue] = useState(0);
   const increment = useCallback(() => {
@@ -82,7 +97,7 @@ function CounterA() {
   const { value, increment } = useCounter();
   return (
     <div>
-      Counter A: {value}
+      <p>Counter A: {value}</p>
       <button onClick={increment}>Increment</button>
     </div>
   );
@@ -99,6 +114,14 @@ function CounterB() {
     </div>
   );
 }
+// --repl-after
+render(
+  <div>
+    <CounterA />
+    <CounterB />
+  </div>,
+  document.getElementById("app")
+);
 ```
 
 Note that both `CounterA` and `CounterB` are completely independent of each other. They both use the `useCounter()` custom hook, but each has its own instance of that hook's associated state.
@@ -148,7 +171,9 @@ When you call the setter and the state is different, it will trigger
 a rerender starting from the component where that useState has been used.
 
 ```jsx
-import { h } from 'preact';
+// --repl
+import { render } from 'preact';
+// --repl-before
 import { useState } from 'preact/hooks';
 
 const Counter = () => {
@@ -165,6 +190,8 @@ const Counter = () => {
     </div>
   )
 }
+// --repl-after
+render(<Counter />, document.getElementById("app"));
 ```
 
 > When our initial state is expensive it's better to pass a function instead of a value.
@@ -174,6 +201,11 @@ const Counter = () => {
 The `useReducer` hook has a close resemblance to [redux](https://redux.js.org/). Compared to [useState](#usestate) it's easier to use when you have complex state logic where the next state depends on the previous one.
 
 ```jsx
+// --repl
+import { render } from 'preact';
+// --repl-before
+import { useReducer } from 'preact/hooks';
+
 const initialState = 0;
 const reducer = (state, action) => {
   switch (action) {
@@ -197,6 +229,8 @@ function Counter() {
     </div>
   );
 }
+// --repl-after
+render(<Counter />, document.getElementById("app"));
 ```
 
 ## Memoization
@@ -236,6 +270,10 @@ const onClick = useCallback(
 To get a reference to a DOM node inside a functional components there is the `useRef` hook. It works similar to [createRef](/guide/v10/refs#createrefs).
 
 ```jsx
+// --repl
+import { useRef } from 'preact/hooks';
+import { render } from 'preact';
+// --repl-before
 function Foo() {
   // Initialize useRef with an initial value of `null`
   const input = useRef(null);
@@ -248,6 +286,8 @@ function Foo() {
     </>
   );
 }
+// --repl-after
+render(<Foo />, document.getElementById("app"));
 ```
 
 > Be careful not to confuse `useRef` with `createRef`.
@@ -257,6 +297,12 @@ function Foo() {
 To access context in a functional component we can use the `useContext` hook, without any higher-order or wrapper components. The first argument must be the context object that's created from a `createContext` call.
 
 ```jsx
+// --repl
+import { render, createContext } from 'preact';
+import { useContext } from 'preact/hooks';
+
+const OtherComponent = props => props.children;
+// --repl-before
 const Theme = createContext('light');
 
 function DisplayTheme() {
@@ -274,6 +320,8 @@ function App() {
     </Theme.Provider>
   )
 }
+// --repl-after
+render(<Foo />, document.getElementById("app"));
 ```
 
 ## Side-Effects
@@ -310,6 +358,10 @@ The first argument to `useEffect` is an argument-less callback that triggers the
 But sometimes we have a more complex use case. Think of a component which needs to subscribe to some data when it mounts and needs to unsubscribe when it unmounts. This can be accomplished with `useEffect` too. To run any cleanup code we just need to return a function in our callback.
 
 ```jsx
+// --repl
+import { useState, useEffect } from 'preact/hooks';
+import { render } from 'preact';
+// --repl-before
 // Component that will always display the current window width
 function WindowWidth(props) {
   const [width, setWidth] = useState(0);
@@ -323,8 +375,10 @@ function WindowWidth(props) {
     return () => window.removeEventListener('resize', onResize);
   }, []);
 
-  return <div>Window width: {width}</div>;
+  return <p>Window width: {width}</p>;
 }
+// --repl-after
+render(<WindowWidth />, document.getElementById("app"));
 ```
 
 > The cleanup function is optional. If you don't need to run any cleanup code, you don't need to return anything in the callback that's passed to `useEffect`.

--- a/content/en/guide/v10/refs.md
+++ b/content/en/guide/v10/refs.md
@@ -20,6 +20,9 @@ A typical use case for it is measuring the actual size of a DOM node. While it's
 The `createRef` function will return a plain object with just one property: `current`. Whenever the `render` method is called, Preact will assign the DOM node or component to `current`.
 
 ```jsx
+// --repl
+import { render, Component, createRef } from "preact";
+// --repl-before
 class Foo extends Component {
   ref = createRef();
 
@@ -32,6 +35,8 @@ class Foo extends Component {
     return <div ref={this.ref}>foo</div>
   }
 }
+// --repl-after
+render(<Foo />, document.getElementById("app"));
 ```
 
 ## Callback Refs
@@ -39,6 +44,9 @@ class Foo extends Component {
 Another way to get the reference to an element can be done by passing a function callback. It's a little more to type, but it works in a similar fashion as `createRef`.
 
 ```jsx
+// --repl
+import { render, Component } from "preact";
+// --repl-before
 class Foo extends Component {
   ref = null;
   setRef = (dom) => this.ref = dom;
@@ -52,6 +60,8 @@ class Foo extends Component {
     return <div ref={this.setRef}>foo</div>
   }
 }
+// --repl-after
+render(<Foo />, document.getElementById("app"));
 ```
 
 > If the ref callback is defined as an inline function it will be called twice. Once with `null` and then with the actual reference. This is a common error and the `createRef` API makes this a little easier by forcing user to check if `ref.current` is defined.
@@ -77,6 +87,9 @@ class Foo extends Component {
 Measurement only makes sense once the `render` method has been called and the component is mounted into the DOM. Before that the DOM node won't exist and there wouldn't make much sense to try to measure it.
 
 ```jsx
+// --repl
+import { render, Component } from "preact";
+// --repl-before
 class Foo extends Component {
   state = {
     width: 0,
@@ -104,6 +117,8 @@ class Foo extends Component {
     );
   }
 }
+// --repl-after
+render(<Foo />, document.getElementById("app"));
 ```
 
 That's it! Now the component will always display the width and height when it's mounted.

--- a/content/en/guide/v10/tutorial.md
+++ b/content/en/guide/v10/tutorial.md
@@ -30,10 +30,11 @@ const App = h('h1', null, 'Hello World');
 This alone doesn't do anything and we need a way to inject our Hello-World app into the DOM. For this we use the `render()` function.
 
 ```jsx
+// --repl
 const App = <h1>Hello World!</h1>;
 
 // Inject our app into the DOM
-render(App, document.body);
+render(App, document.getElementById("app"));
 ```
 
 Congratulations, you've build your first Preact app!
@@ -47,6 +48,7 @@ Our end goal is that we have an app where the user can enter a name and display 
 So let's turn our existing App into a [Components](/guide/v10/components):
 
 ```jsx
+// --repl
 import { h, render, Component } from 'preact';
 
 class App extends Component {
@@ -55,12 +57,13 @@ class App extends Component {
   }
 }
 
-render(<App />, document.body);
+render(<App />, document.getElementById("app"));
 ```
 
 You'll notice that we added a new `Component` import at the top and that we turned `App` into a class. This alone isn't useful but it's the precursor for what we're going to do next. To make things a little more exciting we'll add a form with a text input and a submit button.
 
 ```jsx
+// --repl
 import { h, render, Component } from 'preact';
 
 class App extends Component {
@@ -77,7 +80,7 @@ class App extends Component {
   }
 }
 
-render(<App />, document.body);
+render(<App />, document.getElementById("app"));
 ```
 
 Now we're talking! It's starting to look like a real app! We still need to make it interactive though. Remember that we'll want to change `"Hello world!"` to `"Hello, [userinput]!"`, so we need a way to know the current input value.
@@ -87,6 +90,7 @@ We'll store it in a special property called `state` of our Component. It's speci
 Lastly we need to attach the new state to our input by setting `value` and attaching an event handler to the `input` event.
 
 ```jsx
+// --repl
 import { h, render, Component } from 'preact';
 
 class App extends Component {
@@ -112,7 +116,7 @@ class App extends Component {
   }
 }
 
-render(<App />, document.body);
+render(<App />, document.getElementById("app"));
 ```
 
 At this point the app shouldn't have changed much from a users point of view, but we'll bring all the pieces together in our next step.
@@ -120,6 +124,7 @@ At this point the app shouldn't have changed much from a users point of view, bu
 We'll add a handler to the `submit` event of our `<form>` in similar fashion like we just did for the input. The difference is that it writes into a different property of our `state` called `name`. Then we swap out our heading and insert our `state.name` value there.
 
 ```jsx
+// --repl
 import { h, render, Component } from 'preact';
 
 class App extends Component {
@@ -151,7 +156,7 @@ class App extends Component {
   }
 }
 
-render(<App />, document.body);
+render(<App />, document.getElementById("app"));
 ```
 
 Boom! We're done! We can now enter a custom name, click "Update" and our new name appears in our heading.
@@ -161,6 +166,7 @@ Boom! We're done! We can now enter a custom name, click "Update" and our new nam
 We wrote our first component, so let's get a little more practice. This time we build a clock.
 
 ```jsx
+// --repl
 import { h, render, Component } from 'preact';
 
 class Clock extends Component {
@@ -170,7 +176,7 @@ class Clock extends Component {
   }
 }
 
-render(<Clock />, document.body);
+render(<Clock />, document.getElementById("app"));
 ```
 
 Ok, that was easy enough! Problem is, that the time doesn't change. It's frozen at the moment we rendered our clock component.
@@ -178,6 +184,7 @@ Ok, that was easy enough! Problem is, that the time doesn't change. It's frozen 
 So, we want to have a 1-second timer start once the Component gets added to the DOM, and stop if it is removed. We'll create the timer and store a reference to it in `componentDidMount`, and stop the timer in `componentWillUnmount`. On each timer tick, we'll update the component's `state` object with a new time value. Doing this will automatically re-render the component.
 
 ```jsx
+// --repl
 import { h, render, Component } from 'preact';
 
 class Clock extends Component {
@@ -203,7 +210,7 @@ class Clock extends Component {
   }
 }
 
-render(<Clock />, document.body);
+render(<Clock />, document.getElementById("app"));
 ```
 
 And we did it again! Now we have [a ticking clock](http://jsfiddle.net/developit/u9m5x0L7/embedded/result,js/)!

--- a/content/en/guide/v10/whats-new.md
+++ b/content/en/guide/v10/whats-new.md
@@ -22,6 +22,7 @@ In a nutshell Preact X is what we always wanted Preact to be: A tiny, fast and f
 [Fragment docs →](/guide/v10/components#fragments)
 
 ```jsx
+// --repl
 function Foo() {
   return (
     <>
@@ -39,6 +40,7 @@ We all wish errors wouldn't happen in our applications, but sometimes they do. W
 [Lifecycle docs →](/guide/v10/components#componentdidcatch)
 
 ```jsx
+// --repl
 class Catcher extends Component {
   state = { errored: false }
 
@@ -62,6 +64,7 @@ class Catcher extends Component {
 [Hooks Docs →](/guide/v10/hooks)
 
 ```jsx
+// --repl
 function Counter() {
   const [value, setValue] = useState(0);
   const increment = useCallback(() => setValue(value + 1), [value]);

--- a/content/en/tutorial/01-vdom.md
+++ b/content/en/tutorial/01-vdom.md
@@ -185,25 +185,29 @@ useResult(function(result) {
 
 
 ```jsx:repl-initial
-import { createElement } from 'preact';
+import { render } from 'preact';
 
-export default function App() {
+function App() {
   return (
     <p class="big">Hello World!</p>
   )
 }
+
+render(<App />, document.getElementById("app"));
 ```
 
 ```jsx:repl-final
-import { createElement } from 'preact';
+import { render } from 'preact';
 
-export default function App() {
+function App() {
   return (
     <p class="big" style={{ color: 'purple' }}>
       Hello <em>World</em>!
     </p>
   )
 }
+
+render(<App />, document.getElementById("app"));
 ```
 
 [JSX]: https://en.wikipedia.org/wiki/JSX_(JavaScript)

--- a/content/en/tutorial/02-events.md
+++ b/content/en/tutorial/02-events.md
@@ -72,7 +72,9 @@ useRealm(function (realm) {
 
 
 ```jsx:repl-initial
-export default function App() {
+import { render } from "preact";
+
+function App() {
   return (
     <div>
       <p class="count">Count:</p>
@@ -80,10 +82,14 @@ export default function App() {
     </div>
   )
 }
+
+render(<App />, document.getElementById("app"));
 ```
 
 ```jsx:repl-final
-export default function App() {
+import { render } from "preact";
+
+function App() {
   const clicked = () => {
     console.log('hi')
   }
@@ -95,6 +101,8 @@ export default function App() {
     </div>
   )
 }
+
+render(<App />, document.getElementById("app"));
 ```
 
 [MDN]: https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Events

--- a/content/en/tutorial/03-components.md
+++ b/content/en/tutorial/03-components.md
@@ -283,11 +283,13 @@ useRealm(function (realm) {
 
 
 ```jsx:repl-initial
+import { render } from "preact";
+
 function MyButton(props) {
   // start here!
 }
 
-export default function App() {
+function App() {
   const clicked = () => {
     console.log('Hello!')
   }
@@ -299,14 +301,18 @@ export default function App() {
     </div>
   )
 }
+
+render(<App />, document.getElementById("app"));
 ```
 
 ```jsx:repl-final
+import { render } from "preact";
+
 function MyButton(props) {
   return <button style={props.style} onClick={props.onClick}>{props.children}</button>
 }
 
-export default function App() {
+function App() {
   const clicked = () => {
     console.log('Hello!')
   }
@@ -318,6 +324,8 @@ export default function App() {
     </div>
   )
 }
+
+render(<App />, document.getElementById("app"));
 ```
 
 [ternary]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Conditional_Operator

--- a/content/en/tutorial/04-state.md
+++ b/content/en/tutorial/04-state.md
@@ -25,8 +25,6 @@ can call `this.setState()` to update its `state` property and request that
 it be re-rendered by Preact.
 
 ```jsx
-import { Component } from 'preact'
-
 class MyButton extends Component {
   state = { clicked: false }
 
@@ -175,11 +173,14 @@ useResult(function () {
 
 
 ```jsx:repl-initial
+import { render } from 'preact';
+import { useState } from 'preact/hooks';
+
 function MyButton(props) {
   return <button style={props.style} onClick={props.onClick}>{props.children}</button>
 }
 
-export default function App() {
+function App() {
   const clicked = () => {
     // increment count by 1 here
   }
@@ -191,14 +192,19 @@ export default function App() {
     </div>
   )
 }
+
+render(<App />, document.getElementById("app"));
 ```
 
 ```jsx:repl-final
+import { render } from 'preact';
+import { useState } from 'preact/hooks';
+
 function MyButton(props) {
   return <button style={props.style} onClick={props.onClick}>{props.children}</button>
 }
 
-export default function App() {
+function App() {
   const [count, setCount] = useState(0)
 
   const clicked = () => {
@@ -212,6 +218,8 @@ export default function App() {
     </div>
   )
 }
+
+render(<App />, document.getElementById("app"));
 ```
 
 [ternary]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Conditional_Operator

--- a/content/en/tutorial/05-refs.md
+++ b/content/en/tutorial/05-refs.md
@@ -167,9 +167,10 @@ useResult(function (result) {
 
 
 ```jsx:repl-initial
+import { render } from 'preact';
 import { useRef } from 'preact/hooks';
 
-export default function App() {
+function App() {
   function onClick() {
 
   }
@@ -181,12 +182,15 @@ export default function App() {
     </div>
   );
 }
+
+render(<App />, document.getElementById("app"));
 ```
 
 ```jsx:repl-final
+import { render } from 'preact';
 import { useRef } from 'preact/hooks';
 
-export default function App() {
+function App() {
   const input = useRef();
 
   function onClick() {
@@ -200,4 +204,6 @@ export default function App() {
     </div>
   );
 }
+
+render(<App />, document.getElementById("app"));
 ```

--- a/content/en/tutorial/06-context.md
+++ b/content/en/tutorial/06-context.md
@@ -318,8 +318,8 @@ useResult(function (result) {
 
 
 ```jsx:repl-initial
-import { createContext } from 'preact';
-import { useState, useContext } from 'preact/hooks';
+import { render, createContext } from 'preact';
+import { useState, useContext, useMemo } from 'preact/hooks';
 
 const CounterContext = createContext(null);
 
@@ -332,7 +332,7 @@ function Counter() {
   );
 }
 
-export default function App() {
+function App() {
   const [count, setCount] = useState(0);
 
   return (
@@ -343,11 +343,13 @@ export default function App() {
     </div>
   )
 }
+
+render(<App />, document.getElementById("app"));
 ```
 
 ```jsx:repl-final
-import { createContext } from 'preact';
-import { useState, useContext } from 'preact/hooks';
+import { render, createContext } from 'preact';
+import { useState, useContext, useMemo } from 'preact/hooks';
 
 const CounterContext = createContext(null);
 
@@ -362,7 +364,7 @@ function Counter() {
   );
 }
 
-export default function App() {
+function App() {
   const [count, setCount] = useState(0);
 
   function increment() {
@@ -383,4 +385,6 @@ export default function App() {
     </CounterContext.Provider>
   )
 }
+
+render(<App />, document.getElementById("app"));
 ```

--- a/content/en/tutorial/07-side-effects.md
+++ b/content/en/tutorial/07-side-effects.md
@@ -150,9 +150,10 @@ useRealm(function (realm) {
 
 
 ```jsx:repl-initial
+import { render } from 'preact';
 import { useEffect, useState } from 'preact/hooks';
 
-export default function App() {
+function App() {
   const [count, setCount] = useState(0);
 
   useEffect(() => {
@@ -162,12 +163,15 @@ export default function App() {
 
   return <button onClick={() => setCount(count+1)}>{count}</button>
 }
+
+render(<App />, document.getElementById("app"));
 ```
 
 ```jsx:repl-final
+import { render } from 'preact';
 import { useEffect, useState } from 'preact/hooks';
 
-export default function App() {
+function App() {
   const [count, setCount] = useState(0);
 
   useEffect(() => {
@@ -177,6 +181,8 @@ export default function App() {
 
   return <button onClick={() => setCount(count+1)}>{count}</button>
 }
+
+render(<App />, document.getElementById("app"));
 ```
 
 [lifecycle methods]: http://localhost:8080/guide/v10/components#lifecycle-methods

--- a/content/en/tutorial/08-keys.md
+++ b/content/en/tutorial/08-keys.md
@@ -317,6 +317,9 @@ useResult(function (result) {
 
 
 ```jsx:repl-initial
+import { render } from 'preact';
+import { useState, useEffect } from 'preact/hooks';
+
 const wait = ms => new Promise(r => setTimeout(r, ms))
 
 const getTodos = async () => {
@@ -327,7 +330,7 @@ const getTodos = async () => {
   ]
 }
 
-export default function TodoList() {
+function TodoList() {
   const [todos, setTodos] = useState([])
 
   return (
@@ -335,9 +338,14 @@ export default function TodoList() {
     </ul>
   )
 }
+
+render(<TodoList />, document.getElementById("app"));
 ```
 
 ```jsx:repl-final
+import { render } from 'preact';
+import { useState, useEffect } from 'preact/hooks';
+
 const wait = ms => new Promise(r => setTimeout(r, ms))
 
 const getTodos = async () => {
@@ -348,7 +356,7 @@ const getTodos = async () => {
   ]
 }
 
-export default function TodoList() {
+function TodoList() {
   const [todos, setTodos] = useState([])
 
   useEffect(() => {
@@ -367,4 +375,6 @@ export default function TodoList() {
     </ul>
   )
 }
+
+render(<TodoList />, document.getElementById("app"));
 ```

--- a/content/en/tutorial/09-error-handling.md
+++ b/content/en/tutorial/09-error-handling.md
@@ -110,7 +110,7 @@ useResult(function(result) {
 
 
 ```jsx:repl-initial
-import { Component } from 'preact';
+import { render, Component } from 'preact';
 import { useState } from 'preact/hooks';
 
 function Clicker() {
@@ -130,10 +130,12 @@ class App extends Component {
     return <Clicker />;
   }
 }
+
+render(<App />, document.getElementById("app"));
 ```
 
 ```jsx:repl-final
-import { Component } from 'preact';
+import { render, Component } from 'preact';
 import { useState } from 'preact/hooks';
 
 function Clicker() {
@@ -161,4 +163,6 @@ class App extends Component {
     return <Clicker />;
   }
 }
+
+render(<App />, document.getElementById("app"));
 ```

--- a/content/en/tutorial/10-links.md
+++ b/content/en/tutorial/10-links.md
@@ -23,6 +23,7 @@ Feel free to play around a bit more with the demo code.
 
 
 ```jsx:repl-initial
+import { render } from 'preact';
 import { useState, useEffect } from 'preact/hooks'
 
 const getTodos = async () => {
@@ -36,7 +37,7 @@ const getTodos = async () => {
   }
 }
 
-export default function ToDos() {
+function ToDos() {
   const [todos, setTodos] = useState([])
 
   useEffect(() => {
@@ -95,4 +96,6 @@ export default function ToDos() {
     </div>
   )
 }
+
+render(<ToDos />, document.getElementById("app"));
 ```

--- a/src/components/code-block/index.js
+++ b/src/components/code-block/index.js
@@ -58,15 +58,47 @@ function cachedHighlight(code, lang) {
 }
 
 function HighlightedCodeBlock({ code, lang, ...props }) {
+	let repl = false;
+	let source = code;
+	if (code.startsWith('// --repl')) {
+		repl = true;
+		const idx = code.indexOf('\n');
+		if (idx > -1) {
+			code = code.slice(idx + 1);
+			source = source.slice(idx + 1);
+		}
+
+		const beforeMarker = '// --repl-before';
+		const beforeIdx = code.indexOf(beforeMarker);
+		if (beforeIdx > -1) {
+			const pos = beforeIdx + beforeMarker.length + 1;
+			code = code.slice(pos);
+			// Only replace comment line with newline in source
+			source = source.slice(0, beforeIdx) + '\n' + source.slice(pos);
+		}
+
+		const afterMarker = '// --repl-after';
+		const afterIdx = code.indexOf(afterMarker);
+		if (afterIdx > -1) {
+			code = code.slice(0, afterIdx);
+
+			// Only replace comment line with newline in source
+			// ATTENTION: We cannot reuse the index from `code`
+			// as the content and thereby offsets are different
+			const sourceAfterIdx = source.indexOf(afterMarker);
+			source =
+				source.slice(0, sourceAfterIdx) +
+				'\n' +
+				source.slice(sourceAfterIdx + afterMarker.length + 1) +
+				'\n';
+		}
+	}
+
 	const [highlighted, error, pending] = useFuture(
 		() => cachedHighlight(code, lang),
 		[code, lang]
 	);
-	const repl =
-		(lang === 'js' || lang === 'jsx') &&
-		code.split('\n').length > 2 &&
-		props.repl !== 'false' &&
-		props.repl !== false;
+
 	const canHighlight = !!pending || !error;
 	const html =
 		(canHighlight && highlighted) ||
@@ -79,7 +111,10 @@ function HighlightedCodeBlock({ code, lang, ...props }) {
 				<code class={`language-${lang}`} dangerouslySetInnerHTML={htmlObj} />
 			</pre>
 			{repl && (
-				<Link class="repl-link" href={`/repl?code=${encodeURIComponent(code)}`}>
+				<Link
+					class="repl-link"
+					href={`/repl?code=${encodeURIComponent(source)}`}
+				>
 					Run in REPL
 				</Link>
 			)}

--- a/src/components/controllers/repl/repl.worker.js
+++ b/src/components/controllers/repl/repl.worker.js
@@ -4,10 +4,7 @@ import { parseStackTrace } from './errors';
 
 const PREPEND = `(function(module,exports,require,fetch){`;
 
-const IMPORTS = `\
-import {render,hydrate,h,createElement,Fragment,createRef,Component,cloneElement,createContext,toChildArray,options} from 'preact';\
-import {useState,useReducer,useEffect,useLayoutEffect,useRef,useImperativeHandle,useMemo,useCallback,useContext,useDebugValue} from 'preact/hooks';
-`;
+const IMPORTS = `import {h} from 'preact';`;
 
 export function ping() {
 	return true;

--- a/src/components/controllers/tutorial/index.js
+++ b/src/components/controllers/tutorial/index.js
@@ -140,6 +140,10 @@ export default class Tutorial extends Component {
 		this.setState({ code: solution });
 	};
 
+	clearError = () => {
+		this.setState({ error: null });
+	};
+
 	render({ route, step }, { loading, code, error }) {
 		const state = {
 			route,
@@ -152,7 +156,7 @@ export default class Tutorial extends Component {
 		};
 		return (
 			<TutorialContext.Provider value={this}>
-				<TutorialView {...state} />
+				<TutorialView {...state} clearError={this.clearError} />
 			</TutorialContext.Provider>
 		);
 	}
@@ -165,7 +169,8 @@ function TutorialView({
 	code,
 	error,
 	Runner,
-	CodeEditor
+	CodeEditor,
+	clearError
 }) {
 	const content = useRef();
 
@@ -234,18 +239,23 @@ function TutorialView({
 											clear
 										/>
 									)}
-									{error && [
-										<ErrorOverlay
-											key={'e:' + fullPath}
-											class={style.error}
-											name={error.name}
-											message={error.message}
-											stack={parseStackTrace(error)}
-										/>,
-										<button class={style.rerun} onClick={reRun}>
-											Re-run
-										</button>
-									]}
+									{error && (
+										<div class={style.errorOverlayWrapper}>
+											<button class={style.close} onClick={clearError}>
+												close
+											</button>
+											<ErrorOverlay
+												key={'e:' + fullPath}
+												class={style.error}
+												name={error.name}
+												message={error.message}
+												stack={parseStackTrace(error)}
+											/>
+											<button class={style.rerun} onClick={reRun}>
+												Re-run
+											</button>
+										</div>
+									)}
 								</div>
 								{hasCode && (
 									<button
@@ -387,8 +397,8 @@ function TutorialCodeBlock(props) {
 	// Block Type: ```jsx:repl-initial  /  ```jsx:repl-final
 	const repl = cl.match(/repl-(initial|final)/g);
 	if (repl) {
-		tutorial.setState({ [repl[0]]: code });
-		if (repl[0] === 'repl-initial') tutorial.setState({ code });
+		tutorial.setState({ [repl[0]]: code + '\n' });
+		if (repl[0] === 'repl-initial') tutorial.setState({ code: code + '\n' });
 		return null;
 	}
 

--- a/src/components/controllers/tutorial/style.module.less
+++ b/src/components/controllers/tutorial/style.module.less
@@ -1,5 +1,22 @@
 @import '~style/helpers';
 
+.errorOverlayWrapper {
+	position: absolute;
+	top: 0;
+	left: 0;
+	bottom: 0;
+	right: 0;
+	height: 100%;
+	display: flex;
+}
+
+.close {
+	position: absolute;
+	top: 1rem;
+	right: 1rem;
+	z-index: 10;
+}
+
 .tutorial {
 	position: absolute;
 	left: 0;


### PR DESCRIPTION
This PR changes the conditions on which we decide if we should add the `Run in REPL` link at the top right corner of a code snippet. Before this PR we'd always show it for every `js` or `jsx` code snippet, despite most of them being illustrative and not intended to be run. Basically, nearly all of our repl links were broken.

This PR changes that in that adding the repl link is an opt-in. It can be enabled by adding the `// --repl` comment in the first line.

```js
console.log("this code snippet WILL NOT have the 'Run in REPL' link");
```

vs

```js
// --repl
console.log("this code snippet WILL have the 'Run in REPL' link");
```

The `// --repl` comment is replaced by a new line when passed to the actual repl.

For most code snippets this is not enough though, since they require a little setup to be runable like adding imports. To do that, I've added two additional markers which are stripped for the snippet, but shown in the repl.

- `// --repl-before` - Code that is prepended before the code snippet
- `// --repl-after` - Code that is appended after the code snippet

With these features added we can also get rid of the magic "always call the first function" in repl, which caused me several infinite loops when playing around with our upcoming project in the repl.