### PR TITLE
fix: Ensure GH API error doesn't break prerendering

### DIFF
--- a/src/prerender.js
+++ b/src/prerender.js
@@ -26,7 +26,10 @@ module.exports = async () => {
 			arr.path ? { path: arr.path, name: arr.name } : arr.routes
 		);
 
-	const preactVersion = (await fetchRelease('preactjs/preact')).version;
+	let preactVersion;
+	try {
+		preactVersion = (await fetchRelease('preactjs/preact')).version;
+	} catch {}
 
 	const pageData = routes.flatMap(function map(route) {
 		const url = route.path;


### PR DESCRIPTION
Fix for now, though CLI should handle this better. An uncaught error should not result in a `Failed to load` warning that continues on.