### PR TITLE
chore: Add scrollbar-color to styles

### DIFF
--- a/src/components/code-editor/style.module.less
+++ b/src/components/code-editor/style.module.less
@@ -40,6 +40,7 @@
 			height: 100%;
 			background: var(--color-code-bg);
 			color: var(--color-code-text);
+			scrollbar-color: rgba(150, 150, 150, 0.8) rgba(150, 150, 150, 0.25);
 
 			::-webkit-scrollbar {
 				height: 10px;

--- a/src/components/controllers/tutorial/style.module.less
+++ b/src/components/controllers/tutorial/style.module.less
@@ -61,6 +61,7 @@
 			box-shadow: 1px 0 0 var(--color-brand);
 			overflow-y: scroll;
 			z-index: 10;
+			scrollbar-color: rgba(150, 150, 150, 0.8) rgba(150, 150, 150, 0.25);
 
 			&::-webkit-scrollbar {
 				height: 8px;


### PR DESCRIPTION
This adds `scrollbar-color` styles so that the look and feel of scrollbars on Firefox matches Chrome and Safari.

This property is supported in Firefox and soon to be Chrome and overrides the `::-webkit-scrollbar` styles in Chrome.