### PR TITLE
refactor: Document error boundaries specifically

### DIFF
--- a/content/en/guide/v10/components.md
+++ b/content/en/guide/v10/components.md
@@ -96,25 +96,28 @@ In order to have the clock's time update every second, we need to know when `<Cl
 
 > See [this diagram](https://twitter.com/dan_abramov/status/981712092611989509) to get a visual overview of how they relate to each other.
 
-#### componentDidCatch
+### Error Boundaries
 
-There is one lifecycle method that deserves a special recognition and that is `componentDidCatch`. It's special because it allows you to handle any errors that happen during rendering. This includes errors that happened in a lifecycle hook but excludes any asynchronously thrown errors, like after a `fetch()` call.
+An error boundary is a component that implements either `componentDidCatch()` or the static method `getDerivedStateFromError()` (or both). These are special methods that allow you to catch any errors that happen during rendering and are typically used to provide nicer error messages or other fallback content and save information for logging purposes. It's important to note that error boundaries cannot catch all errors and those thrown in event handlers or asynchronous code (like a `fetch()` call) need to be handled separately.
 
-When an error is caught, we can use this lifecycle to react to any errors and display a nice error message or any other fallback content.
+When an error is caught, we can use these methods to react to any errors and display a nice error message or any other fallback content.
 
 ```jsx
 // --repl
 import { Component, render } from 'preact';
 // --repl-before
 class Catcher extends Component {
-  
   constructor() {
     super();
     this.state = { errored: false };
   }
 
-  componentDidCatch(error) {
-    this.setState({ errored: true });
+  static getDerivedStateFromError(error) {
+    return { errored: true };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    errorReportingService(error, errorInfo);
   }
 
   render(props, state) {

--- a/content/en/guide/v10/components.md
+++ b/content/en/guide/v10/components.md
@@ -106,7 +106,7 @@ When an error is caught, we can use these methods to react to any errors and dis
 // --repl
 import { Component, render } from 'preact';
 // --repl-before
-class Catcher extends Component {
+class ErrorBoundary extends Component {
   constructor() {
     super();
     this.state = { errored: false };
@@ -128,7 +128,7 @@ class Catcher extends Component {
   }
 }
 // --repl-after
-render(<Catcher />, document.getElementById('app'));
+render(<ErrorBoundary />, document.getElementById('app'));
 ```
 
 ## Fragments

--- a/content/en/guide/v10/hooks.md
+++ b/content/en/guide/v10/hooks.md
@@ -427,8 +427,8 @@ const App = props => {
 };
 ```
 
-> If you've been using the class based component API in the past, then this hook is essentially an alternative to the [componentDidCatch](https://preactjs.com/guide/v10/whats-new/#componentdidcatch) lifecycle method.
-> This hook was introduced with Preact 10.2.0 .
+> If you've been using the class based component API in the past, then this hook is essentially an alternative to the [componentDidCatch](/guide/v10/whats-new/#componentdidcatch) lifecycle method.
+> This hook was introduced with Preact 10.2.0.
 
 ## Utility hooks
 

--- a/content/en/guide/v10/whats-new.md
+++ b/content/en/guide/v10/whats-new.md
@@ -37,7 +37,7 @@ function Foo() {
 
 We all wish errors wouldn't happen in our applications, but sometimes they do. With `componentDidCatch`, it's now possible to catch and handle any errors that occur within lifecycle methods like `render`, including exceptions deep in the component tree. This can be used to display user-friendly error messages, or write a log entry to an external service in case something goes wrong.
 
-[Lifecycle docs →](/guide/v10/components#componentdidcatch)
+[Lifecycle docs →](/guide/v10/components#error-boundaries)
 
 ```jsx
 // --repl


### PR DESCRIPTION
Inspired by https://x.com/windchime_yk/status/1707583523052453934?s=20

Mostly just to make error boundary info more discoverable, whether you're coming from a search engine or just searching our own docs, as we never actually use "error boundary" despite that being the prevailing term.