### PR TITLE
chore(i18n): add Korean translation `About pages`

### DIFF
--- a/content/kr/about/browser-support.md
+++ b/content/kr/about/browser-support.md
@@ -1,0 +1,15 @@
+---
+name: 브라우저 지원
+permalink: '/about/browser-support'
+description: "Preact는 모든 최신 브라우저(Chrome, Firefox, Safari, Edge)와 IE11을 지원합니다."
+---
+
+# 브라우저 지원
+
+Preact는 최신 브라우저(Chrome, Firefox, Safari, Edge)와 IE11을 지원합니다. 이 브라우저들과 기본 설정에서 작동하며 추가적인 폴리필이 필요하지 않습니다.
+
+<center>
+    <a href="https://saucelabs.com/u/preact">
+        <img src="https://saucelabs.com/browser-matrix/preact.svg" alt="Browser List" style="background: #fff">
+    </a>
+</center>

--- a/content/kr/about/demos-examples.md
+++ b/content/kr/about/demos-examples.md
@@ -1,0 +1,133 @@
+---
+name: 데모 & 예제
+permalink: '/about/demos-examples'
+description: 'Preact 데모 & 예제 애플리케이션 모음'
+---
+
+# 데모 & 예제
+
+이 페이지는 Preact를 학습하는 데 사용할 수 있는 다양한 데모와 예제를 제공합니다.
+
+> :information_desk_person: _직접 만드셨나요?
+> [추가하기!](https://github.com/preactjs/preact-www/blob/master/content/en/about/demos-examples.md)_
+
+
+## 완전한 앱
+
+[**Preact Website** _(preactjs.com)_](https://preactjs.com)  
+물론 이 웹사이트는 Preact로 만들어졌습니다.  
+[Github Project](https://github.com/preactjs/preact-www)
+
+**[ESBench](http://esbench.com)** :alarm_clock:  
+Preact & Material Design Lite로 만들어진 웹사이트입니다.
+
+[**GuriVR**](https://gurivr.com) :eyeglasses:  
+자연어 기반의 Web VR 스토리 크리에이터  
+[Github Project](https://github.com/opennewslabs/guri-vr)
+
+[**BigWebQuiz**](https://bigwebquiz.com) :game_die:  
+Chrome Dev Summit 2016의 관중 참여형 점진적 웹 앱!  
+[Github Project](https://github.com/jakearchibald/big-web-quiz)
+
+**[Nectarine.rocks](http://nectarine.rocks)** :peach:  
+오픈 소스 peach.cool 앱  
+[Github Project](https://github.com/developit/nectarine)
+
+**[Web Maker](https://webmakerapp.com/app/)** :zap:  
+매우 빠른 오프라인 프런트엔드 플레이그라운드  
+[Github Project](https://github.com/chinchang/web-maker)
+
+**[BitMidi](https://bitmidi.com/)** :musical_keyboard:  
+무료 MIDI 파일을 위한 웨이백 머신  
+[Github Project](https://github.com/feross/bitmidi.com)
+
+**[BBC Roasting Calculator](https://www.bbc.com/food/techniques/articles/roast-calculator)** :turkey:  
+다양한 고기 부위에 대한 조리 시간을 계산합니다.
+
+**[Dropfox](https://github.com/developit/dropfox)** :wolf:  
+Preact, Electron 및 Photon으로 만든 Dropbox용 데스크톱 앱
+
+**[Embed Hacker News](https://github.com/TXTPEN/hn)** :kissing_closed_eyes:  
+블로그 글 아래에 Hacker News 코멘트 트리를 삽입합니다.
+
+**[Connectivity Index](https://cindex.co)** :iphone:  
+[Akamai 인터넷 상태 보고서](https://content.akamai.com/PG7010-Q2-2016-SOTI-Connectivity-Report.html) 데이터를 국가별로 검색할 수 있는 웹사이트
+
+**[Drag & Drop file upload (webpack 2)](https://contentful-labs.github.io/file-upload-example/)** :rocket:  
+Contentful에 애셋을 업로드하는 데 사용되는 데스크톱 앱 (API 기반 CMS)  
+[Github Project](https://github.com/contentful-labs/file-upload-example)
+
+**[Exchange Widget](https://sgtpep.github.io/exchange-widget/dist/)** :currency_exchange:  
+인기 있는 모바일 앱에서 영감을 받은 화폐 환율 위젯을 Preact, Meiosis, HTML 태그 템플릿 및 기본 ES 모듈을 사용해 구현합니다.  
+[Github Project](https://github.com/sgtpep/exchange-widget)
+
+**[Blaze](https://blaze.now.sh)** :zap:  
+모던 P2P 파일 공유 점진적 웹 앱  
+[Github Project](https://github.com/blenderskool/blaze)
+
+**[1tuner](https://1tuner.com)** :radio:  
+라디오와 팟캐스트를 청취할 수 있는 웹사이트  
+[Github Project](https://github.com/robinbakker/1tuner)
+
+## 완전한 데모 & 예제
+
+**[Documentation Viewer](https://documentation-viewer.firebaseapp.com)**  
+documentation.js 출력물을 온라인에서 확인합니다.  
+[Github Project](https://github.com/developit/documentation-viewer)
+
+**[TodoMVC](http://developit.github.io/preact-todomvc/)**  
+비공식이지만 가장 빠른 TodoMVC 구현입니다.  
+[Github Project](https://github.com/developit/preact-todomvc)
+
+**[TodoMVC+PouchDB](http://katopz.github.io/preact-todomvc-pouchdb/)** :floppy_disk:  
+[PouchDB](https://pouchdb.com/)를 사용한 오프라인 동기화 TodoMVC  
+[Github Project](https://github.com/katopz/preact-todomvc-pouchdb)
+
+**[Hacker News Minimal](https://developit.github.io/hn_minimal/)** :newspaper:  
+작은 해커 뉴스 클라이언트  
+[Github Project](https://github.com/developit/hn_minimal)
+
+**[Preact Boilerplate](https://preact-boilerplate.surge.sh)** :zap:  
+두 개의 명령으로 시작하는 프로젝트. Preact + Webpack + LESS + CSS Modules  
+[Github Project](https://github.com/developit/preact-boilerplate)
+
+**[Preact Offline Starter](https://preact-starter.now.sh)** :100:  
+점진적 웹 앱을 위한 Webpack2 스타터의 간소화된 버전. 오프라인 지원 포함  
+[Github Project](https://github.com/lukeed/preact-starter)
+
+**[Preact Redux Example](https://preact-redux-example.surge.sh)** :repeat:  
+간단한 To-Do 리스트를 구현한 Preact + Redux 예제 프로젝트  
+[Github Project](https://github.com/developit/preact-redux-example)
+
+**[Preact Without Babel](https://github.com/developit/preact-without-babel)** :horse:  
+Babel, ES2015 또는 JSX 없이 Preact를 사용하는 방법
+
+**[preact-minimal](https://github.com/aganglada/preact-minimal)** :rocket:  
+프로젝트를 즉시 시작할 수 있는 최소한의 도구가 갖춰져 있는 Preact 구조
+
+**[preact-typescript-webpack4-less](https://github.com/lexey111/preact-typescript-webpack4-boilerplate)**  
+Preact, Typescript 및 Webpack4를 사용하여 최소한의 설정으로 시작하는 프로젝트
+
+**[Preact Homepage Generator](https://thomaswood.me/)** :globe_with_meridians:  
+JSON 데이터만 수정하여 새로운 개인 웹페이지를 빠르게 만듭니다.  
+[Github Project](https://github.com/tomasswood/preact-homepage-generator)
+
+**[Parcel + Preact + Unistore Starter](https://github.com/hwclass/parcel-preact-unistore-starter)**  
+프로토타이핑 및 소규모/중규모 프로젝트 구조를 위한 스타터 팩
+
+**[buildless-preact-starter](https://github.com/ttntm/buildless-preact-starter)** :rocket:  
+빌드 없이 Preact를 사용하는 환경을 위한 스타터 템플릿
+
+## Codepens
+
+- [Flickr Browser](http://codepen.io/developit/full/VvMZwK/) _(@ CodePen)_
+- [Animating Text](http://codepen.io/developit/full/LpNOdm/) _(@ CodePen)_
+- [60FPS Rainbow Spiral](http://codepen.io/developit/full/xGoagz/) _(@ CodePen)_
+- [Simple Clock](http://jsfiddle.net/developit/u9m5x0L7/embedded/result,js/) _(@ JSFiddle)_
+- [3D + ThreeJS](http://codepen.io/developit/pen/PPMNjd?editors=0010) _(@ CodePen)_
+
+## 템플릿
+
+:zap: [**JSFiddle 템플릿**](https://jsfiddle.net/developit/rs6zrh5f/embedded/result/)
+
+:zap: [**CodePen 템플릿**](http://codepen.io/developit/pen/pgaROe?editors=0010)

--- a/content/kr/about/libraries-addons.md
+++ b/content/kr/about/libraries-addons.md
@@ -1,0 +1,66 @@
+
+---
+name: 라이브러리 & 애드온
+permalink: '/about/addons-libraries'
+description: 'Preact와 잘 동작하는 라이브러리와 애드온 모음'
+---
+
+# 라이브러리 & 애드온
+
+Preact와 훌륭하게 동작하는 모듈 모음입니다.
+
+> :information_desk_person: _직접 만드셨나요?
+> [추가하기!](https://github.com/preactjs/preact-www/blob/master/content/en/about/libraries-addons.md)_
+
+## 애드온
+
+- :repeat: [**preact-cycle**](https://github.com/developit/preact-cycle): Functional-reactive paradigm for Preact
+- :page_facing_up: [**preact-render-to-string**](https://github.com/preactjs/preact-render-to-string): Universal rendering.
+- :timer_clock: [**relaks**](https://github.com/trambarhq/relaks): Create components with render methods that return asynchronously.
+- :nut_and_bolt: [**express-preact-views**](https://github.com/edwjusti/express-preact-views): Express View Engine.
+- :floppy_disk: [**Prefresh**](https://github.com/JoviDeCroock/prefresh): Fast-Refresh for Preact.
+- :bookmark_tabs: [**adonis-preact**](https://github.com/DonsWayo/adonis-preact): Use Preact in Adonisjs
+
+## 컴포넌트
+
+- :earth_americas: [**preact-router**](https://github.com/preactjs/preact-router): URL routing for your components
+- :bookmark_tabs: [**preact-markup**](https://github.com/developit/preact-markup): Render HTML & Custom Elements as JSX & Components
+- :satellite: [**preact-portal**](https://github.com/developit/preact-portal): Render Preact components into (a) SPACE :milky_way:
+- :pencil: [**preact-richtextarea**](https://github.com/developit/preact-richtextarea): Simple HTML editor component
+- :bookmark: [**preact-token-input**](https://github.com/developit/preact-token-input): Text field that tokenizes input, for things like tags
+- :card_index: [**preact-virtual-list**](https://github.com/developit/preact-virtual-list): Easily render lists with millions of rows ([demo](https://jsfiddle.net/developit/qqan9pdo/))
+- :triangular_ruler: [**preact-layout**](https://download.github.io/preact-layout/): Small and simple layout library
+- :construction_worker: [**preact-helmet**](https://github.com/download/preact-helmet): A document head manager for Preact
+- :arrow_up_down: [**preact-custom-scrollbars**](https://github.com/lucafalasco/preact-custom-scrollbars): Fully customizable scrollbars, for frictionless native browser scrolling
+- 🧱 [**@modular-forms/preact**](https://modularforms.dev/): Modular and type-safe form library
+
+## 통합
+
+- :thought_balloon: [**preact-socrates**](https://github.com/matthewmueller/preact-socrates): Preact plugin for [Socrates](http://github.com/matthewmueller/socrates)
+- :rowboat: [**preact-flyd**](https://github.com/xialvjun/preact-flyd): Use [flyd](https://github.com/paldepind/flyd) FRP streams in Preact + JSX
+- :speech_balloon: [**preact-i18nline**](https://github.com/download/preact-i18nline): Integrates the ecosystem around [i18n-js](https://github.com/everydayhero/i18n-js) with Preact via [i18nline](https://github.com/download/i18nline).
+- :diamond_shape_with_a_dot_inside: [**Capacitor**](https://capacitorjs.com/solution/preact): Turn your Preact app into a Native iOS/Android App and PWA.
+- :ice_cube: [**Kretes**](https://kretes.dev/docs/howtos/preact-setup/): Build full-stack TypeScript apps using Preact and Node.js
+- 🏝: [**preact-island**](https://github.com/mwood23/preact-island): Run your Preact widget on any website with reactive props.
+
+## GUI 툴킷
+
+- 🎴 [**@mui/material**](https://github.com/mui/material-ui/tree/master/examples/material-preact): the React UI library you always wanted. Follow your own design system, or start with Material Design.
+- :thumbsup: [**preact-material-components**](https://github.com/prateekbh/preact-material-components): Material Components for the Web (supersedes MDL)
+- :white_square_button: [**preact-mdl**](https://github.com/developit/preact-mdl): Use [MDL](https://getmdl.io) as Preact components
+- :rocket: [**preact-photon**](https://github.com/developit/preact-photon): build beautiful desktop UI with [photon](http://photonkit.com)
+- :penguin: [**preact-weui**](https://github.com/afeiship/preact-weui): [Weui](https://github.com/afeiship/preact-weui) for Preact
+- 💅 [**preact-fluid**](https://github.com/ajainvivek/preact-fluid): [Fluid](https://github.com/ajainvivek/preact-fluid) minimal UI kit for Preact
+- :book: [**storybook-preact**](https://github.com/storybooks/storybook/tree/next/app/preact): Storybook for Preact is a UI development environment for your Preact components
+
+## 테스트
+
+- :microscope: [**preact-jsx-chai**](https://github.com/developit/preact-jsx-chai): JSX assertion testing _(no DOM, right in Node)_
+- :white_check_mark: [**unexpected-preact**](https://github.com/bruderstein/unexpected-preact): JSX assertions, events, snapshots in Jest _(DOM, works under Node jsdom or out-of-the-box in Jest)_ - [docs](https://bruderstein.github.io/unexpected-preact/)
+
+## 유틸리티
+
+- :tophat: [**preact-classless-component**](https://github.com/ld0rman/preact-classless-component): create preact components without the class keyword
+- :hammer: [**preact-hyperscript**](https://github.com/queckezz/preact-hyperscript): Hyperscript-like syntax for creating elements
+- :white_check_mark: [**shallow-compare**](https://github.com/tkh44/shallow-compare): simplified `shouldComponentUpdate` helper.
+- :signal_strength: [**@deepsignal/preact**](https://github.com/EthanStandel/deepsignal/tree/main/packages/preact): Extension of `@preact/signals` for full state management

--- a/content/kr/about/project-goals.md
+++ b/content/kr/about/project-goals.md
@@ -1,0 +1,29 @@
+---
+name: 프로젝트 목표
+permalink: '/about/project-goals'
+description: "Preact의 프로젝트 목표에 대해 자세히 알아보기"
+---
+
+# Preact의 목표
+
+## 목표
+
+Preact는 몇 가지 주요 목표를 달성하려 합니다.
+
+- **성능:** 빠르고 효율적인 렌더링
+- **크기:** 작고 가벼움 _(약 3.5 kB 정도)_
+- **효율성:** 효과적인 메모리 사용 _(GC Thrash 회피)_
+- **이해성:** 코드베이스를 이해하는 데 몇 시간 이상 소요되지 않아야 함
+- **호환성:** Preact는 React API와 _대부분 호환_ 되도록 하는 목표를 설정했습니다. [preact/compat]은 React와 가능한 한 많은 호환성을 달성하려고 노력합니다.
+
+## 비목표
+
+React의 일부 기능은 Preact에서 의도적으로 제외되었습니다. 이는 위에 나열된 주요 프로젝트 목표를 충족하면서 얻을 수 없거나 Preact의 핵심 기능 범위 내에 맞지 않기 때문입니다.
+
+의도적으로 [React와 다른 부분](/guide/v10/differences-to-react)에 속하는 항목:
+
+- `PropTypes`, 별도의 라이브러리로 쉽게 사용 가능
+- `Children`, 원시 배열로 대체 가능
+- `Synthetic Events`, Preact는 IE8과 같은 이전 브라우저의 문제를 해결하지 않음
+
+[preact/compat]: /guide/v10/switching-to-preact

--- a/content/kr/about/we-are-using.md
+++ b/content/kr/about/we-are-using.md
@@ -1,0 +1,14 @@
+---
+name: We Are Using
+title: 누가 Preact를 사용하고 있을까요?
+permalink: '/about/we-are-using'
+description: 'Preact를 자랑스럽게 사용하고 있는 기업들'
+---
+
+Preact는 오픈 소스 프로젝트에서부터 대형 다국적 기업까지 다양한 웹사이트에서 사용됩니다. 아래는 Preact를 공개 프로젝트에 사용하는 일부 조직들입니다.
+
+여러분의 회사도 Preact를 사용하고 있나요? [목록에 추가하세요!](https://github.com/preactjs/preact-www/blob/master/src/components/we-are-using/index.js)
+
+<div class="breaker">
+  <we-are-using></we-are-using>
+</div>

--- a/src/config.json
+++ b/src/config.json
@@ -51,6 +51,7 @@
 			"de": "Weiter lesen",
 			"zh": "继续阅读",
 			"es": "Seguir leyendo",
+			"kr": "계속 읽기",
 			"ru": "Продолжить чтение"
 		},
 		"tutorial": {
@@ -81,6 +82,7 @@
 			"name": {
 				"en": "Tutorial",
 				"zh": "教程",
+				"kr": "튜토리얼",
 				"ru": "Учебник"
 			},
 			"controller": "Tutorial"
@@ -93,6 +95,7 @@
 				"ja": "ガイド",
 				"es": "Guía",
 				"zh": "指南",
+				"kr": "가이드",
 				"ru": "Руководство"
 			},
 			"content": "guide",
@@ -107,6 +110,7 @@
 				"ja": "Preactについて",
 				"es": "Sobre",
 				"zh": "关于",
+				"kr": "소개",
 				"ru": "Разное"
 			},
 			"content": "about",
@@ -120,6 +124,7 @@
 						"ja": "Preactを使っている企業",
 						"es": "Empresas que usan Preact",
 						"zh": "使用 Preact 的企业",
+						"kr": "Preact를 사용하는 기업",
 						"ru": "Используют Preact"
 					}
 				},
@@ -132,6 +137,7 @@
 						"ja": "ライブラリとアドオン",
 						"es": "Librerías y complementos",
 						"zh": "第三方库和附加组件",
+						"kr": "라이브러리 & 애드온",
 						"ru": "Библиотеки и дополнения"
 					}
 				},
@@ -144,6 +150,7 @@
 						"ja": "デモと例",
 						"es": "Demostraciones y ejemplos",
 						"zh": "示例",
+						"kr": "데모 & 예제",
 						"ru": "Демонстрации и примеры"
 					}
 				},
@@ -156,6 +163,7 @@
 						"ja": "Preactの目的",
 						"es": "Objetivos del proyecto",
 						"zh": "项目目标",
+						"kr": "프로젝트 목표",
 						"ru": "Цели проекта"
 					}
 				},
@@ -168,6 +176,7 @@
 						"ja": "ブラウザのサポート",
 						"es": "Soporte de navegadores",
 						"zh": "浏览器支持",
+						"kr": "브라우저 지원",
 						"ru": "Поддержка браузеров"
 					}
 				}
@@ -178,6 +187,7 @@
 			"name": {
 				"en": "Blog",
 				"zh": "博客",
+				"kr": "블로그",
 				"ru": "Блог"
 			},
 			"first": "index",
@@ -305,6 +315,7 @@
 				"en": "Introduction",
 				"de": "Einführung",
 				"zh": "介绍",
+				"kr": "개요",
 				"ru": "Введение"
 			},
 			"routes": [
@@ -316,6 +327,7 @@
 						"ja": "はじめに",
 						"de": "Los geht's",
 						"zh": "开始上手",
+						"kr": "시작하기",
 						"ru": "Первые шаги"
 					}
 				},
@@ -326,6 +338,7 @@
 						"ja": "Preact Xの新機能",
 						"pt-br": "o que há de novo",
 						"zh": "新鲜功能",
+						"kr": "새로운 기능",
 						"ru": "Что нового?"
 					}
 				},
@@ -337,6 +350,7 @@
 						"ja": "Preact 8.xからのアップグレード",
 						"de": "Migration von 8.x",
 						"zh": "从 8.x 版本更新",
+						"kr": "8.x에서 업그레이드하기",
 						"ru": "Обновление с 8.x"
 					}
 				},
@@ -348,6 +362,7 @@
 						"ja": "チュートリアル",
 						"de": "Tutorial",
 						"zh": "教程",
+						"kr": "튜토리얼",
 						"ru": "Учебник"
 					}
 				}
@@ -357,6 +372,7 @@
 			"name": {
 				"en": "Essentials",
 				"zh": "基础",
+				"kr": "필수 항목",
 				"ru": "Основы"
 			},
 			"routes": [
@@ -368,6 +384,7 @@
 						"ja": "コンポーネント",
 						"de": "Komponenten",
 						"zh": "组件",
+						"kr": "컴포넌트",
 						"ru": "Компоненты"
 					}
 				},
@@ -379,6 +396,7 @@
 						"ja": "フック(Hooks)",
 						"de": "Hooks",
 						"zh": "钩子",
+						"kr": "훅",
 						"ru": "Хуки"
 					}
 				},
@@ -387,6 +405,7 @@
 					"name": {
 						"en": "Signals",
 						"zh": "信号",
+						"kr": "시그널",
 						"ru": "Сигналы"
 					}
 				},
@@ -398,6 +417,7 @@
 						"ja": "フォーム",
 						"de": "Formulare",
 						"zh": "表单",
+						"kr": "폼",
 						"ru": "Формы"
 					}
 				},
@@ -409,6 +429,7 @@
 						"ja": "リファレンス(Ref)",
 						"de": "Referenzen",
 						"zh": "引用",
+						"kr": "레퍼런스",
 						"ru": "Ссылки"
 					}
 				},
@@ -420,6 +441,7 @@
 						"ja": "コンテキスト(Context)",
 						"de": "Kontext",
 						"zh": "上下文",
+						"kr": "컨텍스트",
 						"ru": "Контекст"
 					}
 				}
@@ -429,6 +451,7 @@
 			"name": {
 				"en": "Debug & Test",
 				"zh": "调试与测试",
+				"kr": "디버그 & 테스트",
 				"ru": "Отладка и тестирование"
 			},
 			"routes": [
@@ -440,6 +463,7 @@
 						"ja": "デバッグツール",
 						"de": "Entwickler-Tools",
 						"zh": "调试工具",
+						"kr": "디버깅 도구",
 						"ru": "Инструменты отладки"
 					}
 				},
@@ -451,6 +475,7 @@
 						"ja": "Preact Testing Library",
 						"de": "Preact Testing Library",
 						"zh": "Preact 测试库",
+						"kr": "Preact 테스팅 라이브러리",
 						"ru": "Preact Testing Library"
 					}
 				},
@@ -472,6 +497,7 @@
 			"name": {
 				"en": "React compatibility",
 				"zh": "React 兼容性",
+				"kr": "React 호환성",
 				"ru": "Совместимость с React"
 			},
 			"routes": [
@@ -506,6 +532,7 @@
 				"en": "Advanced",
 				"de": "Fortgeschritten",
 				"zh": "进阶",
+				"kr": "고급",
 				"ru": "Дополнительно"
 			},
 			"routes": [
@@ -517,6 +544,7 @@
 						"ja": "APIリファレンス",
 						"de": "API Referenz",
 						"zh": "API 参考",
+						"kr": "API 참조",
 						"ru": "Справочник по API"
 					}
 				},
@@ -528,6 +556,7 @@
 						"ja": "Webコンポーネント",
 						"de": "Web Components",
 						"zh": "Web 组件",
+						"kr": "웹 컴포넌트",
 						"ru": "Веб-компоненты"
 					}
 				},
@@ -536,6 +565,7 @@
 					"name": {
 						"en": "Progressive Web Apps",
 						"zh": "渐进式 Web 应用",
+						"kr": "점진적 웹 앱 (PWA)",
 						"ru": "Прогрессивные веб-приложения"
 					}
 				},
@@ -547,6 +577,7 @@
 						"ja": "サーバーサイドレンダリング",
 						"de": "Server-Side Rendering",
 						"zh": "服务端渲染",
+						"kr": "서버 측 렌더링",
 						"ru": "Рендеринг на стороне сервера"
 					}
 				},
@@ -558,6 +589,7 @@
 						"ja": "Preactのステート管理の範囲外のDOMとの連携",
 						"de": "Externe DOM Mutationen",
 						"zh": "外部 DOM 修改",
+						"kr": "외부 DOM 변경",
 						"ru": "Внешние мутации DOM"
 					}
 				},
@@ -568,6 +600,7 @@
 						"ja": "オプションフック",
 						"de": "Optionen",
 						"zh": "选项钩子",
+						"kr": "옵션 훅",
 						"ru": "Опционные хуки"
 					}
 				},
@@ -602,12 +635,14 @@
 			"name": {
 				"en": "Signal Boosting",
 				"zh": "信号增强",
+				"kr": "시그널 부스팅",
 				"ru": "Усиление сигналов"
 			},
 			"date": "2022-09-23",
 			"excerpt": {
 				"en": "The new release of Preact Signals brings significant performance updates to the foundations of the reactive system. Read on to learn what kinds of tricks we employed to make this happen.",
 				"zh": "全新版本 Preact 信号为反应系统带来了显著的性能提升，阅读本文来了解其背后的工作原理。",
+				"kr": "Preact 시그널의 새로운 릴리스는 반응형 시스템의 기초에 중요한 성능 업데이트를 가져왔습니다. 이를 실현하기 위해 사용한 트릭에 대해 알아보세요.",
 				"ru": "Новая версия Preact Signals вносит значительные улучшения производительности в основы реактивной системы. Читайте дальше, чтобы узнать, какие трюки мы использовали, чтобы это произошло."
 			}
 		},
@@ -617,6 +652,7 @@
 				"en": "Introducing Signals",
 				"zh": "初见信号",
 				"es": "Introduciendo los Signals",
+				"kr": "시그널 소개",
 				"ru": "Знакомство с сигналами"
 			},
 			"date": "2022-09-06",
@@ -624,6 +660,7 @@
 				"en": "Signals are an easier way to manage your application's state compared to hooks. A signal is a container object with a special \"value\" property that holds some value. Reading a signal's value property from within a component or computed function automatically subscribes to updates, and writing to the value property triggers subscriptions.",
 				"zh": "信号是相比钩子更为简单直接的状态管理方式，这种存储容器对象的 \"value\" 属性可以存储值。阅读本文来了解如何在组件或计算函数中使用信号和其自动订阅更新和触发订阅的方式。",
 				"es": "Los Signals son una forma más fácil de administrar el estado de tu aplicación en comparación con los hooks. Un signal es un objeto contenedor con una propiedad especial \"value\" que contiene algún valor. Leer la propiedad value de un signal desde un componente o una función computada se suscribe automáticamente a las actualizaciones, y escribir en la propiedad value activa las suscripciones.",
+				"kr": "시그널은 훅에 비해 애플리케이션의 상태를 관리하는 더 쉬운 방법입니다. 시그널은 어떤 값을 저장하는 특수한 \"value\" 속성을 가진 컨테이너 객체입니다. 컴포넌트나 computed 함수 내에서 시그널의 value 속성을 읽으면 자동으로 업데이트를 구독하고, value 속성에 임의의 값을 쓰는 경우 구독을 트리거합니다.",
 				"ru": "Сигналы — это более простой способ управления состоянием вашего приложения по сравнению с хуками. Сигнал — это объект-контейнер со специальным свойством «value», которое содержит некоторое значение. Чтение свойства значения сигнала из компонента или вычисляемой функции автоматически подписывается на обновления, а запись в свойство значения запускает подписку."
 			}
 		}


### PR DESCRIPTION
- browser-support.md
- demos-examples.md
- libraries-addons.md
- project-goals.md
- we-are-using.md

> The libraries & addons page has been translated only for the titles for now