### PR TITLE
docs: Add note about initialValue arg in `createContext`

### DIFF
--- a/content/en/guide/v10/context.md
+++ b/content/en/guide/v10/context.md
@@ -19,6 +19,8 @@ There are two different ways to use context: Via the newer `createContext` API a
 
 First we need to create a context object we can pass around. This is done via the `createContext(initialValue)` function. It returns a `Provider` component that is used to set the context value and a `Consumer` one which retrieves the value from the context.
 
+The `initialValue` argument is only used when a context does not have a matching `Provider` above it in the tree. This may be helpful for testing components in isolation, as it avoids the need for creating a wrapping `Provider`.
+
 ```jsx
 // --repl
 import { render, createContext } from 'preact';


### PR DESCRIPTION
[Someone on Slack](https://preact.slack.com/archives/C3NMBSJKH/p1686255895690249) was confused about why `createContext` needs an initial arg when they've already set the value with a `Provider`, so I think it'd be good to add a little note here.

Reworded [React's description](https://legacy.reactjs.org/docs/context.html#reactcreatecontext) slightly; first sentence is verbatim, not sure if that's problematic. Open to suggestions.