### PR TITLE
fix: Browser page titles

### DIFF
--- a/content/en/blog.md
+++ b/content/en/blog.md
@@ -1,3 +1,8 @@
+---
+title: Blog
+show_title: false
+---
+
 Find out more about what the Preact team is working on.
 
 <div><blog-overview></blog-overview></div>

--- a/content/ru/blog.md
+++ b/content/ru/blog.md
@@ -1,3 +1,8 @@
+---
+title: Blog
+show_title: false
+---
+
 Узнайте больше о том, над чем работает команда Preact.
 
 <div><blog-overview></blog-overview></div>

--- a/content/zh/blog.md
+++ b/content/zh/blog.md
@@ -1,3 +1,8 @@
+---
+title: Blog
+show_title: false
+---
+
 了解 Preact 团队的研究重心。
 
 <div><blog-overview></blog-overview></div>

--- a/src/components/controllers/page/index.js
+++ b/src/components/controllers/page/index.js
@@ -45,7 +45,7 @@ export default function Page({ route, prev, next }, ctx) {
 	// "name" is the exact page ID from the URL
 	// "current" is the currently *displayed* page ID.
 
-	const isHome = current === 'index';
+	const isHome = route.path === '/';
 	const showTitle = meta.show_title !== false;
 	const canEdit = !isHome;
 	const hasSidebar = meta.toc !== false && isDocPage(url);

--- a/src/components/controllers/repl/index.js
+++ b/src/components/controllers/repl/index.js
@@ -6,6 +6,7 @@ import { localStorageGet, localStorageSet } from '../../../lib/localstorage';
 import { parseStackTrace } from './errors';
 import style from './style.module.css';
 import REPL_CSS from '!!raw-loader!./examples.css';
+import { useTitle } from '../utils';
 
 import simpleCounterExample from '!!file-loader!./examples/simple-counter.txt';
 import counterWithHtmExample from '!!file-loader!./examples/counter-with-htm.txt';
@@ -234,6 +235,8 @@ export default class Repl extends Component {
 	}
 
 	render(_, { loading, code, error, exampleSlug, copied }) {
+		useTitle('REPL: Try Preact in the browser');
+
 		if (loading) {
 			return (
 				<ReplWrapper loading>

--- a/src/components/controllers/tutorial/index.js
+++ b/src/components/controllers/tutorial/index.js
@@ -22,7 +22,7 @@ import { ErrorOverlay } from '../repl/error-overlay';
 import { parseStackTrace } from '../repl/errors';
 import ContentRegion from '../../content-region';
 import widgets from '../../widgets';
-import { usePage } from '../page';
+import { usePage } from '../utils';
 import { useStore, storeCtx } from '../../store-adapter';
 import { InjectPrerenderData } from '../../../lib/prerender-data';
 import { getContent } from '../../../lib/content';

--- a/src/components/controllers/utils.js
+++ b/src/components/controllers/utils.js
@@ -1,0 +1,113 @@
+import { useEffect, useRef, useState } from 'preact/hooks';
+
+import { getContentOnServer, getContent } from '../../lib/content';
+import { getPrerenderData } from '../../lib/prerender-data';
+import { createTitle } from '../../lib/page-title';
+
+/**
+ * Set `document.title`
+ * @param {string} title
+ */
+export function useTitle(title) {
+	useEffect(() => {
+		if (title) {
+			document.title = createTitle(title);
+		}
+	}, [title]);
+}
+
+/**
+ * Set the meta description tag content
+ * @param {string} text
+ */
+export function useDescription(text) {
+	useEffect(() => {
+		const el = document.querySelector('meta[name=description]');
+		if (text && el) {
+			el.setAttribute('content', text);
+		}
+	}, [text]);
+}
+
+export const getContentId = route => route.content || route.path;
+export function usePage(route, lang) {
+	// on the server, pass data down through the tree to avoid repeated FS lookups
+	if (PRERENDER) {
+		const { content, html, meta } = getContentOnServer(route.path, lang);
+		return {
+			current: null,
+			content,
+			html,
+			meta,
+			loading: true // this is important since the client will initialize in a loading state.
+		};
+	}
+
+	const [current, setCurrent] = useState(getContentId(route));
+
+	const bootData = getPrerenderData(current);
+
+	const [hydrated, setHydrated] = useState(!!bootData);
+	const [content, setContent] = useState(
+		hydrated && bootData && bootData.content
+	);
+	const [html, setHtml] = useState(hydrated && bootData && bootData.html);
+
+	const [loading, setLoading] = useState(true);
+	const [isFallback, setFallback] = useState(false);
+	let [meta, setMeta] = useState(hydrated ? bootData.meta : undefined);
+	if (!meta) meta = (hydrated && bootData.meta) || {};
+
+	const lock = useRef();
+	useEffect(() => {
+		if (!didLoad) {
+			setLoading(true);
+		}
+		const contentId = getContentId(route);
+		lock.current = contentId;
+		getContent([lang, contentId]).then(data => {
+			// Discard old load events
+			if (lock.current !== contentId) return;
+			onLoad(data);
+		});
+	}, [getContentId(route), lang]);
+
+	useTitle(meta.title);
+	useDescription(meta.description);
+
+	let didLoad = false;
+	function onLoad(data) {
+		const { content, html, meta, fallback } = data;
+		didLoad = true;
+
+		// Don't show loader forever in case of an error
+		if (!meta) return;
+
+		setContent(content);
+		setMeta(meta);
+		setHtml(html);
+		setLoading(false);
+		setFallback(fallback);
+		const current = getContentId(route);
+		const bootData = getPrerenderData(current);
+		setHydrated(!!bootData);
+		setCurrent(current);
+		// content was loaded. if this was a forward route transition, animate back to top
+		if (window.nextStateToTop) {
+			window.nextStateToTop = false;
+			scrollTo({
+				top: 0,
+				left: 0
+			});
+		}
+	}
+
+	return {
+		current,
+		content,
+		html,
+		meta,
+		loading,
+		isFallback
+	};
+}

--- a/src/lib/page-title.js
+++ b/src/lib/page-title.js
@@ -1,0 +1,27 @@
+/**
+ * @param {string} title
+ * @param {string} [url]
+ */
+export function createTitle(title, url) {
+	url = url || window.location.pathname;
+
+	// Titles for various content areas
+	let suffix = '';
+	switch (true) {
+		// Shouldn't be an issue, but `startsWith` is wildly faster than `includes`
+		case url.startsWith('/guide/v10'):
+			suffix = 'Preact Guide';
+			break;
+		case url.startsWith('/tutorial'):
+			suffix = 'Preact Tutorial';
+			break;
+		case url.startsWith('/guide/v8'):
+			suffix = 'Preact Version 8';
+			break;
+		default:
+			suffix = 'Preact';
+	}
+
+	if (suffix !== title) title += ' – ' + suffix;
+	return title;
+}

--- a/src/prerender.js
+++ b/src/prerender.js
@@ -3,15 +3,8 @@ const path = require('path');
 const marked = require('marked');
 const yaml = require('yaml');
 const config = require('./config.json');
+const { createTitle } = require('./lib/page-title');
 const { fetchRelease } = require('./lambda/release');
-
-// Titles for various content areas
-const groups = {
-	'/v8': 'Preact Version 8',
-	'/tutorial': 'Preact Tutorial',
-	'/guide': 'Preact Guide',
-	'': 'Preact'
-};
 
 const FRONT_MATTER_REG = /^\s*---\n\s*([\s\S]*?)\s*\n---\n/i;
 
@@ -56,15 +49,7 @@ module.exports = async () => {
 		const fm = (content.match(FRONT_MATTER_REG) || [])[1];
 		const meta = (fm && yaml.parse(`---\n${fm.replace(/^/gm, '  ')}\n`)) || {};
 		const contentBody = content.replace(FRONT_MATTER_REG, '');
-		let suffix = '';
-		for (let pattern in groups) {
-			if (url.match(pattern)) {
-				suffix = groups[pattern];
-				break;
-			}
-		}
-		let title = meta.title || meta.name || name || 'Preact';
-		if (suffix !== title) title += ' – ' + suffix;
+		const title = createTitle(meta.title || meta.name || name || 'Preact', url);
 		let description;
 		if (meta.description) {
 			description = meta.description;
@@ -86,6 +71,7 @@ module.exports = async () => {
 		};
 	});
 
+	// eslint-disable-next-line no-console
 	console.log(
 		'Routes:\n ',
 		pageData


### PR DESCRIPTION
This addresses a few things:

- REPL doesn't set the page (browser) title
  - This can be seen most easily by opening [this link](https://preactjs.com/guide/v10/getting-started) to the 'Getting Started' page and then switching to the REPL from the header -- the browser title will still be 'Getting Started ...'
- The prerendered titles do not match the titles as they'd be set client-side
  - I like the prerendered titles way more, `Getting Started - Preact Guide` vs `Getting Started | Preact: Fast 3kb React alternative with the same ES6 API. Components & Virtual DOM.` See below, I think this might've been a bug.
- Upon extracting out the title creation, I also tried to make `/page` less of a grab-bag and moved most of the main utilities out. It's still not ideal and can use some refactoring (splitting it up into guide, tutorial, and blog would probably be a good idea), but this is an improvement I think.
- Slightly edited the `showTitle` for Page, see below for explanation  