### PR TITLE
docs: update preact-signal-store to @deepsignal/preact in libraries-addons.md

### DIFF
--- a/content/en/about/libraries-addons.md
+++ b/content/en/about/libraries-addons.md
@@ -59,4 +59,4 @@ A collection of modules built to work wonderfully with Preact.
 - :tophat: [**preact-classless-component**](https://github.com/ld0rman/preact-classless-component): create preact components without the class keyword
 - :hammer: [**preact-hyperscript**](https://github.com/queckezz/preact-hyperscript): Hyperscript-like syntax for creating elements
 - :white_check_mark: [**shallow-compare**](https://github.com/tkh44/shallow-compare): simplified `shouldComponentUpdate` helper.
-- :signal_strength: [**preact-signal-store**](https://github.com/EthanStandel/preact-signal-store): Extension of `@preact/signals` for full state management
+- :signal_strength: [**@deepsignal/preact**](https://github.com/EthanStandel/deepsignal/tree/main/packages/preact): Extension of `@preact/signals` for full state management


### PR DESCRIPTION
I'm the maintainer of the library previously named `preact-signal-store`, but to support React I recently deprecated the library under that name so that I could create scoped packages like the main Signals repo.

This PR is just updating the reference to the deprecated repo to have the name of the new repo.