### PR TITLE
url for trivago open source replaced with working url

### DIFF
--- a/src/components/sponsors/index.js
+++ b/src/components/sponsors/index.js
@@ -32,7 +32,7 @@ export default function Sponsors() {
 			</li>
 			<li class={styles.sponsorItem}>
 				<a
-					href="https://tech.trivago.com/opensource/"
+					href="https://tech.trivago.com/categories/open-source/"
 					title="Trivago"
 					target="_blank"
 					rel="noopener noreferrer"


### PR DESCRIPTION
This PR updates the URL from the outdated link to Trivago's Open Source page to the currently working one.
The tried and tested demo is as shown:


https://user-images.githubusercontent.com/20269286/220933819-c08645e3-429b-42b9-9da8-83c849dba99d.mp4

