### PR TITLE
Switch REPL + Tutorial runner to Rollup + ESM.sh

### DIFF
--- a/content/en/tutorial/08-keys.md
+++ b/content/en/tutorial/08-keys.md
@@ -286,8 +286,9 @@ Finally, update the JSX to render each item from `todos` as an
 
 
 ```js:setup
-useResult(function (result) {
-  var out = result.output;
+useRealm(function (realm) {
+  // the app element
+  var out = realm.globalThis.document.body.firstElementChild;
   var options = require('preact').options;
 
   var oldRender = options.__r;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "license": "MIT",
       "dependencies": {
         "@preact/signals": "^1.1.3",
+        "@preact/signals-core": "^1.2.3",
+        "@rollup/browser": "^3.18.0",
         "babel-standalone": "^6.26.0",
         "classnames": "^2.2.6",
         "codemirror": "^5.50.2",
@@ -2313,6 +2315,11 @@
         "preact": "^10.4.0",
         "webpack": "^4.0.0 || ^5.0.0"
       }
+    },
+    "node_modules/@rollup/browser": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@rollup/browser/-/browser-3.18.0.tgz",
+      "integrity": "sha512-YR57RH7/yItm9oyAuDT+d1MYh8EqWDdczYOe8ePXbh+zhrtyjMrpdHGrf5WUqsB8/0qD2tBJXihaPGbs2UAzsw=="
     },
     "node_modules/@rollup/plugin-babel": {
       "version": "5.3.1",
@@ -25002,6 +25009,11 @@
         "@prefresh/core": "^1.3.3",
         "@prefresh/utils": "^1.1.2"
       }
+    },
+    "@rollup/browser": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@rollup/browser/-/browser-3.18.0.tgz",
+      "integrity": "sha512-YR57RH7/yItm9oyAuDT+d1MYh8EqWDdczYOe8ePXbh+zhrtyjMrpdHGrf5WUqsB8/0qD2tBJXihaPGbs2UAzsw=="
     },
     "@rollup/plugin-babel": {
       "version": "5.3.1",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,8 @@
   },
   "dependencies": {
     "@preact/signals": "^1.1.3",
+    "@preact/signals-core": "^1.2.3",
+    "@rollup/browser": "^3.18.0",
     "babel-standalone": "^6.26.0",
     "classnames": "^2.2.6",
     "codemirror": "^5.50.2",

--- a/src/components/controllers/repl/runner.js
+++ b/src/components/controllers/repl/runner.js
@@ -2,13 +2,10 @@ import { h, Component, createRef } from 'preact';
 import { memoize } from 'decko';
 import style from './style.module.less';
 import ReplWorker from 'workerize-loader?name=repl.[hash:5]!./repl.worker';
-import bundledModulesUrl from 'worker-plugin/loader?name=repl.setup&esModule!./repl.setup.js';
 import { patchErrorLocation } from './errors';
 
 let cachedFetcher = memoize(fetch);
 let cachedFetch = (...args) => cachedFetcher(...args).then(r => r.clone());
-
-const bundledModules = fetch(bundledModulesUrl).then(r => r.text());
 
 const worker = new ReplWorker();
 
@@ -67,8 +64,10 @@ export default class Runner extends Component {
 		if (this.timer) return;
 		this.timer = setTimeout(() => {
 			let { code, setup } = this.props;
+			// onRealm must be called after imports but before user code:
+			const fullSetup = `if (self._onRealm) self._onRealm();${setup || ''}\n`;
 			this.running = worker
-				.process(code, setup)
+				.process(code, fullSetup)
 				.then(transpiled => this.execute(transpiled))
 				.then(this.commitResult)
 				.catch(this.commitError)
@@ -94,17 +93,9 @@ export default class Runner extends Component {
 
 	setup(fresh) {
 		if (this.settingUp && fresh !== true) return this.settingUp;
-		this.settingUp = bundledModules.then(async code => {
-			this.setupRealm();
-
-			await this.realm.eval(code);
-			this.require = await this.realm.eval('window._require');
-
-			if (this.props.onRealm) {
-				this.props.onRealm(this.realm);
-			}
-		});
-		return this.settingUp;
+		this.setupRealm();
+		// silly leftover promise stuff
+		return (this.settingUp = Promise.resolve());
 	}
 
 	setupRealm() {
@@ -141,12 +132,18 @@ export default class Runner extends Component {
 		}
 
 		const base = this.output;
-		const { render } = this.require('preact');
+		const render = this.realm?.globalThis?.$preact?.render;
 
 		if (this.didError) {
 			// no need to reset, this is a fresh frame
-		} else if (this.props.clear === true || isFallback === true) {
-			this.root = render(null, base);
+		} else if (render || this.props.clear === true || isFallback === true) {
+			if (render) {
+				try {
+					this.root = render(null, base);
+				} catch (e) {
+					console.error('Failed to unmount previous code: ', e);
+				}
+			}
 			base.innerHTML = '';
 			createRoot(this.realm.globalThis.document);
 		}
@@ -155,10 +152,18 @@ export default class Runner extends Component {
 
 		let module = { exports: {} };
 
+		// inject onRealm so it can be called after imports but before user code:
+		this.realm.globalThis._onRealm = () => {
+			this.realm.globalThis._onRealm = null;
+			if (this.props.onRealm) {
+				this.props.onRealm(this.realm);
+			}
+		};
+
 		let fn = await this.realm.eval(transpiled);
 
 		try {
-			fn(module, module.exports, this.require, cachedFetch);
+			fn(module, module.exports);
 		} catch (error) {
 			// try once more without DOM reuse:
 			if (isFallback !== true) {


### PR DESCRIPTION
It took some effort to get this working in the Tutorial in addition to just the REPL, but I'm fairly confident it's all functioning correctly now. 

The main benefit of this approach is that the REPL now supports importing any package.

[Here's an example](https://deploy-preview-971--preactjs.netlify.app/repl?code=aW1wb3J0IHsgcmVuZGVyIH0gZnJvbSAicHJlYWN0IjsKaW1wb3J0IHsgdXNlRWZmZWN0IH0gZnJvbSAicHJlYWN0L2hvb2tzIjsKaW1wb3J0IHsgdXNlQ29tcHV0ZWQsIHVzZVNpZ25hbCB9IGZyb20gIkBwcmVhY3Qvc2lnbmFscyI7CgpmdW5jdGlvbiBBcHAoKSB7CiAgY29uc3QgbnVtYmVyc1NpZ25hbCA9IHVzZVNpZ25hbChbMSwgMiwgM10pOwoKICB1c2VFZmZlY3QoKCkgPT4gewogICAgc2V0VGltZW91dCgoKSA9PiB7CiAgICAgIG51bWJlcnNTaWduYWwudmFsdWUgPSBudWxsOwogICAgfSwgMTAwMCk7CiAgfSwgW10pOwoKICByZXR1cm4gbnVtYmVyc1NpZ25hbC52YWx1ZSA%2FICgKICAgIDxOdW1iZXJzIG51bWJlcnNTaWduYWw9e251bWJlcnNTaWduYWx9IC8%2BCiAgKSA6ICgKICAgIDxkaXY%2BTm8gbnVtYmVycyE8L2Rpdj4KICApOwp9CgpmdW5jdGlvbiBOdW1iZXJzKHsgbnVtYmVyc1NpZ25hbCB9KSB7CiAgY29uc3QgbnVtYmVycyA9IHVzZUNvbXB1dGVkKCgpID0%2BIG51bWJlcnNTaWduYWwudmFsdWUuam9pbigiIHwgIikpOwoKICByZXR1cm4gPGRpdj57bnVtYmVycyArICcnfTwvZGl2PjsKfQoKcmVuZGVyKDxBcHAgLz4sIGRvY3VtZW50LmdldEVsZW1lbnRCeUlkKCJhcHAiKSk7Cg%3D%3D) that was not runnable in the REPL previously (due to missing deps/versioning)