### PR TITLE
fix: Table of Contents link gen w/ function args

### DIFF
--- a/src/lib/content.js
+++ b/src/lib/content.js
@@ -158,8 +158,8 @@ function generateToc(markdown) {
 		// Note: character range in regex is roughly "word characters including accented" (eg: bublé)
 		const id = text
 			.toLowerCase()
-			.replace(/[\s-!()<>`",]+/g, '-')
-			.replace(/^-|-$|[/&.[\]']/g, '');
+			.replace(/[\s-!<>`",]+/g, '-')
+			.replace(/^-|-$|[/&.()[\]']/g, '');
 		toc.push({ text, id, level });
 	}
 	return toc;


### PR DESCRIPTION
Closes #944

The [API Reference](https://preactjs.com/guide/v10/api-reference) page is better to test with as it contains functions  both w/ and w/out args in the table of contents.