### PR TITLE
refactor: Flesh out 'Todo List' REPL example to match 'Todo List (Signals)'

### DIFF
--- a/src/components/controllers/repl/examples/todo-list.txt
+++ b/src/components/controllers/repl/examples/todo-list.txt
@@ -1,26 +1,64 @@
 import { render, Component } from 'preact';
 
 class TodoList extends Component {
-	state = { todos: [], text: '' };
-	setText = e => {
-		this.setState({ text: e.target.value });
+	state = {
+		todos: [
+			{ text: "Write my first post", completed: true },
+			{ text: "Buy new groceries", completed: false },
+			{ text: "Walk the dog", completed: false },
+		],
+		newItem: ''
 	};
+
+	setNewItem = e => {
+		this.setState({ newItem: e.target.value });
+	};
+
 	addTodo = () => {
-		let { todos, text } = this.state;
-		todos = todos.concat({ text });
-		this.setState({ todos, text: '' });
+		let { todos, newItem } = this.state;
+		todos = todos.concat({ text: newItem, completed: false });
+		this.setState({ todos, newItem: '' });  // Reset input value on add
 	};
-	render({}, { todos, text }) {
+
+	completeTodo = (index) => {
+		let { todos } = this.state;
+		todos[index].completed = !todos[index].completed;
+		this.setState({ todos });
+	};
+
+	removeTodo = (index) => {
+		let { todos } = this.state;
+		todos.splice(index, 1);
+		this.setState({ todos });
+	};
+
+	completedCount = () => {
+		return this.state.todos.filter(todo => todo.completed).length;
+	};
+
+	render({}, { todos, newItem }) {
 		return (
-			<form onSubmit={this.addTodo} action="javascript:">
-				<input value={text} onInput={this.setText} />
-				<button type="submit">Add</button>
+			<>
+				<input type="text" value={newItem} onInput={this.setNewItem} />
+				<button onClick={this.addTodo}>Add</button>
 				<ul>
-					{todos.map(todo => (
-						<li>{todo.text}</li>
+					{todos.map((todo, index) => (
+						<li>
+							<label>
+								<input
+									type="checkbox"
+									checked={todo.completed}
+									onInput={() => this.completeTodo(index)}
+								/>
+								{todo.completed ? <s>{todo.text}</s> : todo.text}
+							</label>
+							{' '}
+							<button onClick={() => this.removeTodo(index)}>❌</button>
+						</li>
 					))}
 				</ul>
-			</form>
+				<p>Completed count: {this.completedCount()}</p>
+			</>
 		);
 	}
 }


### PR DESCRIPTION
Someone mentioned this ages ago and it's been on my todo list (hehe) since.

If we have `Todo List` and `Todo List (Signals)`, it should be expected that the functionality otherwise matches and is more useful at comparing the class component to signals implementations. I tried to keep them looking pretty similar where possible, even if this might be a bit more verbose than you'd usually see.

Supersedes #822