### PR TITLE
support cascading import

### DIFF
--- a/src/components/controllers/repl/repl.worker.js
+++ b/src/components/controllers/repl/repl.worker.js
@@ -85,9 +85,14 @@ async function bundle(sources) {
 				name: 'repl',
 				resolveId(id, importer) {
 					if (isSource(id)) return id;
-					if (id[0] === '/') return new URL(id, importer).href;
-					if (!importer || isSource(importer) || /(^\.\/|:\/\/)/.test(id))
+					if (id[0] === '/') {
+						try {
+							return new URL(id, importer).href;
+						} catch (e) {}
+					}
+					if (!importer || isSource(importer) || /(^\.\/|:\/\/)/.test(id)) {
 						return id;
+					}
 					return new URL(id, new URL(importer + '/', 'file:')).pathname.slice(
 						1
 					);


### PR DESCRIPTION
fixes #1008

It looks like esm.sh now has a new import when the file from https://esm.sh/preact@10.17.1 is initially loaded 😅 this amounted to us throwing an invalid URL for the block that is shielded with `try catch` in doing so it works correctly.

Example output of id, importer

```
/stable/preact@10.17.1/es2022/preact.mjs preact
/stable/preact@10.17.1/es2022/preact.mjs preact/hooks
/stable/preact@10.17.1/es2022/hooks.js preact/hooks
/stable/preact@10.17.1/es2022/preact.mjs stable/preact@10.17.1/es2022/hooks.js
```

all of these start with a slash but aren't valid URLs when combined.