### PR TITLE
chore: Remove "in 10 minutes" portion of tutorial intro header

### DIFF
--- a/content/en/tutorial/index.md
+++ b/content/en/tutorial/index.md
@@ -1,7 +1,7 @@
 ---
 next: /tutorial/01-vdom
 nextText: 'Begin Tutorial'
-title: Learn Preact in 10 minutes
+title: Learn Preact
 code: false
 solvable: false
 ---


### PR DESCRIPTION
A very common piece of feeback is that the tutorial takes much longer than 10 minutes [[1](https://github.com/preactjs/preact-www/discussions/815)] and I've seen a few comments saying that the "in 10 minutes" gave them the wrong idea about the tutorial when starting it.

Some have spent nearly 10 minutes per page, others have skimmed and gotten through pretty quickly. so I've removed the time estimation altogether as I don't think we can really provide anything that's accurate for the wide audience that may go through it.