### PR TITLE
Change blog post meta to fit in one line

### DIFF
--- a/src/components/controllers/page/index.js
+++ b/src/components/controllers/page/index.js
@@ -186,39 +186,41 @@ export default function Page({ route, prev, next }, ctx) {
 					/>
 					{showTitle && (
 						<div class={style.pageTitle}>
-							{meta.date && (
-								<div class={style.time}>
-									<Time value={meta.date} />
-								</div>
-							)}
-							{Array.isArray(meta.authors) && meta.authors.length > 0 && (
-								<p style="margin: 0">
-									Written by:{' '}
-									<address class={style.authors}>
-										{meta.authors.map((author, i, arr) => {
-											const authorData = config.blogAuthors.find(
-												data => data.name === author
-											);
-											return (
-												<span key={author} class={style.author}>
-													{authorData ? (
-														<a
-															href={authorData.link}
-															target="_blank"
-															rel="noopener noreferrer"
-														>
-															{author}
-														</a>
-													) : (
-														<span>{author}</span>
-													)}
-													{i < arr.length - 1 ? ', ' : null}
-												</span>
-											);
-										})}
-									</address>
-								</p>
-							)}
+							<div>
+								{meta.date && <Time value={meta.date} />}
+								{Array.isArray(meta.authors) && meta.authors.length > 0 && (
+									<>
+										, written by{' '}
+										<address class={style.authors}>
+											{meta.authors.map((author, i, arr) => {
+												const authorData = config.blogAuthors.find(
+													data => data.name === author
+												);
+												return (
+													<span key={author} class={style.author}>
+														{authorData ? (
+															<a
+																href={authorData.link}
+																target="_blank"
+																rel="noopener noreferrer"
+															>
+																{author}
+															</a>
+														) : (
+															<span>{author}</span>
+														)}
+														{i < arr.length - 2
+															? ', '
+															: i === arr.length - 2
+															? ' and '
+															: null}
+													</span>
+												);
+											})}
+										</address>
+									</>
+								)}
+							</div>
 							<h1
 								class={cx(
 									style.title,

--- a/src/components/time/time.less
+++ b/src/components/time/time.less
@@ -1,4 +1,4 @@
 .time {
 	font-size: 1rem;
-	display: block;
+	display: inline-block;
 }


### PR DESCRIPTION
Kinda changed my mind on this. Originally, thought the 2 line version would look better. But looking at it again now I don't thing so anymore.

Before:

<img width="478" alt="Screenshot 2022-09-23 at 15 10 20" src="https://user-images.githubusercontent.com/1062408/191967670-e1048ac0-67fc-43cc-8b6d-b3084a69e89e.png">

After:

<img width="500" alt="Screenshot 2022-09-23 at 15 10 17" src="https://user-images.githubusercontent.com/1062408/191967693-2844d14c-34ec-4c3d-b3bf-9b1a52020dfd.png">
