### PR TITLE
fix: Correct language picker dropdown arrow on light mode

### DIFF
--- a/src/components/header/style.module.less
+++ b/src/components/header/style.module.less
@@ -189,7 +189,7 @@
 				left: 7px;
 				top: -1px;
 				font-size: 60%;
-				vertical-align: middle;
+				color: #fff;
 			}
 		}
 


### PR DESCRIPTION
It'll turn black if the user browses in light mode, which isn't right.

The `vertical-align` is unused; a leftover from when I was testing out various methods I suppose.