### PR TITLE
fix: Invalid yaml structure in Italian translation of signals blog post

### DIFF
--- a/content/it/blog/introducing-signals.md
+++ b/content/it/blog/introducing-signals.md
@@ -4,7 +4,7 @@ date: 2023-11-01
 authors:
   - Marvin Hagemeister
   - Jason Miller
-  translation_by:
+translation_by:
   - Francesco Luca Labianca
 ---
 


### PR DESCRIPTION
This was the cause of the failure to deploy. `yaml` would choke upon attempting to parse it