### PR TITLE
modify dead link "GlobalEventHandlers" in Differences to React page

### DIFF
--- a/content/en/guide/v10/differences-to-react.md
+++ b/content/en/guide/v10/differences-to-react.md
@@ -18,7 +18,7 @@ The reason Preact does not attempt to include every single feature of React is i
 
 ## Main differences
 
-The main difference between Preact and React is that Preact does not implement a synthetic event system for size and performance reasons. Preact uses the browser's standard `addEventListener` to register event handlers, which means event naming and behavior works the same in Preact as it does in plain JavaScript / DOM. See [GlobalEventHandlers] for a full list of DOM event handlers.
+The main difference between Preact and React is that Preact does not implement a synthetic event system for size and performance reasons. Preact uses the browser's standard `addEventListener` to register event handlers, which means event naming and behavior works the same in Preact as it does in plain JavaScript / DOM. See [MDN's Event Reference] for a full list of DOM event handlers.
 
 Standard browser events work very similarly to how events work in React, with a few small differences. In Preact:
 
@@ -218,4 +218,4 @@ A React-compatible `Children` API is available from `preact/compat` to make inte
 [Project Goals]: /about/project-goals
 [hyperscript]: https://github.com/dominictarr/hyperscript
 [preact/compat]: /guide/v10/switching-to-preact
-[GlobalEventHandlers]: https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers
+[MDN's Event Reference]: https://developer.mozilla.org/en-US/docs/Web/Events

--- a/content/ja/guide/v10/differences-to-react.md
+++ b/content/ja/guide/v10/differences-to-react.md
@@ -20,7 +20,7 @@ PreactがReactの機能をすべて含まない理由は**小さい**、**集中
 
 PreactとReactの主な違いはPreactには合成イベント(Synthetic Event)がないことです。
 Preactはイベント処理に内部でブラウザネイティブの`addEventListener`を使用しています。
-DOMイベントハンドラの完全なリストは[GlobalEventHandlers]を見てください。
+DOMイベントハンドラの完全なリストは[MDN's Event Reference]を見てください。
 
 ブラウザのイベントシステムは必要なすべての機能を満たしているので、Preactにとって合成イベントは意味がありません。
 合成イベントのようなカスタムイベントを完全に実装するとメンテナンスのオーバーヘッドが増加しAPIが複雑になってしまいます。
@@ -193,4 +193,4 @@ function App(props) {
 [Projectの目的]: /about/project-goals
 [hyperscript]: https://github.com/dominictarr/hyperscript
 [preact/compat]: /guide/v10/switching-to-preact
-[GlobalEventHandlers]: https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers
+[MDN's Event Reference]: https://developer.mozilla.org/en-US/docs/Web/Events

--- a/content/ja/guide/v10/differences-to-react.md
+++ b/content/ja/guide/v10/differences-to-react.md
@@ -193,4 +193,4 @@ function App(props) {
 [Projectの目的]: /about/project-goals
 [hyperscript]: https://github.com/dominictarr/hyperscript
 [preact/compat]: /guide/v10/switching-to-preact
-[MDN's Event Reference]: https://developer.mozilla.org/en-US/docs/Web/Events
+[MDN's Event Reference]: https://developer.mozilla.org/ja/docs/Web/Events

--- a/content/kr/guide/v10/differences-to-react.md
+++ b/content/kr/guide/v10/differences-to-react.md
@@ -18,7 +18,7 @@ Preact가 React의 모든 기능을 하나하나 포함하지 않으려는 이�
 
 ## 주요 차이점
 
-Preact 앱과 React 앱을 비교할 때 주요 차이점은 Preact에서는 자체 이벤트 시스템을 제공하지 않는다는 점입니다. Preact는 내부에서 모든 이벤트를 핸들링할 때 브라우저에서 제공하는 `addEventListner`를 사용합니다. 모든 DOM 이벤트 핸들러에 대한 리스트를 보려면 [GlobalEventHandlers]를 보세요.
+Preact 앱과 React 앱을 비교할 때 주요 차이점은 Preact에서는 자체 이벤트 시스템을 제공하지 않는다는 점입니다. Preact는 내부에서 모든 이벤트를 핸들링할 때 브라우저에서 제공하는 `addEventListner`를 사용합니다. 모든 DOM 이벤트 핸들러에 대한 리스트를 보려면 [MDN's Event Reference]를 보세요.
 
 브라우저의 이벤트 시스템에서 우리가 필요로 하는 모든 기능을 지원합니다. 자체적인 커스텀 이벤트를 구현하는 건 유지보수 비용 증대와 API 영역의 확장을 의미합니다.
 
@@ -221,4 +221,4 @@ React와 호환되는 `Children` API는 `preact/compat`에서 제공되며 기�
 [Project Goals]: /about/project-goals
 [hyperscript]: https://github.com/dominictarr/hyperscript
 [preact/compat]: /guide/v10/switching-to-preact
-[GlobalEventHandlers]: https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers
+[MDN's Event Reference]: https://developer.mozilla.org/ko/docs/Web/Events

--- a/content/pt-br/guide/v10/differences-to-react.md
+++ b/content/pt-br/guide/v10/differences-to-react.md
@@ -18,7 +18,7 @@ Preact não tenta incluir cada pequeno recurso do React em razão manter-se **pe
 
 ## Principais diferenças
 
-A principal diferença ao comparar os aplicativos Preact e React é que não enviamos nosso próprio sistema de evento sintético. O Preact usa o `addEventlistener` nativo do navegador para manipulação de eventos internamente. Consulte [Manipuladores de Evento Globais] para obter uma lista completa dos manipuladores de eventos DOM.
+A principal diferença ao comparar os aplicativos Preact e React é que não enviamos nosso próprio sistema de evento sintético. O Preact usa o `addEventlistener` nativo do navegador para manipulação de eventos internamente. Consulte [MDN's Event Reference] para obter uma lista completa dos manipuladores de eventos DOM.
 
 Para nós, não faz sentido, pois o sistema de eventos do navegador suporta todos os recursos que precisamos. Uma implementação completa de eventos personalizados significaria mais sobrecarga de manutenção e uma maior área de superfície da API para nós.
 
@@ -152,4 +152,4 @@ function App(props) {
 [Objetivos do projeto]: /about/project-goals
 [hyperscript]: https://github.com/dominictarr/hyperscript
 [preact/compat]: /guide/v10/switching-to-preact
-[Manipuladores de Evento Globais]: https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers
+[MDN's Event Reference]: https://developer.mozilla.org/pt-BR/docs/Web/Events


### PR DESCRIPTION
@rschristian 
https://github.com/preactjs/preact-www/issues/930

change link from [GlobalEventHandlers](https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers) to [MDN's Event Reference](https://developer.mozilla.org/en-US/docs/Web/Events) on [differences to react](https://preactjs.com/guide/v10/differences-to-react) page

I've modified Japanese and English so far