### PR TITLE
refactor: Replace unpkg with esm.sh in 'Getting Started'

### DIFF
--- a/content/en/guide/v10/getting-started.md
+++ b/content/en/guide/v10/getting-started.md
@@ -22,7 +22,7 @@ Preact is packaged to be used directly in the browser, and doesn't require any b
 
 ```html
 <script type="module">
-  import { h, Component, render } from 'https://unpkg.com/preact?module';
+  import { h, Component, render } from 'https://esm.sh/preact';
 
   // Create your app
   const app = h('h1', null, 'Hello World!');
@@ -43,8 +43,8 @@ Writing raw `h` or `createElement` calls can be tedious. JSX has the advantage o
 
 ```html
 <script type="module">
-  import { h, Component, render } from 'https://unpkg.com/preact?module';
-  import htm from 'https://unpkg.com/htm?module';
+  import { h, Component, render } from 'https://esm.sh/preact';
+  import htm from 'https://esm.sh/htm';
 
   // Initialize htm with Preact
   const html = htm.bind(h);
@@ -61,7 +61,7 @@ Writing raw `h` or `createElement` calls can be tedious. JSX has the advantage o
 
 > **Tip:** HTM also provides a convenient single-import Preact version:
 >
-> `import { html, render } from 'https://unpkg.com/htm/preact/index.mjs?module'`
+> `import { html, render } from 'https://esm.sh/htm/preact/standalone'`
 
 For more information on HTM, check out its [documentation][htm].
 

--- a/content/es/guide/v10/getting-started.md
+++ b/content/es/guide/v10/getting-started.md
@@ -32,7 +32,7 @@ Preact se ha empaquetado fácilmente para usarlo directamente en el navegador. E
 
 
 ```js
-import { h, Component, render } from 'https://unpkg.com/preact';
+import { h, Component, render } from 'https://esm.sh/preact';
 
 // Create your app
 const app = h('div', null, 'Hello World!');
@@ -52,8 +52,8 @@ Escribir llamadas sin formato `h` o `createElement` todo el tiempo es mucho meno
 En pocas palabras, [htm](https://github.com/developit/htm) se puede describir mejor como: sintaxis similar a JSX en JavaScript sin necesidad de un transpilador. En lugar de usar una sintaxis personalizada, se basa en cadenas de plantillas con etiquetas nativas que se agregaron a JavaScript hace un tiempo.
 
 ```js
-import { h, Component, render } from 'https://unpkg.com/preact';
-import htm from 'https://unpkg.com/htm';
+import { h, Component, render } from 'https://esm.sh/preact';
+import htm from 'https://esm.sh/htm';
 
 // Initialize htm with Preact
 const html = htm.bind(h);

--- a/content/ja/guide/v10/getting-started.md
+++ b/content/ja/guide/v10/getting-started.md
@@ -21,7 +21,7 @@ Preactはビルドやツールなしでブラウザで直に使うためのパ�
 
 ```html
 <script type="module">
-  import { h, Component, render } from 'https://unpkg.com/preact?module';
+  import { h, Component, render } from 'https://esm.sh/preact';
 
   // アプリケーションを作成する。
   const app = h('h1', null, 'Hello World!');
@@ -47,8 +47,8 @@ HTMは今までのフロントエンドのビルドツールよりシンプル�
 
 ```html
 <script type="module">
-  import { h, Component, render } from 'https://unpkg.com/preact?module';
-  import htm from 'https://unpkg.com/htm?module';
+  import { h, Component, render } from 'https://esm.sh/preact';
+  import htm from 'https://esm.sh/htm';
 
   // htmをPreactで使う用意をする。
   const html = htm.bind(h);

--- a/content/pt-br/guide/v10/getting-started.md
+++ b/content/pt-br/guide/v10/getting-started.md
@@ -20,7 +20,7 @@ Se você está apenas começando, é altamente recomendável usar o [preact-cli]
 O Preact sempre foi prontamente empacotado para ser usado diretamente no navegador. Isso não requer nenhuma ferramenta de construção.
 
 ```js
-import { h, Component, render } from 'https://unpkg.com/preact?module';
+import { h, Component, render } from 'https://esm.sh/preact';
 
 // Crie seu aplicativo
 const app = h('div', null, 'Olá Mundo!');
@@ -39,8 +39,8 @@ Escrever chamadas brutas `h` ou `createElement` o tempo todo é muito menos dive
 Em poucas palavras, [htm] pode ser melhor descrito como: sintaxe semelhante a JSX em JavaScript comum, sem a necessidade de um transpiler. Em vez de usar uma sintaxe personalizada, ele se baseia em seqüências de modelos com tags nativas que foram adicionadas ao JavaScript há algum tempo.
 
 ```js
-import { h, Component, render } from 'https://unpkg.com/preact?module';
-import htm from 'https://unpkg.com/htm?module';
+import { h, Component, render } from 'https://esm.sh/preact';
+import htm from 'https://esm.sh/htm';
 
 // Inicialize htm com Preact
 const html = htm.bind(h);

--- a/content/zh/guide/v10/getting-started.md
+++ b/content/zh/guide/v10/getting-started.md
@@ -21,7 +21,7 @@ Preact 可在浏览器中直接使用，无需构建或任何工具：
 
 ```html
 <script type="module">
-  import { h, Component, render } from 'https://unpkg.com/preact?module';
+  import { h, Component, render } from 'https://esm.sh/preact';
 
   // Create your app
   const app = h('h1', null, 'Hello World!');
@@ -42,8 +42,8 @@ Preact 可在浏览器中直接使用，无需构建或任何工具：
 
 ```html
 <script type="module">
-  import { h, Component, render } from 'https://unpkg.com/preact?module';
-  import htm from 'https://unpkg.com/htm?module';
+  import { h, Component, render } from 'https://esm.sh/preact';
+  import htm from 'https://esm.sh/htm';
 
   // 为 Preact 初始化 htm
   const html = htm.bind(h);
@@ -60,7 +60,7 @@ Preact 可在浏览器中直接使用，无需构建或任何工具：
 
 > **小提示：**HTM 还提供了一键 import 的 Preact 版本：
 >
-> `import { html, render } from 'https://unpkg.com/htm/preact/index.mjs?module'`
+> `import { html, render } from 'https://esm.sh/htm/preact/standalone'`
 
 要了解有关 HTM 的更多信息，请参阅其[文档][htm]。
 


### PR DESCRIPTION
Marvin mentioned this the other day in the slack and it's been something I've been thinking about for a while too, seeing as how we have a pinned issue warning against some Unpkg headaches in the main repo.

So long as grep isn't failing me, this should be the only remaining (non-code comment) reference: https://github.com/preactjs/preact-www/blob/500911ce4e2d0bbe988bb404bdbd492c3946defd/content/en/tutorial/index.md?plain=1#L22-L26