### PR TITLE
Add `useSignalEffect` to the API list

### DIFF
--- a/content/en/guide/v10/signals.md
+++ b/content/en/guide/v10/signals.md
@@ -519,7 +519,7 @@ name.value = "John";
 // Logs: "Hello John"
 ```
 
-When using effects tracking signals within a component, use the hook variant: `useSignalEffect(fn)`.
+When responding to signal changes within a component, use the hook variant: `useSignalEffect(fn)`.
 
 ### batch(fn)
 

--- a/content/en/guide/v10/signals.md
+++ b/content/en/guide/v10/signals.md
@@ -519,6 +519,8 @@ name.value = "John";
 // Logs: "Hello John"
 ```
 
+When using effects tracking signals within a component, use the hook variant: `useSignalEffect(fn)`.
+
 ### batch(fn)
 
 The `batch(fn)` function can be used to combine multiple value updates into one "commit" at the end of the provided callback. Batches can be nested and changes are only flushed once the outermost batch callback completes. Accessing a signal that has been modified within a batch will reflect its updated value.


### PR DESCRIPTION
#992

We may need to include `useSignalEffect()` in the "Local state with signals" section. However, since `effect()` hasn't been introduced in that section yet, I've only added it to the API list for now.