### PR TITLE
fix: Fragment links incorrectly hiding blog titles

### DIFF
--- a/src/style/markdown.css
+++ b/src/style/markdown.css
@@ -395,20 +395,22 @@
 			padding-top: calc(var(--header-and-banner-height) + 3.25rem);
 		}
 
-		a {
-			opacity: 0;
-			display: inline-flex;
-			width: 1.5rem;
-			margin-left: -1.5rem;
-
-			&::before {
-				content: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="%23fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 7h3a5 5 0 0 1 5 5 5 5 0 0 1-5 5h-3m-6 0H6a5 5 0 0 1-5-5 5 5 0 0 1 5-5h3"></path><line x1="8" y1="12" x2="16" y2="12"></line></svg>');
-			}
-		}
-
-		content-region[name*='guide'] &:hover {
+		content-region[name*='guide'] & {
 			a {
-				opacity: 1;
+				opacity: 0;
+				display: inline-flex;
+				width: 1.5rem;
+				margin-left: -1.5rem;
+
+				&::before {
+					content: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="%23fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 7h3a5 5 0 0 1 5 5 5 5 0 0 1-5 5h-3m-6 0H6a5 5 0 0 1-5-5 5 5 0 0 1 5-5h3"></path><line x1="8" y1="12" x2="16" y2="12"></line></svg>');
+				}
+			}
+
+			&:hover {
+				a {
+					opacity: 1;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
From #1012, fixes #1041

Moves entire block into `content-region[name*='guide']` so the styles don't leak out