### PR TITLE
Fix signals REPL example

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4357,9 +4357,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.21.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
-      "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
+      "integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
       "dev": true,
       "funding": [
         {
@@ -4369,13 +4369,17 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001400",
-        "electron-to-chromium": "^1.4.251",
-        "node-releases": "^2.0.6",
-        "update-browserslist-db": "^1.0.9"
+        "caniuse-lite": "^1.0.30001541",
+        "electron-to-chromium": "^1.4.535",
+        "node-releases": "^2.0.13",
+        "update-browserslist-db": "^1.0.13"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -4669,9 +4673,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001402",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001402.tgz",
-      "integrity": "sha512-Mx4MlhXO5NwuvXGgVb+hg65HZ+bhUYsz8QtDGDo2QmaJS2GBX47Xfi2koL86lc8K+l+htXeTEB/Aeqvezoo6Ew==",
+      "version": "1.0.30001541",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001541.tgz",
+      "integrity": "sha512-bLOsqxDgTqUBkzxbNlSBt8annkDpQB9NdzdTbO2ooJ+eC/IQcvDspDc058g84ejCelF7vHUx57KIOjEecOHXaw==",
       "dev": true,
       "funding": [
         {
@@ -4681,6 +4685,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -7256,9 +7264,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.254",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.254.tgz",
-      "integrity": "sha512-Sh/7YsHqQYkA6ZHuHMy24e6TE4eX6KZVsZb9E/DvU1nQRIrH4BflO/4k+83tfdYvDl+MObvlqHPRICzEdC9c6Q==",
+      "version": "1.4.536",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.536.tgz",
+      "integrity": "sha512-L4VgC/76m6y8WVCgnw5kJy/xs7hXrViCFdNKVG8Y7B2isfwrFryFyJzumh3ugxhd/oB1uEaEEvRdmeLrnd7OFA==",
       "dev": true
     },
     "node_modules/elegant-spinner": {
@@ -13294,9 +13302,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
-      "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
+      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
       "dev": true
     },
     "node_modules/normalize-package-data": {
@@ -21373,9 +21381,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.9.tgz",
-      "integrity": "sha512-/xsqn21EGVdXI3EXSum1Yckj3ZVZugqyOZQ/CxYPBD/R+ko9NSUScf8tFF4dOKY+2pvSSJA/S+5B8s4Zr4kyvg==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
       "dev": true,
       "funding": [
         {
@@ -21385,6 +21393,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
@@ -21392,7 +21404,7 @@
         "picocolors": "^1.0.0"
       },
       "bin": {
-        "browserslist-lint": "cli.js"
+        "update-browserslist-db": "cli.js"
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
@@ -26655,15 +26667,15 @@
       }
     },
     "browserslist": {
-      "version": "4.21.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
-      "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
+      "integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001400",
-        "electron-to-chromium": "^1.4.251",
-        "node-releases": "^2.0.6",
-        "update-browserslist-db": "^1.0.9"
+        "caniuse-lite": "^1.0.30001541",
+        "electron-to-chromium": "^1.4.535",
+        "node-releases": "^2.0.13",
+        "update-browserslist-db": "^1.0.13"
       }
     },
     "buffer": {
@@ -26905,9 +26917,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001402",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001402.tgz",
-      "integrity": "sha512-Mx4MlhXO5NwuvXGgVb+hg65HZ+bhUYsz8QtDGDo2QmaJS2GBX47Xfi2koL86lc8K+l+htXeTEB/Aeqvezoo6Ew==",
+      "version": "1.0.30001541",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001541.tgz",
+      "integrity": "sha512-bLOsqxDgTqUBkzxbNlSBt8annkDpQB9NdzdTbO2ooJ+eC/IQcvDspDc058g84ejCelF7vHUx57KIOjEecOHXaw==",
       "dev": true
     },
     "capture-stack-trace": {
@@ -28927,9 +28939,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.254",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.254.tgz",
-      "integrity": "sha512-Sh/7YsHqQYkA6ZHuHMy24e6TE4eX6KZVsZb9E/DvU1nQRIrH4BflO/4k+83tfdYvDl+MObvlqHPRICzEdC9c6Q==",
+      "version": "1.4.536",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.536.tgz",
+      "integrity": "sha512-L4VgC/76m6y8WVCgnw5kJy/xs7hXrViCFdNKVG8Y7B2isfwrFryFyJzumh3ugxhd/oB1uEaEEvRdmeLrnd7OFA==",
       "dev": true
     },
     "elegant-spinner": {
@@ -33625,9 +33637,9 @@
       "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA="
     },
     "node-releases": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
-      "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
+      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
       "dev": true
     },
     "normalize-package-data": {
@@ -39802,9 +39814,9 @@
       "devOptional": true
     },
     "update-browserslist-db": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.9.tgz",
-      "integrity": "sha512-/xsqn21EGVdXI3EXSum1Yckj3ZVZugqyOZQ/CxYPBD/R+ko9NSUScf8tFF4dOKY+2pvSSJA/S+5B8s4Zr4kyvg==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
       "dev": true,
       "requires": {
         "escalade": "^3.1.1",

--- a/preact.config.js
+++ b/preact.config.js
@@ -5,6 +5,10 @@ import netlifyPlugin from 'preact-cli-plugin-netlify';
 import customProperties from 'postcss-custom-properties';
 import pageConfig from './src/config.json';
 import { Feed } from 'feed';
+
+// Enables some options that make local debugging easier
+const LOCAL_DEBUG = false;
+
 // prettier-ignore
 
 /**
@@ -39,6 +43,16 @@ export default function (config, env, helpers) {
 
 	const { rule: babel } = helpers.getLoadersByName(config, 'babel-loader')[0];
 	babel.exclude = [/babel-standalone/].concat(babel.exclude || []);
+
+	if (LOCAL_DEBUG) {
+		// When debugging locally, compile for higher browser versions to avoid
+		// having to debug through polyfills and overly transpiled code.
+		const envPresetConfig = babel.options.presets.find(preset => preset[0].includes('@babel/preset-env'))[1];
+		envPresetConfig.targets = {
+			browsers: ["fully supports es6-module"],
+		};
+		// config.devtool = 'cheap-source-map';
+	}
 
 	// Add CSS Custom Property fallback
 	const { loader: postcssLoader } = helpers.getLoadersByName(config, 'postcss-loader')[0];

--- a/src/components/controllers/repl/examples/todo-list-signal.txt
+++ b/src/components/controllers/repl/examples/todo-list-signal.txt
@@ -34,18 +34,18 @@ function TodoList() {
         {todos.value.map((todo, index) => {
           return (
             <li>
-							<label>
-								<input
-									type="checkbox"
-									checked={todo.completed}
-									onInput={() => {
-										todo.completed = !todo.completed
-										todos.value = [...todos.value];
-									}}
-								/>
-								{todo.completed ? <s>{todo.text}</s> : todo.text}
-							</label>
-							{' '}
+              <label>
+                <input
+                  type="checkbox"
+                  checked={todo.completed}
+                  onInput={() => {
+                    todo.completed = !todo.completed
+                    todos.value = [...todos.value];
+                  }}
+                />
+                {todo.completed ? <s>{todo.text}</s> : todo.text}
+              </label>
+              {' '}
               <button onClick={() => removeTodo(index)}>❌</button>
             </li>
           );

--- a/src/components/controllers/repl/examples/todo-list-signal.txt
+++ b/src/components/controllers/repl/examples/todo-list-signal.txt
@@ -34,15 +34,18 @@ function TodoList() {
         {todos.value.map((todo, index) => {
           return (
             <li>
-              <input
-                type="checkbox"
-                checked={todo.completed}
-                onInput={() => {
-                  todo.completed = !todo.completed
-                  todos.value = [...todos.value];
-                }}
-              />
-              {todo.completed ? <s>{todo.text}</s> : todo.text}{' '}
+							<label>
+								<input
+									type="checkbox"
+									checked={todo.completed}
+									onInput={() => {
+										todo.completed = !todo.completed
+										todos.value = [...todos.value];
+									}}
+								/>
+								{todo.completed ? <s>{todo.text}</s> : todo.text}
+							</label>
+							{' '}
               <button onClick={() => removeTodo(index)}>❌</button>
             </li>
           );

--- a/src/components/controllers/repl/repl.worker.js
+++ b/src/components/controllers/repl/repl.worker.js
@@ -84,18 +84,40 @@ async function bundle(sources) {
 			{
 				name: 'repl',
 				resolveId(id, importer) {
+					// Handle local source files
 					if (isSource(id)) return id;
+
+					// Resolve absolute path ids relative to their importer. For example,
+					// esm.sh will return this internally. `https://esm.sh/preact` returns
+					// `exports * from "/stable/preact@10.18.0/es2022/preact.mjs"`
 					if (id[0] === '/') {
+						if (!importer.match(/^https?:/)) {
+							throw new Error(`Cannot resolve ${id} from ${importer}`);
+						}
+
 						try {
 							return new URL(id, importer).href;
 						} catch (e) {}
 					}
-					if (!importer || isSource(importer) || /(^\.\/|:\/\/)/.test(id)) {
+
+					// If id is already an esm.sh url, add `?external=*` to it and return
+					if (id.includes('://esm.sh/')) {
+						const url = new URL(id);
+						url.searchParams.set('external', '*');
+						return url.href;
+					}
+
+					// Leave initial import, relative imports, & other http imports alone
+					if (!importer || /(^\.\/|:\/\/)/.test(id)) {
 						return id;
 					}
-					return new URL(id, new URL(importer + '/', 'file:')).pathname.slice(
-						1
-					);
+
+					// For everything else (i.e. bare module specifiers), resolve to a
+					// package on esm.sh. We'll support any syntax & options that esm.sh
+					// supports
+					const url = new URL(id, 'https://esm.sh/');
+					url.searchParams.set('external', '*');
+					return url.href;
 				},
 				async load(id) {
 					if (isSource(id)) {
@@ -103,11 +125,7 @@ async function bundle(sources) {
 						const out = transpile(code);
 						return out;
 					}
-					if (id.startsWith('https://esm.sh/')) return get(id);
-					const [, mod, v, path] =
-						id.match(/^((?:@[^@/]+\/)?[^@/]+)(?:@(\d[^@/]*))?(?:\/(.*))?$/) ||
-						[];
-					return dep(mod, v, path);
+					return get(id);
 				}
 			}
 		]
@@ -115,13 +133,6 @@ async function bundle(sources) {
 	const result = await bundle.generate({ format: 'cjs' });
 	await bundle.close();
 	return result.output[0];
-}
-
-// helper: fetch a dependency from esm.sh
-function dep(mod, version, path) {
-	path = (path || '').replace(/(?:^\/|\/$)/g, '');
-	if (path) path = '/' + path;
-	return get(`https://esm.sh/${mod}${version ? '@' + version : ''}${path}`);
 }
 
 // helper: cached http get text


### PR DESCRIPTION
Signals REPL example was failing cuz we were loading two copies of Preact on the page. The repl file imported 'preact' which esm.sh resolved to `esm.sh/preact@10.18.0`. The repl file also imported `@preact/signals` which also imports `preact` but esm.sh puts the version from the signals package.json on that import so the signals package imported `preact@10.17.0`.

This PR fixes the REPL by forcing all esm.sh URLs to have the `external=*` query param meaning any external imports are imported using bare specifiers (e.g. `preact` instead of `preact@10.17.0`). This ensures any imports transitive imports from esm.sh go through our bundler to get resolved, and we can resolve them to the same URL.

I've also updated the rollup config to use `resolveId` to resolve bare module specifiers to esm.sh URLs simplifying the logic a bit I think.

This does mean that if you import a library that breaks with the latest version of a package, it won't work in the REPL :/ But I figured getting something working for our examples and for Preact libs would be a good start.

Resolves #978