### PR TITLE
refactor: Create a more prominent TS-subsection in guide

### DIFF
--- a/content/en/guide/v10/configuring-typescript.md
+++ b/content/en/guide/v10/configuring-typescript.md
@@ -1,0 +1,92 @@
+---
+name: Configuring TypeScript
+description: "Preact has built-in TypeScript support. Learn how to configure it!"
+---
+
+# TypeScript
+
+Preact ships TypeScript type definitions, which are used by the library itself!
+
+When you use Preact in a TypeScript-aware editor (like VSCode), you can benefit from the added type information even while writing regular JavaScript. If you want to add type information to your own applications, you can use [JSDoc annotations](https://fettblog.eu/typescript-jsdoc-superpowers/), or write TypeScript and transpile to regular JavaScript. These docs will focus on the latter.
+
+---
+
+<div><toc></toc></div>
+
+---
+
+## Configuring TypeScript
+
+TypeScript includes a full-fledged JSX compiler that you can use instead of Babel. Add the following configuration to your `tsconfig.json` to transpile JSX to Preact-compatible JavaScript:
+
+```json
+// TypeScript >= 4.1.1
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
+    //...
+  }
+}
+```
+```json
+// TypeScript < 4.1.1
+{
+  "compilerOptions": {
+    "jsx": "react",
+    "jsxFactory": "h",
+    "jsxFragmentFactory": "Fragment",
+    //...
+  }
+}
+```
+
+If you use TypeScript within a Babel toolchain, set `jsx` to `preserve` and let Babel handle the transpilation. You still need to specify `jsxFactory` and `jsxFragmentFactory` to get the correct types.
+
+```json
+{
+  "compilerOptions": {
+    "jsx": "preserve",
+    "jsxFactory": "h",
+    "jsxFragmentFactory": "Fragment",
+    //...
+  }
+}
+```
+
+In your `.babelrc`:
+
+```javascript
+{
+  presets: [
+    "@babel/env",
+    ["@babel/typescript", { jsxPragma: "h" }],
+  ],
+  plugins: [
+    ["@babel/transform-react-jsx", { pragma: "h" }]
+  ],
+}
+```
+
+Rename your `.jsx` files to `.tsx` for TypeScript to correctly parse your JSX.
+
+## Configuring with `preact/compat`
+
+If you're using `preact/compat` in your application to get access to the wider React ecosystem,
+you may need to disable type checking declaration files (`.d.ts`) and/or add path aliases to ensure
+your React-based libraries are consuming Preact's types instead:
+
+```json
+{
+  "compilerOptions": {
+    ...
+    "skipLibCheck": true,
+    ...
+    "baseUrl": "./",
+    "paths": {
+      "react": ["./node_modules/preact/compat/"],
+      "react-dom": ["./node_modules/preact/compat/"]
+    }
+  }
+}
+```

--- a/content/en/guide/v10/using-typescript.md
+++ b/content/en/guide/v10/using-typescript.md
@@ -1,94 +1,19 @@
 ---
-name: TypeScript
+name: Using TypeScript
 description: "Preact has built-in TypeScript support. Learn how to make use of it!"
 ---
 
 # TypeScript
 
-Preact ships TypeScript type definitions, which are used by the library itself! 
+Preact ships TypeScript type definitions, which are used by the library itself!
 
-When you use Preact in a TypeScript-aware editor (like VSCode), you can benefit from the added type information while writing regular JavaScript. If you want to add type information to your own applications, you can use [JSDoc annotations](https://fettblog.eu/typescript-jsdoc-superpowers/), or write TypeScript and transpile to regular JavaScript. This section will focus on the latter.
+When you use Preact in a TypeScript-aware editor (like VSCode), you can benefit from the added type information even while writing regular JavaScript. If you want to add type information to your own applications, you can use [JSDoc annotations](https://fettblog.eu/typescript-jsdoc-superpowers/), or write TypeScript and transpile to regular JavaScript. These docs will focus on the latter.
 
 ---
 
 <div><toc></toc></div>
 
 ---
-
-## TypeScript configuration
-
-TypeScript includes a full-fledged JSX compiler that you can use instead of Babel. Add the following configuration to your `tsconfig.json` to transpile JSX to Preact-compatible JavaScript:
-
-```json
-// TypeScript < 4.1.1
-{
-  "compilerOptions": {
-    "jsx": "react",
-    "jsxFactory": "h",
-    "jsxFragmentFactory": "Fragment",
-    //...
-  }
-}
-```
-```json
-// TypeScript >= 4.1.1
-{
-  "compilerOptions": {
-    "jsx": "react-jsx",
-    "jsxImportSource": "preact",
-    //...
-  }
-}
-```
-
-If you use TypeScript within a Babel toolchain, set `jsx` to `preserve` and let Babel handle the transpilation. You still need to specify `jsxFactory` and `jsxFragmentFactory` to get the correct types.
-
-```json
-{
-  "compilerOptions": {
-    "jsx": "preserve",
-    "jsxFactory": "h",
-    "jsxFragmentFactory": "Fragment",
-    //...
-  }
-}
-```
-
-In your `.babelrc`:
-
-```javascript
-{
-  presets: [
-    "@babel/env",
-    ["@babel/typescript", { jsxPragma: "h" }],
-  ],
-  plugins: [
-    ["@babel/transform-react-jsx", { pragma: "h" }]
-  ],
-}
-```
-
-Rename your `.jsx` files to `.tsx` for TypeScript to correctly parse your JSX.
-
-## TypeScript preact/compat configuration
-
-Your project could need support for the wider React ecosystem.  To make your application
-compile, you might need to disable type checking on your `node_modules` and add paths to the types
-like this.  This way, your alias will work properly when libraries import React.
-
-```json
-{
-  "compilerOptions": {
-    ...
-    "skipLibCheck": true,
-    "baseUrl": "./",
-    "paths": {
-      "react": ["./node_modules/preact/compat/"],
-      "react-dom": ["./node_modules/preact/compat/"]
-    }
-  }
-}
-```
 
 ## Typing components
 

--- a/src/config.json
+++ b/src/config.json
@@ -414,6 +414,25 @@
 		},
 		{
 			"name": {
+				"en": "TypeScript"
+			},
+			"routes": [
+				{
+					"path": "/guide/v10/configuring-typescript",
+					"name": {
+						"en": "Configuring TypeScript"
+					}
+				},
+				{
+					"path": "/guide/v10/using-typescript",
+					"name": {
+						"en": "Using TypeScript"
+					}
+				}
+			]
+		},
+		{
+			"name": {
 				"en": "Debug & Test",
 				"zh": "调试与测试"
 			},
@@ -513,10 +532,6 @@
 						"de": "Optionen",
 						"zh": "选项钩子"
 					}
-				},
-				{
-					"path": "/guide/v10/typescript",
-					"name": "TypeScript"
 				}
 			]
 		},

--- a/src/config.json
+++ b/src/config.json
@@ -384,6 +384,36 @@
 		},
 		{
 			"name": {
+				"en": "React compatibility",
+				"zh": "React 兼容性"
+			},
+			"routes": [
+				{
+					"path": "/guide/v10/differences-to-react",
+					"name": {
+						"en": "Differences to React",
+						"pt-br": "Diferenças do React",
+						"ja": "Reactとの違い",
+						"de": "Unterschiede zu React",
+						"kr": "React와의 차이점",
+						"zh": "与 React 的区别"
+					}
+				},
+				{
+					"path": "/guide/v10/switching-to-preact",
+					"name": {
+						"en": "Switching to Preact",
+						"pt-br": "Mudando para Preact",
+						"ja": "Preactへの移行",
+						"de": "Wechsel zu Preact",
+						"kr": "Preact로 전환",
+						"zh": "从 React 转到 Preact"
+					}
+				}
+			]
+		},
+		{
+			"name": {
 				"en": "Debug & Test",
 				"zh": "调试与测试"
 			},
@@ -417,36 +447,6 @@
 						"de": "Unit-Tests mit Enzyme",
 						"kr": "Enzyme를 이용한 유닛 테스트",
 						"zh": "使用 Enzyme 进行单元测试"
-					}
-				}
-			]
-		},
-		{
-			"name": {
-				"en": "React compatibility",
-				"zh": "React 兼容性"
-			},
-			"routes": [
-				{
-					"path": "/guide/v10/differences-to-react",
-					"name": {
-						"en": "Differences to React",
-						"pt-br": "Diferenças do React",
-						"ja": "Reactとの違い",
-						"de": "Unterschiede zu React",
-						"kr": "React와의 차이점",
-						"zh": "与 React 的区别"
-					}
-				},
-				{
-					"path": "/guide/v10/switching-to-preact",
-					"name": {
-						"en": "Switching to Preact",
-						"pt-br": "Mudando para Preact",
-						"ja": "Preactへの移行",
-						"de": "Wechsel zu Preact",
-						"kr": "Preact로 전환",
-						"zh": "从 React 转到 Preact"
 					}
 				}
 			]


### PR DESCRIPTION
I'm thinking it might be better to move TS out of 'Advanced' and into a more prominent subsection -- no longer is TS really seen as an advanced feature, but table stakes.