### PR TITLE
fix: blog page title invisible issue

### DIFF
--- a/src/components/blog-overview/blog.module.less
+++ b/src/components/blog-overview/blog.module.less
@@ -10,6 +10,8 @@
 	margin-top: 0 !important;
 
 	a {
+		width: 100% !important;
+		opacity: 1 !important;
 		color: var(--color-link);
 	}
 }

--- a/src/config.json
+++ b/src/config.json
@@ -51,6 +51,7 @@
 			"de": "Weiter lesen",
 			"zh": "继续阅读",
 			"es": "Seguir leyendo",
+			"kr": "계속 읽기",
 			"ru": "Продолжить чтение"
 		},
 		"tutorial": {
@@ -81,6 +82,7 @@
 			"name": {
 				"en": "Tutorial",
 				"zh": "教程",
+				"kr": "튜토리얼",
 				"ru": "Учебник"
 			},
 			"controller": "Tutorial"
@@ -93,6 +95,7 @@
 				"ja": "ガイド",
 				"es": "Guía",
 				"zh": "指南",
+				"kr": "가이드",
 				"ru": "Руководство"
 			},
 			"content": "guide",
@@ -107,6 +110,7 @@
 				"ja": "Preactについて",
 				"es": "Sobre",
 				"zh": "关于",
+				"kr": "소개",
 				"ru": "Разное"
 			},
 			"content": "about",
@@ -120,6 +124,7 @@
 						"ja": "Preactを使っている企業",
 						"es": "Empresas que usan Preact",
 						"zh": "使用 Preact 的企业",
+						"kr": "Preact를 사용하는 기업",
 						"ru": "Используют Preact"
 					}
 				},
@@ -132,6 +137,7 @@
 						"ja": "ライブラリとアドオン",
 						"es": "Librerías y complementos",
 						"zh": "第三方库和附加组件",
+						"kr": "라이브러리 & 애드온",
 						"ru": "Библиотеки и дополнения"
 					}
 				},
@@ -144,6 +150,7 @@
 						"ja": "デモと例",
 						"es": "Demostraciones y ejemplos",
 						"zh": "示例",
+						"kr": "데모 & 예제",
 						"ru": "Демонстрации и примеры"
 					}
 				},
@@ -156,6 +163,7 @@
 						"ja": "Preactの目的",
 						"es": "Objetivos del proyecto",
 						"zh": "项目目标",
+						"kr": "프로젝트 목표",
 						"ru": "Цели проекта"
 					}
 				},
@@ -168,6 +176,7 @@
 						"ja": "ブラウザのサポート",
 						"es": "Soporte de navegadores",
 						"zh": "浏览器支持",
+						"kr": "브라우저 지원",
 						"ru": "Поддержка браузеров"
 					}
 				}
@@ -178,6 +187,7 @@
 			"name": {
 				"en": "Blog",
 				"zh": "博客",
+				"kr": "블로그",
 				"ru": "Блог"
 			},
 			"first": "index",
@@ -305,6 +315,7 @@
 				"en": "Introduction",
 				"de": "Einführung",
 				"zh": "介绍",
+				"kr": "개요",
 				"ru": "Введение"
 			},
 			"routes": [
@@ -316,6 +327,7 @@
 						"ja": "はじめに",
 						"de": "Los geht's",
 						"zh": "开始上手",
+						"kr": "시작하기",
 						"ru": "Первые шаги"
 					}
 				},
@@ -326,6 +338,7 @@
 						"ja": "Preact Xの新機能",
 						"pt-br": "o que há de novo",
 						"zh": "新鲜功能",
+						"kr": "새로운 기능",
 						"ru": "Что нового?"
 					}
 				},
@@ -337,6 +350,7 @@
 						"ja": "Preact 8.xからのアップグレード",
 						"de": "Migration von 8.x",
 						"zh": "从 8.x 版本更新",
+						"kr": "8.x에서 업그레이드",
 						"ru": "Обновление с 8.x"
 					}
 				},
@@ -348,6 +362,7 @@
 						"ja": "チュートリアル",
 						"de": "Tutorial",
 						"zh": "教程",
+						"kr": "튜토리얼",
 						"ru": "Учебник"
 					}
 				}
@@ -357,6 +372,7 @@
 			"name": {
 				"en": "Essentials",
 				"zh": "基础",
+				"kr": "기본 요소",
 				"ru": "Основы"
 			},
 			"routes": [
@@ -368,6 +384,7 @@
 						"ja": "コンポーネント",
 						"de": "Komponenten",
 						"zh": "组件",
+						"kr": "컴포넌트 (Component)",
 						"ru": "Компоненты"
 					}
 				},
@@ -379,6 +396,7 @@
 						"ja": "フック(Hooks)",
 						"de": "Hooks",
 						"zh": "钩子",
+						"kr": "훅 (Hook)",
 						"ru": "Хуки"
 					}
 				},
@@ -387,6 +405,7 @@
 					"name": {
 						"en": "Signals",
 						"zh": "信号",
+						"kr": "시그널 (Signal)",
 						"ru": "Сигналы"
 					}
 				},
@@ -398,6 +417,7 @@
 						"ja": "フォーム",
 						"de": "Formulare",
 						"zh": "表单",
+						"kr": "폼 (Form)",
 						"ru": "Формы"
 					}
 				},
@@ -409,6 +429,7 @@
 						"ja": "リファレンス(Ref)",
 						"de": "Referenzen",
 						"zh": "引用",
+						"kr": "레퍼런스 (Ref)",
 						"ru": "Ссылки"
 					}
 				},
@@ -420,6 +441,7 @@
 						"ja": "コンテキスト(Context)",
 						"de": "Kontext",
 						"zh": "上下文",
+						"kr": "컨텍스트 (Context)",
 						"ru": "Контекст"
 					}
 				}
@@ -429,6 +451,7 @@
 			"name": {
 				"en": "Debug & Test",
 				"zh": "调试与测试",
+				"kr": "디버그 & 테스트",
 				"ru": "Отладка и тестирование"
 			},
 			"routes": [
@@ -440,6 +463,7 @@
 						"ja": "デバッグツール",
 						"de": "Entwickler-Tools",
 						"zh": "调试工具",
+						"kr": "디버깅 도구",
 						"ru": "Инструменты отладки"
 					}
 				},
@@ -451,6 +475,7 @@
 						"ja": "Preact Testing Library",
 						"de": "Preact Testing Library",
 						"zh": "Preact 测试库",
+						"kr": "Preact 테스팅 라이브러리",
 						"ru": "Preact Testing Library"
 					}
 				},
@@ -472,6 +497,7 @@
 			"name": {
 				"en": "React compatibility",
 				"zh": "React 兼容性",
+				"kr": "React 호환성",
 				"ru": "Совместимость с React"
 			},
 			"routes": [
@@ -506,6 +532,7 @@
 				"en": "Advanced",
 				"de": "Fortgeschritten",
 				"zh": "进阶",
+				"kr": "고급",
 				"ru": "Дополнительно"
 			},
 			"routes": [
@@ -517,6 +544,7 @@
 						"ja": "APIリファレンス",
 						"de": "API Referenz",
 						"zh": "API 参考",
+						"kr": "API 참조",
 						"ru": "Справочник по API"
 					}
 				},
@@ -528,6 +556,7 @@
 						"ja": "Webコンポーネント",
 						"de": "Web Components",
 						"zh": "Web 组件",
+						"kr": "웹 컴포넌트",
 						"ru": "Веб-компоненты"
 					}
 				},
@@ -536,6 +565,7 @@
 					"name": {
 						"en": "Progressive Web Apps",
 						"zh": "渐进式 Web 应用",
+						"kr": "프로그레시브 웹 앱",
 						"ru": "Прогрессивные веб-приложения"
 					}
 				},
@@ -547,6 +577,7 @@
 						"ja": "サーバーサイドレンダリング",
 						"de": "Server-Side Rendering",
 						"zh": "服务端渲染",
+						"kr": "서버 측 렌더링",
 						"ru": "Рендеринг на стороне сервера"
 					}
 				},
@@ -558,6 +589,7 @@
 						"ja": "Preactのステート管理の範囲外のDOMとの連携",
 						"de": "Externe DOM Mutationen",
 						"zh": "外部 DOM 修改",
+						"kr": "외부 DOM 변경",
 						"ru": "Внешние мутации DOM"
 					}
 				},
@@ -568,6 +600,7 @@
 						"ja": "オプションフック",
 						"de": "Optionen",
 						"zh": "选项钩子",
+						"kr": "옵션 훅",
 						"ru": "Опционные хуки"
 					}
 				},
@@ -600,7 +633,7 @@
 		{
 			"path": "/blog/signal-boosting",
 			"name": {
-				"en": "Signal Boosting",
+				"en": "시그널 증폭",
 				"zh": "信号增强",
 				"ru": "Усиление сигналов"
 			},
@@ -608,6 +641,7 @@
 			"excerpt": {
 				"en": "The new release of Preact Signals brings significant performance updates to the foundations of the reactive system. Read on to learn what kinds of tricks we employed to make this happen.",
 				"zh": "全新版本 Preact 信号为反应系统带来了显著的性能提升，阅读本文来了解其背后的工作原理。",
+				"kr": "Preact 시그널의 새 릴리스는 반응형 시스템의 기초에 중요한 성능 업데이트를 가져왔습니다. 어떤 종류의 트릭을 사용하여 이를 실현했는지 알아보려면 계속 읽어보세요.",
 				"ru": "Новая версия Preact Signals вносит значительные улучшения производительности в основы реактивной системы. Читайте дальше, чтобы узнать, какие трюки мы использовали, чтобы это произошло."
 			}
 		},
@@ -617,6 +651,7 @@
 				"en": "Introducing Signals",
 				"zh": "初见信号",
 				"es": "Introduciendo los Signals",
+				"kr": "시그널 소개",
 				"ru": "Знакомство с сигналами"
 			},
 			"date": "2022-09-06",
@@ -624,6 +659,7 @@
 				"en": "Signals are an easier way to manage your application's state compared to hooks. A signal is a container object with a special \"value\" property that holds some value. Reading a signal's value property from within a component or computed function automatically subscribes to updates, and writing to the value property triggers subscriptions.",
 				"zh": "信号是相比钩子更为简单直接的状态管理方式，这种存储容器对象的 \"value\" 属性可以存储值。阅读本文来了解如何在组件或计算函数中使用信号和其自动订阅更新和触发订阅的方式。",
 				"es": "Los Signals son una forma más fácil de administrar el estado de tu aplicación en comparación con los hooks. Un signal es un objeto contenedor con una propiedad especial \"value\" que contiene algún valor. Leer la propiedad value de un signal desde un componente o una función computada se suscribe automáticamente a las actualizaciones, y escribir en la propiedad value activa las suscripciones.",
+				"kr": "시그널은 애플리케이션의 상태를 훅보다 더 쉽게 관리하는 방법입니다. 시그널은 \"value\"라는 특별한 속성을 가진 컨테이너 객체로, 이 속성에 임의의 값을 저장합니다. 컴포넌트나 computed 함수 내에서 시그널의 value 속성을 읽음으로써 자동으로 업데이트를 구독하며, value 속성에 값을 쓰는 경우에 구독을 발생시킵니다.",
 				"ru": "Сигналы — это более простой способ управления состоянием вашего приложения по сравнению с хуками. Сигнал — это объект-контейнер со специальным свойством «value», которое содержит некоторое значение. Чтение свойства значения сигнала из компонента или вычисляемой функции автоматически подписывается на обновления, а запись в свойство значения запускает подписку."
 			}
 		}


### PR DESCRIPTION
## What is this PR?

I have fixed the issue of the post titles being invisible on the blog page. It was found to be influenced by the parent styles, and I have temporarily addressed it using `!important`.

## Screenshot

### Before

<img width="1060" alt="image" src="https://github.com/preactjs/preact-www/assets/42988225/ecee160b-6ea2-4aa6-9fff-0ef14adf664b">

### After

<img width="1030" alt="image" src="https://github.com/preactjs/preact-www/assets/42988225/ecf0e25c-8b31-4132-9af9-5eb7c4985fbf">
