### PR TITLE
fix: Formatting issue in FR docs and typo in PT-BR

### DIFF
--- a/content/fr/about/we-are-using.md
+++ b/content/fr/about/we-are-using.md
@@ -9,4 +9,6 @@ Vous trouverez ci-dessous un petit échantillon d'entreprises qui utilisent Prea
 
 Votre entreprise utilise Preact ? [Ajoutez-la à la liste !](https://github.com/preactjs/preact-www/blob/master/src/components/we-are-using/index.js)
 
-<we-are-using></we-are-using>
+<div class="breaker">
+  <we-are-using></we-are-using>
+</div>

--- a/content/pt-br/guide/v10/whats-new.md
+++ b/content/pt-br/guide/v10/whats-new.md
@@ -69,7 +69,7 @@ function Counter() {
   return (
     <div>
       Counter: {value}
-      <button onClick={increment}>Icrementar</button>
+      <button onClick={increment}>Incrementar</button>
     </div>
   );
 }


### PR DESCRIPTION
The French version of "Companies using Preact" was missing a wrapper resulting in the following UI:

![French translation of "Companies using Preact" page](https://user-images.githubusercontent.com/33403762/190841073-6650f459-0745-4479-8926-71382e0946a9.png)

---

Additionally, as I was grepping for something, I happened to notice a translation in the the Brazilian Portuguese docs that stood out to me. While I admittedly don't speak a word of Portuguese, 'incrementar' is used numerous times throughout other translated pages (like in the [pt-br 'Hooks' page translation](https://github.com/preactjs/preact-www/blob/master/content/pt-br/guide/v10/hooks.md)), so I think it's pretty safe to call 'icrementar' a simple typo.
