### PR TITLE
fix: Mobile content width on tutorial

### DIFF
--- a/src/components/controllers/tutorial/style.module.less
+++ b/src/components/controllers/tutorial/style.module.less
@@ -55,7 +55,6 @@
 			background: var(--color-sidebar-bg);
 			color: var(--color-text);
 			display: flex;
-			flex: 1 1 var(--x, 50%);
 			flex-direction: column;
 			padding: 12px;
 			transition: opacity 1s ease;
@@ -212,16 +211,16 @@
 
 		&:not(.showCode) {
 			.tutorialWindow {
-				flex-basis: 100%;
-
 				& > * {
+					// Fixes content region whilst keeping
+					// title & button container centered
+					&:nth-child(2) {
+						width: 100%;
+					}
+
 					max-width: 700px;
-					margin-left: auto;
-					margin-right: auto;
+					margin: 0 auto;
 				}
-			}
-			.codeWindow {
-				flex-basis: 0%;
 			}
 		}
 		&.showCode .codeWindow {
@@ -238,7 +237,6 @@
 			height: 100%;
 			display: flex;
 			flex-direction: column;
-			flex: 1 1 calc(100% - var(--x, 50%));
 			position: relative;
 			transition: opacity 1s ease;
 			overflow: auto;


### PR DESCRIPTION
Before             |  After
:-------------------------:|:-------------------------:
![Before, with horizontal scroll](https://user-images.githubusercontent.com/33403762/232197537-f07a52d2-e699-4339-95d0-c38da18344d0.png) |  ![After, no horizontal scroll](https://user-images.githubusercontent.com/33403762/232197559-9b929dba-d9c2-4671-909b-3afdb2b4fc8e.png)

Might be opinion, but I think it's a bit easier to read without the horizontal scroll if we can help it.