### PR TITLE
fix: Minor styling issues in header

### DIFF
--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -65,9 +65,11 @@ export default function Header() {
 								height="28"
 							/>
 						</a>
-						<NavItem />
 					</div>
-					<Hamburger open={open} onClick={toggle} />
+					<div class={style.translation}>
+						<NavMenu language />
+					</div>
+					<HamburgerMenu open={open} onClick={toggle} />
 				</div>
 			</div>
 			<Corner />
@@ -75,8 +77,7 @@ export default function Header() {
 	);
 }
 
-// hamburger menu
-const Hamburger = ({ open, ...props }) => (
+const HamburgerMenu = ({ open, ...props }) => (
 	<div class={style.hamburger} open={open} {...props}>
 		<div class={style.hb1} />
 		<div class={style.hb2} />
@@ -87,25 +88,31 @@ const Hamburger = ({ open, ...props }) => (
 // nested nav renderer
 const Nav = ({ routes, current, ...props }) => (
 	<nav {...props}>
-		{routes.map(route => (
-			<NavItem
-				to={route}
-				current={current}
-				data-route={getRouteIdent(route)}
-				class={cx(
-					route.class,
-					(pathMatchesRoute(current, route) ||
-						(route.content === 'guide' && /^\/guide\//.test(current)) ||
-						(route.content === 'blog' && /^\/blog\//.test(current))) &&
-						style.current
-				)}
-			/>
-		))}
+		{routes.map(route =>
+			route.routes ? (
+				<NavMenu
+					to={route}
+					current={current}
+					data-route={getRouteIdent(route)}
+				/>
+			) : (
+				<NavLink
+					to={route}
+					class={cx(
+						route.class,
+						(pathMatchesRoute(current, route) ||
+							(route.content === 'guide' && /^\/guide\//.test(current)) ||
+							(route.content === 'blog' && /^\/blog\//.test(current))) &&
+							style.current
+					)}
+				/>
+			)
+		)}
 	</nav>
 );
 
 // nav items are really the only complex bit for menuing, since they handle click events.
-class NavItem extends Component {
+class NavMenu extends Component {
 	state = { open: false };
 
 	close = () => (this.setState({ open: false }), false);
@@ -135,27 +142,32 @@ class NavItem extends Component {
 		}
 	}
 
-	render({ to, current, ...props }, { open }) {
-		if (!to)
-			return (
-				<LanguageSelector
-					isOpen={open}
-					toggle={this.toggle}
-					close={this.close}
-					{...props}
-				/>
-			);
-		if (!to.routes) return <NavLink to={to} {...props} />;
-
+	render({ to, current, language, ...props }, { open }) {
 		return (
 			<div {...props} data-open={open} class={style.navGroup}>
-				<NavLink to={to} onClick={this.toggle} aria-haspopup isOpen={open} />
-				<Nav
-					routes={to.routes}
-					current={current}
-					aria-label="submenu"
-					aria-hidden={'' + !open}
-				/>
+				{language ? (
+					<LanguageSelectorMenu
+						isOpen={open}
+						toggle={this.toggle}
+						close={this.close}
+						{...props}
+					/>
+				) : (
+					<>
+						<NavLink
+							to={to}
+							onClick={this.toggle}
+							aria-haspopup
+							isOpen={open}
+						/>
+						<Nav
+							routes={to.routes}
+							current={current}
+							aria-label="submenu"
+							aria-hidden={'' + !open}
+						/>
+					</>
+				)}
 			</div>
 		);
 	}
@@ -201,7 +213,7 @@ const NavLink = ({ to, isOpen, route, ...props }) => {
 	);
 };
 
-const LanguageSelector = ({ isOpen, toggle, close, ...props }) => {
+const LanguageSelectorMenu = ({ isOpen, toggle, close, ...props }) => {
 	const [lang, setLang] = useLanguage();
 	const onClick = useCallback(
 		e => {
@@ -212,11 +224,7 @@ const LanguageSelector = ({ isOpen, toggle, close, ...props }) => {
 	);
 
 	return (
-		<div
-			{...props}
-			data-open={isOpen}
-			class={cx(style.navGroup, style.translation)}
-		>
+		<>
 			<button {...props} onClick={toggle} aria-haspopup aria-expanded={isOpen}>
 				<img
 					src="/assets/i18n.svg"
@@ -236,7 +244,7 @@ const LanguageSelector = ({ isOpen, toggle, close, ...props }) => {
 					</span>
 				))}
 			</nav>
-		</div>
+		</>
 	);
 };
 

--- a/src/components/header/style.module.less
+++ b/src/components/header/style.module.less
@@ -393,7 +393,7 @@
 	font-size: 16px;
 	cursor: pointer;
 	transition: all 0.3s;
-	padding: 0 1rem;
+	padding: 0 0.5rem;
 }
 
 .release {

--- a/src/components/header/style.module.less
+++ b/src/components/header/style.module.less
@@ -498,11 +498,11 @@
 
 .search {
 	display: inline-block;
-	vertical-align: top;
 	height: 56px;
 	min-width: 80px;
 	overflow: visible;
 	background: var(--color-brand);
+	padding-right: 0.5rem;
 
 	@media (max-width: @header-mobile-breakpoint) {
 		flex-grow: 1;

--- a/src/components/header/style.module.less
+++ b/src/components/header/style.module.less
@@ -178,6 +178,7 @@
 		display: inline-block;
 		position: relative;
 		overflow: visible;
+		height: 100%;
 
 		& > a,
 		& > button {
@@ -334,11 +335,11 @@
 	}
 }
 
-.social {
+.social,
+.translation {
 	position: absolute;
 	height: 2rem;
 	top: calc(var(--vh) - 3rem); // TODO: Why does bottom not work?
-	padding: 0 0.5rem;
 	display: flex;
 	width: 100%;
 	justify-content: space-between;
@@ -353,10 +354,17 @@
 	}
 }
 
-.socialItem,
-.translation {
-	display: flex;
+.socialItem {
 	padding: 0 0.5rem;
+}
+
+.translation button {
+	padding: 0 0.6rem 0 0.5rem;
+}
+
+.socialItem,
+.translation button {
+	display: flex;
 	height: 100%;
 	justify-content: center;
 	align-items: center;
@@ -365,10 +373,6 @@
 
 	@media (min-width: 1024px) {
 		padding: 0 1rem;
-	}
-
-	&.translation {
-		padding: 0;
 	}
 
 	&:hover,
@@ -384,16 +388,9 @@
 }
 
 .translation button {
-	display: flex;
-	height: 100%;
-	align-items: center;
 	border: none;
-	color: #eee;
 	background-color: #0000;
-	font-size: 16px;
 	cursor: pointer;
-	transition: all 0.3s;
-	padding: 0 0.5rem;
 }
 
 .release {

--- a/src/components/header/style.module.less
+++ b/src/components/header/style.module.less
@@ -189,7 +189,6 @@
 				left: 7px;
 				top: -1px;
 				font-size: 60%;
-				color: #fff;
 			}
 		}
 
@@ -339,7 +338,7 @@
 	position: absolute;
 	height: 2rem;
 	top: calc(var(--vh) - 3rem); // TODO: Why does bottom not work?
-	padding: 0 .5rem;
+	padding: 0 0.5rem;
 	display: flex;
 	width: 100%;
 	justify-content: space-between;
@@ -389,11 +388,12 @@
 	height: 100%;
 	align-items: center;
 	border: none;
+	color: #eee;
 	background-color: #0000;
 	font-size: 16px;
 	cursor: pointer;
 	transition: all 0.3s;
-	padding: 0 0.5rem;
+	padding: 0 1rem;
 }
 
 .release {


### PR DESCRIPTION
When header items with dropdown menus were opened, the drop down arrow would stay white, resulting in it disappearing:

Before             |  After
:-------------------------:|:-------------------------:
![white-on-white drop-down arrow](https://user-images.githubusercontent.com/33403762/231938067-18bc2f53-38e4-43f5-98e0-ef855a56ad29.png)  |  ![black-on-white drop-down arrow](https://user-images.githubusercontent.com/33403762/231938258-19d078a7-4e3b-4e5c-b9f3-46434bd20aa6.png)

