### PR TITLE
fix: Correct signals example

### DIFF
--- a/content/en/guide/v10/signals.md
+++ b/content/en/guide/v10/signals.md
@@ -348,7 +348,7 @@ const surname = signal("Doe");
 const fullName = computed(() => `${name.value} ${surname.value}`);
 
 // Logs name every time it changes:
-effect(() => console.log(name.value));
+effect(() => console.log(fullName.value));
 // Logs: "Jane Doe"
 
 // Updating `name` updates `fullName`, which triggers the effect again:


### PR DESCRIPTION
Spotted by an eagle-eyed Twitter user: https://twitter.com/boris0crypto/status/1567231740015427586?s=20&t=HgVxE--d4uYMEwgkoqOwtA

Same thing was already corrected in `signals`'s readme: https://github.com/preactjs/signals/pull/69/files