### PR TITLE
docs: Clarify that signals + dom props != two-way data binding

### DIFF
--- a/content/en/blog/introducing-signals.md
+++ b/content/en/blog/introducing-signals.md
@@ -174,7 +174,7 @@ const count = signal(0);
 <p>Value: {count}</p>
  
 // … or even passing them as DOM properties:
-<input value={count} />
+<input value={count} onInput={...} />
 ```
 
 So yeah, we did that too. You can pass a signal directly into the JSX anywhere you'd normally use a string. The signal's value will be rendered as text, and it will automatically update itself when the signal changes. This also works for props.


### PR DESCRIPTION
There's been at least [one case of someone confusing this example for two-way data binding](https://twitter.com/rauschma/status/1576235509306695680). If we're showcasing a new reactivity library, it's not a stretch for a user to think that an omitted input handler is an unnecessary one, especially if they're looking at the code samples alone (we do say this is a rendering optimization in the text above, but that can be missed). Hopefully adding an `onInput` should be a clear signal (pun somewhat intended) that we're not supporting two-way data binding with signals.

Alternatively, we could add a comment but I felt that might not catch users who are quickly skimming.

Will PR signal's docs with whatever direction we go with here, as we have a very similar example in one of the readmes.