### PR TITLE
refactor: Ensure landing page only has a single `<h1>`

### DIFF
--- a/content/de/index.md
+++ b/content/de/index.md
@@ -37,7 +37,7 @@ function Counter() {
 </div>
 
 <section class="home-top">
-    <h1>Eine Bibliothek der anderen Art</h1>
+    <h2>Eine Bibliothek der anderen Art</h2>
 </section>
 
 
@@ -45,7 +45,7 @@ function Counter() {
   <img src="/assets/home/metal.svg" alt="metal">
 
   <div>
-    <h2>Näher am Geschehen</h2>
+    <h3>Näher am Geschehen</h3>
     <p>
         Preact bietet die kleinstmögliche Virtual DOM Abstraktion auf dem DOM.
         Das Web ist eine stabile Plattform und es ist an der Zeit, dass wir es im Namen der Sicherheit neu implementieren.
@@ -61,7 +61,7 @@ function Counter() {
   <img src="/assets/home/size.svg" alt="größe">
 
   <div>
-    <h2>Kleine Größe</h2>
+    <h3>Kleine Größe</h3>
     <p>
         Die meisten UI-Frameworks sind so riesig, dass sie den Großteil einer JavaScript-App ausmachen.
         Mit Preact ist das anders: Es ist winzig genug, damit <em>eigener Code</em> den Großteil der Application ausmacht.
@@ -77,7 +77,7 @@ function Counter() {
   <img src="/assets/home/performance.svg" alt="leistung">
 
   <div>
-    <h2>Große Leistung</h2>
+    <h3>Große Leistung</h3>
     <p>
         Preact ist schnell, was nicht nur an seiner Größe liegt. Dank einer simplen und vorhersehbaren Differenzierungsimplementation ist es eine der schnellsten Virtual DOM-Bibliotheken überhaupt.
     </p>
@@ -91,7 +91,7 @@ function Counter() {
 <section class="home-section">
   <img src="/assets/home/portable.svg" alt="portabel">
   <div>
-    <h2>Portabel &amp; Einbettbar</h2>
+    <h3>Portabel &amp; Einbettbar</h3>
     <p>
         Preacts winziger Fußabdruck ermöglicht dem ressourcenreichen Virtual DOM-Komponentenparadigma Dinge, von dem es sonst nur träumen könnte.
     </p>
@@ -105,7 +105,7 @@ function Counter() {
 <section class="home-section">
   <img src="/assets/home/productive.svg" alt="produktiv">
   <div>
-    <h2>Sofort produktiv</h2>
+    <h3>Sofort produktiv</h3>
     <p>
         Leichtigkeit ist deutlich spaßiger, wenn man dafür Produktivität nicht einbüßen muss. Preacts macht dich von Anfang an produktiv! Es hat sogar einige Bonusfunktionen:
     </p>
@@ -120,7 +120,7 @@ function Counter() {
 <section class="home-section">
   <img src="/assets/home/compatible.svg" alt="kompatibel">
   <div>
-    <h2>Ökosystem-kompatibel</h2>
+    <h3>Ökosystem-kompatibel</h3>
     <p>
         Virtual DOM-Komponenten machen es einfach, Dinge wieder zu verwenden - alles vom Knopf bis hin zu Datenquellen.
         Preacts Gestaltung lässt dich tausende Komponenten, die bereits im React-Ökosystem verfügbar sind, verwenden.
@@ -133,13 +133,13 @@ function Counter() {
 
 
 <section class="home-top">
-    <h1>Erlebe es in freier Wildbahn!</h1>
+    <h2>Erlebe es in freier Wildbahn!</h2>
 </section>
 
 
 <section class="home-split">
     <div>
-        <h2>To Do-Listen-Komponente</h2>
+        <h3>To Do-Listen-Komponente</h3>
         <pre><code class="lang-jsx">
 // --repl
 export default class TodoList extends Component {
@@ -174,7 +174,7 @@ render(&lt;TodoList /&gt;, document.getElementById("app"));
         </code></pre>
     </div>
     <div>
-        <h2>Laufendes Beispiel</h2>
+        <h3>Laufendes Beispiel</h3>
         <pre repl="false"><code class="lang-jsx">
 import ToDoList from './todo-list';
 
@@ -189,7 +189,7 @@ render(&lt;ToDoList /&gt;, document.body);
 
 <section class="home-split">
     <div>
-        <h2>Zeige GitHub-Stars</h2>
+        <h3>Zeige GitHub-Stars</h3>
         <pre><code class="lang-jsx">
 // --repl
 export default class Stars extends Component {
@@ -211,7 +211,7 @@ render(&lt;Stars /&gt;, document.getElementById("app"));
         </code></pre>
     </div>
     <div>
-        <h2>Laufendes Beispiel</h2>
+        <h3>Laufendes Beispiel</h3>
         <pre repl="false"><code class="lang-jsx">
 import Stars from './stars';
 
@@ -228,7 +228,7 @@ render(
 
 
 <section class="home-top">
-    <h1>Bereit einzutauchen?</h1>
+    <h2>Bereit einzutauchen?</h2>
 </section>
 
 

--- a/content/en/index.md
+++ b/content/en/index.md
@@ -37,14 +37,14 @@ function Counter() {
 </section>
 
 <section class="home-top">
-    <h1>A different kind of library</h1>
+    <h2>A different kind of library</h2>
 </section>
 
 <section class="home-section">
   <img src="/assets/home/metal.svg" alt="metal" loading="lazy" width="54" height="54">
 
   <div>
-    <h2>Closer to the DOM</h2>
+    <h3>Closer to the DOM</h3>
     <p>
       Preact provides the thinnest possible Virtual DOM abstraction on top of the DOM.
       It builds on stable platform features, registers real event handlers and plays nicely with other libraries.
@@ -59,7 +59,7 @@ function Counter() {
   <img src="/assets/home/size.svg" alt="size" loading="lazy" width="54" height="54">
 
   <div>
-    <h2>Small Size</h2>
+    <h3>Small Size</h3>
     <p>
       Most UI frameworks are large enough to be the majority of an app's JavaScript size.
       Preact is different: it's small enough that <em>your code</em> is the largest part of your application.
@@ -74,7 +74,7 @@ function Counter() {
   <img src="/assets/home/performance.svg" alt="performance" loading="lazy" width="54" height="54">
 
   <div>
-    <h2>Big Performance</h2>
+    <h3>Big Performance</h3>
     <p>
       Preact is fast, and not just because of its size. It's one of the fastest Virtual DOM libraries out there, thanks to a simple and predictable diff implementation.
     </p>
@@ -89,7 +89,7 @@ function Counter() {
   <img src="/assets/home/portable.svg" alt="portable" loading="lazy" width="54" height="54">
 
   <div>
-    <h2>Portable &amp; Embeddable</h2>
+    <h3>Portable &amp; Embeddable</h3>
     <p>
       Preact's tiny footprint means you can take the powerful Virtual DOM Component paradigm to new places it couldn't otherwise go.
     </p>
@@ -103,7 +103,7 @@ function Counter() {
   <img src="/assets/home/productive.svg" alt="productive" loading="lazy" width="54" height="54">
 
   <div>
-    <h2>Instantly Productive</h2>
+    <h3>Instantly Productive</h3>
     <p>
       Lightweight is a lot more fun when you don't have to sacrifice productivity to get there. Preact gets you productive right away. It even has a few bonus features:
     </p>
@@ -118,7 +118,7 @@ function Counter() {
   <img src="/assets/home/compatible.svg" alt="compatible" loading="lazy" width="54" height="54">
 
   <div>
-    <h2>Ecosystem Compatible</h2>
+    <h3>Ecosystem Compatible</h3>
     <p>
       Virtual DOM Components make it easy to share reusable things - everything from buttons to data providers.
       Preact's design means you can seamlessly use thousands of Components available in the React ecosystem.
@@ -131,12 +131,12 @@ function Counter() {
 </section>
 
 <section class="home-top">
-    <h1>See it in action!</h1>
+    <h2>See it in action!</h2>
 </section>
 
 <section class="home-split">
     <div>
-        <h2>Todo List</h2>
+        <h3>Todo List</h3>
         <pre><code class="lang-jsx">
 // --repl
 export default class TodoList extends Component {
@@ -171,7 +171,7 @@ render(&lt;TodoList /&gt;, document.getElementById("app"));
         </code></pre>
     </div>
     <div>
-        <h2>Running Example</h2>
+        <h3>Running Example</h3>
         <pre repl="false"><code class="lang-jsx">
 import TodoList from './todo-list';
 
@@ -185,7 +185,7 @@ render(&lt;TodoList /&gt;, document.body);
 
 <section class="home-split">
     <div>
-        <h2>Fetch GitHub Stars</h2>
+        <h3>Fetch GitHub Stars</h3>
         <pre><code class="lang-jsx">
 // --repl
 export default class Stars extends Component {
@@ -207,7 +207,7 @@ render(&lt;Stars /&gt;, document.getElementById("app"));
         </code></pre>
     </div>
     <div>
-        <h2>Running Example</h2>
+        <h3>Running Example</h3>
         <pre repl="false"><code class="lang-jsx">
 import Stars from './stars';
 
@@ -223,7 +223,7 @@ render(
 </section>
 
 <section class="home-top">
-    <h1>Ready to dive in?</h1>
+    <h2>Ready to dive in?</h2>
 </section>
 
 <section style="text-align:center;">

--- a/content/es/index.md
+++ b/content/es/index.md
@@ -37,7 +37,7 @@ function Counter() {
 </div>
 
 <section class="home-top">
-    <h1>Una librería distinta</h1>
+    <h2>Una librería distinta</h2>
 </section>
 
 
@@ -45,7 +45,7 @@ function Counter() {
   <img src="/assets/home/metal.svg">
 
   <div>
-    <h2>Más cerca del DOM</h2>
+    <h3>Más cerca del DOM</h3>
     <p>
         Preact provee la abstracción más pequeña del Virtual DOM sobre el DOM.
         Se basa en características estables de la plataforma, registra manejadores de eventos reales y funciona muy bien con otras librerías.
@@ -61,7 +61,7 @@ function Counter() {
   <img src="/assets/home/size.svg">
 
   <div>
-    <h2>Tamaño reducido</h2>
+    <h3>Tamaño reducido</h3>
     <p>
         La mayoría de los frameworks de UI son suficientemente grandes como para ser la mayor parte del tamaño del JavaScript de una app.
         Preact es distinto: es lo suficientemente pequeño como para que <em>tu código</em> sea la parte más pesada de tu aplicación.
@@ -77,7 +77,7 @@ function Counter() {
   <img src="/assets/home/performance.svg">
 
   <div>
-    <h2>Gran Rendimiento</h2>
+    <h3>Gran Rendimiento</h3>
     <p>
         Preact es rápido, y no solo por su peso. Es una de las librerías de Virtual DOM más rápidas que vas a encontrar, gracias a su implementación de diffing simple y predecible.
     </p>
@@ -92,7 +92,7 @@ function Counter() {
   <img src="/assets/home/portable.svg">
 
   <div>
-    <h2>Portable y embebible</h2>
+    <h3>Portable y embebible</h3>
     <p>
         La pequeña huella que deja Preact significa que puedes tomar el poderoso paradigma del Componente de Virtual DOM a nuevos lugares donde de otra manera no podría entrar.
     </p>
@@ -107,7 +107,7 @@ function Counter() {
   <img src="/assets/home/productive.svg">
 
   <div>
-    <h2>Productividad instantánea</h2>
+    <h3>Productividad instantánea</h3>
     <p>
         La liviandad es mucho más divertida cuando no tienes que sacrificar productividad para llegar a ella.
         Preact habilita tu productividad desde el comienzo. De hecho tiene algunos bonus:
@@ -125,7 +125,7 @@ function Counter() {
   <img src="/assets/home/compatible.svg">
 
   <div>
-    <h2>Ecosistema compatible</h2>
+    <h3>Ecosistema compatible</h3>
     <p>
         Los Componentes de Virtual DOM hacen simple compartir elementos reusables - desde botones hasta proveedores de data.
         El diseño de Preact significa también que tienes miles de Componentes disponibles desde el ecosistema de React.
@@ -139,13 +139,13 @@ function Counter() {
 
 
 <section class="home-top">
-    <h1>Míralo en acción!</h1>
+    <h2>Míralo en acción!</h2>
 </section>
 
 
 <section class="home-split">
     <div>
-        <h2>Componente de Todo List</h2>
+        <h3>Componente de Todo List</h3>
         <pre><code class="lang-jsx">
 // --repl
 export default class TodoList extends Component {
@@ -180,7 +180,7 @@ render(&lt;TodoList /&gt;, document.getElementById("app"));
         </code></pre>
     </div>
     <div>
-        <h2>Ejemplo corriendo</h2>
+        <h3>Ejemplo corriendo</h3>
         <pre repl="false"><code class="lang-jsx">
 import TodoList from './todo-list';
 
@@ -195,7 +195,7 @@ render(&lt;TodoList /&gt;, document.body);
 
 <section class="home-split">
     <div>
-        <h2>Buscando las estrellas de Github</h2>
+        <h3>Buscando las estrellas de Github</h3>
         <pre><code class="lang-jsx">
 // --repl
 export default class Stars extends Component {
@@ -217,7 +217,7 @@ render(&lt;Stars /&gt;, document.getElementById("app"));
         </code></pre>
     </div>
     <div>
-        <h2>Ejemplo corriendo</h2>
+        <h3>Ejemplo corriendo</h3>
         <pre repl="false"><code class="lang-jsx">
 import Stars from './stars';
 
@@ -234,7 +234,7 @@ render(
 
 
 <section class="home-top">
-    <h1>¿Preparada/o para meterte de lleno?</h1>
+    <h2>¿Preparada/o para meterte de lleno?</h2>
 </section>
 
 

--- a/content/fr/index.md
+++ b/content/fr/index.md
@@ -36,7 +36,7 @@ function Counter() {
 </div>
 
 <section class="home-top">
-    <h1>Un concept différent</h1>
+    <h2>Un concept différent</h2>
 </section>
 
 
@@ -44,7 +44,7 @@ function Counter() {
   <img src="/assets/home/metal.svg" alt="metal">
 
   <div>
-    <h2>Plus proche de la machine</h2>
+    <h3>Plus proche de la machine</h3>
     <p>
         Preact possède l'abstraction du DOM virtuel la plus fine.
         Le web est une plateforme stable, il est temps d'arrêter de réinventer la roue.
@@ -60,7 +60,7 @@ function Counter() {
   <img src="/assets/home/size.svg" alt="size">
 
   <div>
-    <h2>Petite taille</h2>
+    <h3>Petite taille</h3>
     <p>
         La plupart des frameworks UI sont très larges et possèdent généralement plus de code que votre application. Preact est différent : la majorité du code de votre application sera le vôtre.
     </p>
@@ -75,7 +75,7 @@ function Counter() {
   <img src="/assets/home/performance.svg" alt="performance">
 
   <div>
-    <h2>Grande performance</h2>
+    <h3>Grande performance</h3>
     <p>
         Preact est performant, non seulement à cause de sa taille, mais aussi parce qu'il possède une des implémentations les plus rapides pour détecter les différences entre le DOM du navigateur et le DOM virtuel.
     </p>
@@ -90,7 +90,7 @@ function Counter() {
   <img src="/assets/home/portable.svg" alt="portable">
 
   <div>
-    <h2>Portable &amp; embarquable</h2>
+    <h3>Portable &amp; embarquable</h3>
     <p>
         Contrairement aux autres frameworks, Preact ne représente pas un énorme surcoût. Il vous permettra de bénéficier de la puissance du DOM virtuel.
     </p>
@@ -105,7 +105,7 @@ function Counter() {
   <img src="/assets/home/productive.svg" alt="productive">
 
   <div>
-    <h2>Productif instantanément</h2>
+    <h3>Productif instantanément</h3>
     <p>
         La légereté est plus amusante quand vous n'avez pas à sacrifier la productivité pour y arriver. Avec Preact vous serez productif en quelques instants. Vous aurez même droit aux fonctionnalités supplémentaires suivantes :
     </p>
@@ -120,7 +120,7 @@ function Counter() {
 <section class="home-section">
   <div>
     <img src="/assets/home/compatible.svg" alt="compatible">
-    <h2>Compatible avec l'écosystème</h2>
+    <h3>Compatible avec l'écosystème</h3>
     <p>
         Les composants du DOM virtuel vous permettent de réutiliser des briques de votre application. Grâce à la conception de Preact, vous avez à votre disposition les composants de l'écosystème React.
     </p>
@@ -132,13 +132,13 @@ function Counter() {
 
 
 <section class="home-top">
-    <h1>Voir en action!</h1>
+    <h2>Voir en action!</h2>
 </section>
 
 
 <section class="home-split">
     <div>
-        <h2>Composant liste de tâches</h2>
+        <h3>Composant liste de tâches</h3>
         <pre><code class="lang-jsx">
 // --repl
 export default class TodoList extends Component {
@@ -173,7 +173,7 @@ render(&lt;TodoList /&gt;, document.getElementById("app"));
         </code></pre>
     </div>
     <div>
-        <h2>Exemple interactif</h2>
+        <h3>Exemple interactif</h3>
         <pre repl="false"><code class="lang-jsx">
 import TodoList from './todo-list';
 
@@ -188,7 +188,7 @@ render(&lt;TodoList /&gt;, document.body);
 
 <section class="home-split">
     <div>
-        <h2>Récupérer les Stars Github</h2>
+        <h3>Récupérer les Stars Github</h3>
         <pre><code class="lang-jsx">
 // --repl
 export default class Stars extends Component {
@@ -210,7 +210,7 @@ render(&lt;Stars /&gt;, document.getElementById("app"));
         </code></pre>
     </div>
     <div>
-        <h2>Exemple fonctionnel</h2>
+        <h3>Exemple fonctionnel</h3>
         <pre repl="false"><code class="lang-jsx">
 import Stars from './stars';
 
@@ -227,7 +227,7 @@ render(
 
 
 <section class="home-top">
-    <h1>Prêt à vous lancer ?</h1>
+    <h2>Prêt à vous lancer ?</h2>
 </section>
 
 

--- a/content/it/index.md
+++ b/content/it/index.md
@@ -37,7 +37,7 @@ function Counter() {
 </div>
 
 <section class="home-top">
-    <h1>Una Libreria differente</h1>
+    <h2>Una Libreria differente</h2>
 </section>
 
 
@@ -45,7 +45,7 @@ function Counter() {
   <img src="/assets/home/metal.svg" alt="metal">
 
   <div>
-    <h2>Più vicino alla macchina</h2>
+    <h3>Più vicino alla macchina</h3>
     <p>
         Preact fornisce la più leggera astrazione possibile del Virtual DOM.
         Il web è una piattaforma stabile, è giunto il momento in cui dobbiamo smettere di reimplementarlo in nome della sicurezza.
@@ -62,7 +62,7 @@ function Counter() {
   <img src="/assets/home/size.svg" alt="size">
 
   <div>
-    <h2>Piccolo nelle dimensioni</h2>
+    <h3>Piccolo nelle dimensioni</h3>
     <p>
         Molti degli UI framework sono grandi abbastanza per essere la parte più pesante del Javascript di un applicazione.
         Preact è differente: è così piccolo che il tuo codice sarà la parte più grande nella tua applicazione
@@ -79,7 +79,7 @@ function Counter() {
   <img src="/assets/home/performance.svg" alt="performance">
 
   <div>
-    <h2>Grandi Perfomance</h2>
+    <h3>Grandi Perfomance</h3>
     <p>
         Preact è veloce, e non solo per il suo peso. Ha una delle implementazioni più veloci per rilevare le differenze tra il DOM sulla pagina e il DOM virtuale.
     </p>
@@ -94,7 +94,7 @@ function Counter() {
   <img src="/assets/home/portable.svg" alt="portable">
 
   <div>
-    <h2>Portatile ed Integrabile</h2>
+    <h3>Portatile ed Integrabile</h3>
     <p>
         La minuscola impronta di Preact permette di usare il potente paradigma dei Componenti del Virtual DOM in posti dove altrimenti non avresti potuto.
     </p>
@@ -109,7 +109,7 @@ function Counter() {
   <img src="/assets/home/productive.svg" alt="productive">
 
   <div>
-    <h2>Immediatamente Produttivo</h2>
+    <h3>Immediatamente Produttivo</h3>
     <p>
         La leggerezza è molto più divertente quando non si deve sacrificare la produttività. Preact ti rende subito
         produttivo. Ha anche alcune caratteristiche bonus:
@@ -126,7 +126,7 @@ function Counter() {
   <img src="/assets/home/compatible.svg" alt="compatible">
 
   <div>
-    <h2>Compatibile con l'Ecosistema</h2>
+    <h3>Compatibile con l'Ecosistema</h3>
     <p>
         I componenti DOM virtuali facilitano la condivisione di cose riutilizzabili - qualsiasi cosa dai bottoni ai fornitori di dati.
         Il design di Preact ti permette di utilizzare senza problemi migliaia di componenti disponibili nell'ecosistema React.
@@ -139,13 +139,13 @@ function Counter() {
 
 
 <section class="home-top">
-    <h1>Guardalo in azione!</h1>
+    <h2>Guardalo in azione!</h2>
 </section>
 
 
 <section class="home-split">
     <div>
-        <h2>Componente Lista delle attività</h2>
+        <h3>Componente Lista delle attività</h3>
         <pre><code class="lang-jsx">
 // --repl
 export default class TodoList extends Component {
@@ -180,7 +180,7 @@ render(&lt;TodoList /&gt;, document.getElementById("app"));
         </code></pre>
     </div>
     <div>
-        <h2>Esempio in esecuzione</h2>
+        <h3>Esempio in esecuzione</h3>
         <pre repl="false"><code class="lang-jsx">
 import TodoList from './todo-list';
 
@@ -195,7 +195,7 @@ render(&lt;TodoList /&gt;, document.body);
 
 <section class="home-split">
     <div>
-        <h2>Visualizzare le stelle su GitHub</h2>
+        <h3>Visualizzare le stelle su GitHub</h3>
         <pre><code class="lang-jsx">
 // --repl
 export default class Stars extends Component {
@@ -217,7 +217,7 @@ render(&lt;Stars /&gt;, document.getElementById("app"));
         </code></pre>
     </div>
     <div>
-        <h2>Esempio in esecuzione</h2>
+        <h3>Esempio in esecuzione</h3>
         <pre repl="false"><code class="lang-jsx">
 import Stars from './stars';
 
@@ -234,7 +234,7 @@ render(
 
 
 <section class="home-top">
-    <h1>Pronto a tuffarti?</h1>
+    <h2>Pronto a tuffarti?</h2>
 </section>
 
 

--- a/content/ja/index.md
+++ b/content/ja/index.md
@@ -37,14 +37,14 @@ function Counter() {
 </section>
 
 <section class="home-top">
-    <h1>Preactの特徴</h1>
+    <h2>Preactの特徴</h2>
 </section>
 
 <section class="home-section">
   <img src="/assets/home/metal.svg" alt="metal">
 
   <div>
-    <h2>よりDOMに近い</h2>
+    <h3>よりDOMに近い</h3>
     <p>
       Preact(プリアクト)はDOM上に薄い仮想DOMによる抽象化を提供します。
       ブラウザの安定した機能の上に構築され、素のイベントハンドラをそのまま使います。他のライブラリとの連携もスムーズに行えます。
@@ -59,7 +59,7 @@ function Counter() {
   <img src="/assets/home/size.svg" alt="size">
 
   <div>
-    <h2>サイズが小さい</h2>
+    <h3>サイズが小さい</h3>
     <p>
       ほとんどのUIフレームワークはアプリケーションを構成するJavaScriptのサイズの大部分を占めてしまうくらいの大きさです。
       Preactは違います。あなたが書いたコードがアプリケーションの大部分を占めるようになるくらいの小ささです。
@@ -74,7 +74,7 @@ function Counter() {
   <img src="/assets/home/performance.svg" alt="performance">
 
   <div>
-    <h2>卓越したパフォーマンス</h2>
+    <h3>卓越したパフォーマンス</h3>
     <p>
       Preactが高速な理由は単にサイズだけではありません。 Preactはシンプルで安定した差分アルゴリズムの実装によって最も高速な仮想DOMライブラリの1つになりました。
     </p>
@@ -88,7 +88,7 @@ function Counter() {
   <img src="/assets/home/portable.svg" alt="portable">
 
   <div>
-    <h2>ポータブル &amp; 組み込みやすい</h2>
+    <h3>ポータブル &amp; 組み込みやすい</h3>
     <p>
       Preactのサイズの小ささは、強力な仮想DOMコンポーネントの枠組みを新しい用途に広げることを可能にしました。
     </p>
@@ -103,7 +103,7 @@ function Counter() {
   <img src="/assets/home/productive.svg" alt="productive">
 
   <div>
-    <h2>高い生産性</h2>
+    <h3>高い生産性</h3>
     <p>
       生産性を犠牲にすることなくアプリケーションを軽量化することができるので、Preactでの開発はより楽しいものになるでしょう。Preactを使うとすぐに生産性が上がります。以下のおまけの機能もあります。
     </p>
@@ -118,7 +118,7 @@ function Counter() {
   <img src="/assets/home/compatible.svg" alt="compatible">
 
   <div>
-    <h2>エコシステムの互換性</h2>
+    <h3>エコシステムの互換性</h3>
     <p>
       仮想DOMコンポーネントは、ボタンからデータプロバイダまですべての再利用可能なコンポーネントの共有を簡単にします。
       PreactはReactのエコシステムにある何千ものコンポーネントをシームレスに利用できるように設計されています。
@@ -130,12 +130,12 @@ function Counter() {
 </section>
 
 <section class="home-top">
-    <h1>動くものを見てみましょう。</h1>
+    <h2>動くものを見てみましょう。</h2>
 </section>
 
 <section class="home-split">
     <div>
-        <h2>Todoリスト</h2>
+        <h3>Todoリスト</h3>
         <pre><code class="lang-jsx">
 // --repl
 export default class TodoList extends Component {
@@ -170,7 +170,7 @@ render(&lt;TodoList /&gt;, document.getElementById("app"));
         </code></pre>
     </div>
     <div>
-        <h2>実行結果</h2>
+        <h3>実行結果</h3>
         <pre repl="false"><code class="lang-jsx">
 import TodoList from './todo-list';
 
@@ -184,7 +184,7 @@ render(&lt;TodoList /&gt;, document.body);
 
 <section class="home-split">
     <div>
-        <h2>GitHubのスター数を取得</h2>
+        <h3>GitHubのスター数を取得</h3>
         <pre><code class="lang-jsx">
 // --repl
 export default class Stars extends Component {
@@ -206,7 +206,7 @@ render(&lt;Stars /&gt;, document.getElementById("app"));
         </code></pre>
     </div>
     <div>
-        <h2>実行結果</h2>
+        <h3>実行結果</h3>
         <pre repl="false"><code class="lang-jsx">
 import Stars from './stars';
 
@@ -222,7 +222,7 @@ render(
 </section>
 
 <section class="home-top">
-    <h1>もっと詳しく知りたいですか？</h1>
+    <h2>もっと詳しく知りたいですか？</h2>
 </section>
 
 <section style="text-align:center;">

--- a/content/kr/index.md
+++ b/content/kr/index.md
@@ -37,14 +37,14 @@ function Counter() {
 </section>
 
 <section class="home-top">
-    <h1>다른 종류의 라이브러리</h1>
+    <h2>다른 종류의 라이브러리</h2>
 </section>
 
 <section class="home-section">
   <img src="/assets/home/metal.svg" alt="metal" loading="lazy" width="54" height="54">
 
   <div>
-    <h2>DOM에 더 가까이</h2>
+    <h3>DOM에 더 가까이</h3>
     <p>
     Preact는 DOM 위에 가능한 가장 얇은 가상 DOM 추상화를 제공합니다. 안정적인 플랫폼 기능을 기반으로 하며 실제 이벤트 핸들러를 등록할 수 있고, 다른 라이브러리들과 잘 어울립니다.
     </p>
@@ -58,7 +58,7 @@ function Counter() {
   <img src="/assets/home/size.svg" alt="size" loading="lazy" width="54" height="54">
 
   <div>
-    <h2>작은 크기</h2>
+    <h3>작은 크기</h3>
     <p>
       대부분의 UI 프레임워크는 프레임워크 자체의 JavaScript 크기가 애플리케이션의 대부분을 차지할 만큼 매우 큽니다. Preact는 다릅니다. 프레임워크 자체의 JavaScript 크기가 아닌, <em>여러분이 작성한 코드</em> 가 애플리케이션의 가장 큰 부분을 차지할 만큼 매우 가볍습니다.
     </p>
@@ -72,7 +72,7 @@ function Counter() {
   <img src="/assets/home/performance.svg" alt="performance" loading="lazy" width="54" height="54">
 
   <div>
-    <h2>놀라운 성능</h2>
+    <h3>놀라운 성능</h3>
     <p>
       Preact가 빠른 이유는 단순히 크기 뿐만이 아닙니다 간단하고 예측 가능한 diff 구현 덕분에 세상에서 가장 빠른 Virtual DOM 라이브러리 중 하나입니다.
     </p>
@@ -86,7 +86,7 @@ function Counter() {
   <img src="/assets/home/portable.svg" alt="portable" loading="lazy" width="54" height="54">
 
   <div>
-    <h2>휴대 가능 &amp; 삽입 가능</h2>
+    <h3>휴대 가능 &amp; 삽입 가능</h3>
     <p>
       Preact의 작은 설치 공간은 강력한 Virtual DOM 구성 요소 패러다임을 다른 방법으로는 갈 수 없는 새로운 장소로 가져갈 수 있음을 의미합니다.
     </p>
@@ -100,7 +100,7 @@ function Counter() {
   <img src="/assets/home/productive.svg" alt="productive" loading="lazy" width="54" height="54">
 
   <div>
-    <h2>즉각적인 생산성</h2>
+    <h3>즉각적인 생산성</h3>
     <p>
      경량화는 거기에 도달하기 위해 생산성을 희생할 필요가 없을 때 훨씬 더 재미있습니다. Preact는 즉시 생산성을 높여줍니다. 몇 가지 보너스 기능도 있습니다.
     </p>
@@ -115,7 +115,7 @@ function Counter() {
   <img src="/assets/home/compatible.svg" alt="compatible" loading="lazy" width="54" height="54">
 
   <div>
-    <h2>생태계 호환</h2>
+    <h3>생태계 호환</h3>
     <p>
       가상 DOM 구성 요소를 사용하면 버튼에서 데이터 공급자에 이르기까지 재사용 가능한 모든 것을 쉽게 공유할 수 있습니다. Preact의 디자인은 React 생태계에서 사용 가능한 수천 개의 구성 요소를 원활하게 사용할 수 있음을 의미합니다.
     </p>
@@ -126,12 +126,12 @@ function Counter() {
 </section>
 
 <section class="home-top">
-    <h1>직접 확인하세요!</h1>
+    <h2>직접 확인하세요!</h2>
 </section>
 
 <section class="home-split">
     <div>
-        <h2>Todo 리스트</h2>
+        <h3>Todo 리스트</h3>
         <pre><code class="lang-jsx">
 // --repl
 export default class TodoList extends Component {
@@ -166,7 +166,7 @@ render(&lt;TodoList /&gt;, document.getElementById("app"));
         </code></pre>
     </div>
     <div>
-        <h2>실행 예시</h2>
+        <h3>실행 예시</h3>
         <pre repl="false"><code class="lang-jsx">
 import TodoList from './todo-list';
 
@@ -180,7 +180,7 @@ render(&lt;TodoList /&gt;, document.body);
 
 <section class="home-split">
     <div>
-        <h2>GitHub Star 가져오기</h2>
+        <h3>GitHub Star 가져오기</h3>
         <pre><code class="lang-jsx">
 // --repl
 export default class Stars extends Component {
@@ -202,7 +202,7 @@ render(&lt;Stars /&gt;, document.getElementById("app"));
         </code></pre>
     </div>
     <div>
-        <h2>실행 예시</h2>
+        <h3>실행 예시</h3>
         <pre repl="false"><code class="lang-jsx">
 import Stars from './stars';
 
@@ -218,7 +218,7 @@ render(
 </section>
 
 <section class="home-top">
-    <h1>뛰어들 준비가 되셨나요?</h1>
+    <h2>뛰어들 준비가 되셨나요?</h2>
 </section>
 
 <section style="text-align:center;">

--- a/content/pt-br/index.md
+++ b/content/pt-br/index.md
@@ -37,14 +37,14 @@ function Counter() {
 </div>
 
 <section class="home-top">
-    <h1>Uma biblioteca diferente</h1>
+    <h2>Uma biblioteca diferente</h2>
 </section>
 
 
 <section class="home-section">
   <img src="/assets/home/metal.svg">
   <div>
-    <h2>Mais próximo do DOM.</h2>
+    <h3>Mais próximo do DOM.</h3>
     <p>
         Preact fornece a mais leve abstração de Virtual DOM possível em cima do DOM.
         A web é uma plataforma estável - É tempo de pararmos de reimplementá-la em nome da segurança.
@@ -58,7 +58,7 @@ function Counter() {
 <section class="home-section">
   <img src="/assets/home/size.svg">
   <div>
-    <h2>Leve e Pequeno</h2>
+    <h3>Leve e Pequeno</h3>
     <p>
         A maioria dos frameworks de UI são grandes o suficiente pra serem a maior parte do peso de uma aplicação JavaScript.
         Preact é diferente: é pequeno o suficiente pra que o <em>seu código</em> seja a maior parte da sua aplicação.
@@ -73,7 +73,7 @@ function Counter() {
 <section class="home-section">
   <img src="/assets/home/performance.svg">
   <div>
-    <h2>Alta Performance</h2>
+    <h3>Alta Performance</h3>
     <p>
         Preact é rápido, e não só por causa do seu tamanho. É uma das bibliotecas Virtual DOM mais rápidas disponíveis, graças a uma simples e rápida implementação do algorítimo de comparação.
     </p>
@@ -87,7 +87,7 @@ function Counter() {
 <section class="home-section">
   <img src="/assets/home/portable.svg">
   <div>
-    <h2>Portável &amp; Embutível</h2>
+    <h3>Portável &amp; Embutível</h3>
     <p>
         O pequeno impacto do Preact significa que você pode levar o poderoso paradigma de Componentes Virtual DOM a lugares antes não possíveis.
     </p>
@@ -101,7 +101,7 @@ function Counter() {
 <section class="home-section">
   <img src="/assets/home/productive.svg">
   <div>
-    <h2>Produtividade Instantânea</h2>
+    <h3>Produtividade Instantânea</h3>
     <p>
         O "leve" fica muito mais divertido quando você não tem que sacrificar produtividade para alcançá-lo. Preact te torna produtivo imediatamente. Tem até mesmo alguns recursos bônus:
     </p>
@@ -116,7 +116,7 @@ function Counter() {
 <section class="home-section">
   <img src="/assets/home/compatible.svg">
   <div>
-    <h2>Ecossistema compatível</h2>
+    <h3>Ecossistema compatível</h3>
     <p>
         Componentes Virtual DOM tornam fácil o compartilhamento de coisas reutílizáveis - tudo, de botôes a provedores de dado.
         O design do Preact significa que você pode usar de forma harmoniosa os milhares de Componentes disponíveis no ecossistema React.
@@ -129,13 +129,13 @@ function Counter() {
 
 
 <section class="home-top">
-    <h1>Veja na prática!</h1>
+    <h2>Veja na prática!</h2>
 </section>
 
 
 <section class="home-split">
     <div>
-        <h2>Componente de <i>Todo List</i> </h2>
+        <h3>Componente de <i>Todo List</i> </h3>
         <pre><code class="lang-jsx">
 // --repl
 export default class TodoList extends Component {
@@ -170,7 +170,7 @@ render(&lt;TodoList /&gt;, document.getElementById("app"));
         </code></pre>
     </div>
     <div>
-        <h2>Exemplo em ação</h2>
+        <h3>Exemplo em ação</h3>
         <pre repl="false"><code class="lang-jsx">
 import TodoList from './todo-list';
 
@@ -185,7 +185,7 @@ render(&lt;TodoList /&gt;, document.body);
 
 <section class="home-split">
     <div>
-        <h2>Buscar estrelas no Github</h2>
+        <h3>Buscar estrelas no Github</h3>
         <pre><code class="lang-jsx">
 // --repl
 export default class Stars extends Component {
@@ -207,7 +207,7 @@ render(&lt;Stars /&gt;, document.getElementById("app"));
         </code></pre>
     </div>
     <div>
-        <h2>Exemplo em ação</h2>
+        <h3>Exemplo em ação</h3>
         <pre repl="false"><code class="lang-jsx">
 import Stars from './stars';
 
@@ -224,7 +224,7 @@ render(
 
 
 <section class="home-top">
-    <h1>Pronto pra mergulhar?</h1>
+    <h2>Pronto pra mergulhar?</h2>
 </section>
 
 

--- a/content/ru/index.md
+++ b/content/ru/index.md
@@ -37,14 +37,14 @@ function Counter() {
 </section>
 
 <section class="home-top">
-    <h1>Библиотека другого типа</h1>
+    <h2>Библиотека другого типа</h2>
 </section>
 
 <section class="home-section">
   <img src="/assets/home/metal.svg" alt="metal" loading="lazy" width="54" height="54">
 
   <div>
-    <h2>Ближе к DOM</h2>
+    <h3>Ближе к DOM</h3>
     <p>
       Preact предоставляет максимально тонкую абстракцию Virtual DOM поверх DOM.
       Она опирается на стабильные возможности платформы, регистрирует реальные обработчики событий и хорошо взаимодействует с другими библиотеками.
@@ -59,7 +59,7 @@ function Counter() {
   <img src="/assets/home/size.svg" alt="size" loading="lazy" width="54" height="54">
 
   <div>
-    <h2>Малый размер</h2>
+    <h3>Малый размер</h3>
     <p>
       Большинство UI-фреймворков достаточно велики и составляют большую часть объема JavaScript в приложении.
       Preact — это совсем другое: он достаточно мал, чтобы <em>ваш код</em> был самой большой частью вашего приложения.
@@ -74,7 +74,7 @@ function Counter() {
   <img src="/assets/home/performance.svg" alt="performance" loading="lazy" width="54" height="54">
 
   <div>
-    <h2>Большая производительность</h2>
+    <h3>Большая производительность</h3>
     <p>
       Preact работает быстро, и не только благодаря своим размерам. Это одна из самых быстрых библиотек Virtual DOM, благодаря простой и предсказуемой реализации diff.
     </p>
@@ -88,7 +88,7 @@ function Counter() {
   <img src="/assets/home/portable.svg" alt="portable" loading="lazy" width="54" height="54">
 
   <div>
-    <h2>Портативная и встраиваемая</h2>
+    <h3>Портативная и встраиваемая</h3>
     <p>
       Небольшой размер Preact позволяет использовать мощную парадигму компонентов Virtual DOM в новых местах, куда иначе не попасть.
     </p>
@@ -102,7 +102,7 @@ function Counter() {
   <img src="/assets/home/productive.svg" alt="productive" loading="lazy" width="54" height="54">
 
   <div>
-    <h2>Мгновенная продуктивность</h2>
+    <h3>Мгновенная продуктивность</h3>
     <p>
       Легкий вес гораздо интереснее, когда для его достижения не приходится жертвовать производительностью. Preact позволяет сразу же повысить производительность труда. В нем даже есть несколько бонусов:
     </p>
@@ -117,7 +117,7 @@ function Counter() {
   <img src="/assets/home/compatible.svg" alt="compatible" loading="lazy" width="54" height="54">
 
   <div>
-    <h2>Совместимость с экосистемой</h2>
+    <h3>Совместимость с экосистемой</h3>
     <p>
       Компоненты Virtual DOM упрощают совместное использование многократно используемых элементов — от кнопок до поставщиков данных.
       Дизайн Preact позволяет легко использовать тысячи компонентов, доступных в экосистеме React.
@@ -129,12 +129,12 @@ function Counter() {
 </section>
 
 <section class="home-top">
-    <h1>Посмотрите в действии!</h1>
+    <h2>Посмотрите в действии!</h2>
 </section>
 
 <section class="home-split">
     <div>
-        <h2>Список дел</h2>
+        <h3>Список дел</h3>
         <pre><code class="lang-jsx">
 // --repl
 export default class TodoList extends Component {
@@ -169,7 +169,7 @@ render(&lt;TodoList /&gt;, document.getElementById("app"));
         </code></pre>
     </div>
     <div>
-        <h2>Пример выполнения</h2>
+        <h3>Пример выполнения</h3>
         <pre repl="false"><code class="lang-jsx">
 import TodoList from './todo-list';
 
@@ -185,7 +185,7 @@ render(&lt;TodoList /&gt;, document.body);
 
 <section class="home-split">
     <div>
-        <h2>Получение звёзд GitHub</h2>
+        <h3>Получение звёзд GitHub</h3>
         <pre><code class="lang-jsx">
 // --repl
 export default class Stars extends Component {
@@ -207,7 +207,7 @@ render(&lt;Stars /&gt;, document.getElementById("app"));
         </code></pre>
     </div>
     <div>
-        <h2>Пример выполнения</h2>
+        <h3>Пример выполнения</h3>
         <pre repl="false"><code class="lang-jsx">
 import Stars from './stars';
 
@@ -225,7 +225,7 @@ document.body
 </section>
 
 <section class="home-top">
-    <h1>Готовы к погружению?</h1>
+    <h2>Готовы к погружению?</h2>
 </section>
 
 <section style="text-align:center;">

--- a/content/tr/index.md
+++ b/content/tr/index.md
@@ -37,7 +37,7 @@ function Counter() {
 </div>
 
 <section class="home-top">
-    <h1>Başka bir tür kütüphane</h1>
+    <h2>Başka bir tür kütüphane</h2>
 </section>
 
 
@@ -45,7 +45,7 @@ function Counter() {
   <img src="/assets/home/metal.svg" alt="metal">
 
   <div>
-    <h2>Metal'e yakın</h2>
+    <h3>Metal'e yakın</h3>
     <p>
         Preact, DOM'un üzerinde mümkün olabilecek en ince Sanal DOM soyutlamasını sağlar.
         Web stabil bir platform, emniyet adına sürekli yeniden icat etmeyi bırakmamızın zamanı geldi.
@@ -62,7 +62,7 @@ function Counter() {
   <img src="/assets/home/size.svg" alt="boyut">
 
   <div>
-    <h2>Küçük Boyutlu</h2>
+    <h3>Küçük Boyutlu</h3>
     <p>
         Çoğu UI framework'ü, uygulamanın Javascript boyutunun çoğunluğunu oluşturacak kadar büyüktür.
         Preact ise farklı: <em>sizin kodunuz</em> uygulamanın çoğunluğunu oluşturacak kadar büyük kalır.
@@ -78,7 +78,7 @@ function Counter() {
   <img src="/assets/home/performance.svg" alt="performans">
 
   <div>
-    <h2>Büyük Performans</h2>
+    <h3>Büyük Performans</h3>
     <p>
         Preact hızlıdır, fakat sadece boyutu yüzünden değil.
         Basit ve öngörülebilir fark algoritması sayesinde en hızlı Sanal DOM kütüphanelerine sahipdir.
@@ -94,7 +94,7 @@ function Counter() {
   <img src="/assets/home/portable.svg" alt="taşınabilir">
 
   <div>
-    <h2>Taşınabilir &amp; Gömülebilir</h2>
+    <h3>Taşınabilir &amp; Gömülebilir</h3>
     <p>
         Preact'in küçük boyutlu kod tabanı, güçlü bir Sanal DOM Bileşeni paradigmasını alıp erişilmez denizlere yelken açabileceğiniz manasına gelir.
     </p>
@@ -110,7 +110,7 @@ function Counter() {
   <img src="/assets/home/productive.svg" alt="üretken">
 
   <div>
-    <h2>Anlık Üretkenlik</h2>
+    <h3>Anlık Üretkenlik</h3>
     <p>
         Hafiflik, üretkenlikten feda ederek oraya ulaşmak zorunda kalmadığınızda daha çok eğlencelidir.
         Preact sizi anlık üretken yapar.
@@ -128,7 +128,7 @@ function Counter() {
   <img src="/assets/home/compatible.svg" alt="uyumlu">
 
   <div>
-    <h2>Ekosistem Uyumluluğu</h2>
+    <h3>Ekosistem Uyumluluğu</h3>
     <p>
         Sanal DOM Component'leri, butonlardan data sağlayıcılarına kadar yeniden kullanılabilir şeyleri paylaşmayı kolaylaştırır.
         Preact'ın tasarımı, halihazırda React'ın ekosisteminde bulunan yüzlerce Component'i sorunsuz bir şekilde kullanabileceğiniz manasına gelir.
@@ -141,13 +141,13 @@ function Counter() {
 
 
 <section class="home-top">
-    <h1>Örneğe gözatın!</h1>
+    <h2>Örneğe gözatın!</h2>
 </section>
 
 
 <section class="home-split">
     <div>
-        <h2>TodoList (yapılacaklar listesi) Component'i</h2>
+        <h3>TodoList (yapılacaklar listesi) Component'i</h3>
         <pre><code class="lang-jsx">
 // --repl
 export default class TodoList extends Component {
@@ -182,7 +182,7 @@ render(&lt;TodoList /&gt;, document.getElementById("app"));
         </code></pre>
     </div>
     <div>
-        <h2>Çalışan Örnek</h2>
+        <h3>Çalışan Örnek</h3>
         <pre repl="false"><code class="lang-jsx">
 import TodoList from './todo-list';
 
@@ -197,7 +197,7 @@ render(&lt;TodoList /&gt;, document.body);
 
 <section class="home-split">
     <div>
-        <h2>Github Yıldız Sayısını Çekmek</h2>
+        <h3>Github Yıldız Sayısını Çekmek</h3>
         <pre><code class="lang-jsx">
 // --repl
 export default class Stars extends Component {
@@ -219,7 +219,7 @@ render(&lt;Stars /&gt;, document.getElementById("app"));
         </code></pre>
     </div>
     <div>
-        <h2>Çalışan Örnek</h2>
+        <h3>Çalışan Örnek</h3>
         <pre repl="false"><code class="lang-jsx">
 import Stars from './stars';
 
@@ -236,7 +236,7 @@ render(
 
 
 <section class="home-top">
-    <h1>Kolları sıvamaya hazır mısın?</h1>
+    <h2>Kolları sıvamaya hazır mısın?</h2>
 </section>
 
 

--- a/content/zh/index.md
+++ b/content/zh/index.md
@@ -38,14 +38,14 @@ function Counter() {
 </section>
 
 <section class="home-top">
-    <h1>与众不同的库</h1>
+    <h2>与众不同的库</h2>
 </section>
 
 <section class="home-section">
   <img src="/assets/home/metal.svg" alt="metal" loading="lazy" width="54" height="54">
 
   <div>
-    <h2>贴近实质</h2>
+    <h3>贴近实质</h3>
     <p>
       Preact 在 DOM 之上提供了最薄的虚拟 DOM 抽象，在提供稳定的平台特性和注册事件处理程序的同时还确保与其他库无缝兼容。
     </p>
@@ -60,7 +60,7 @@ function Counter() {
   <img src="/assets/home/size.svg" alt="size" loading="lazy" width="54" height="54">
 
   <div>
-    <h2>微小体积</h2>
+    <h3>微小体积</h3>
     <p>
     大多数 UI 框架占了应用 JavaScript 大小的半边天，Preact 却不一样：它的微小让<b>您写的代码</b>成为您应用中占比最大的部分。
     </p>
@@ -75,7 +75,7 @@ function Counter() {
   <img src="/assets/home/performance.svg" alt="performance" loading="lazy" width="54" height="54">
 
   <div>
-    <h2>性能卓越</h2>
+    <h3>性能卓越</h3>
     <p>
       Preact 很快，不只是因为其体量微小，更是因为其基于树差异的简单、可预测而极快的虚拟 DOM 实现。
     </p>
@@ -90,7 +90,7 @@ function Counter() {
   <img src="/assets/home/portable.svg" alt="portable" loading="lazy" width="54" height="54">
 
   <div>
-    <h2>轻松嵌入</h2>
+    <h3>轻松嵌入</h3>
     <p>
       Preact 的轻量让您可以将强大的虚拟 DOM 实现移植到其他框架无法进入的领域。
     </p>
@@ -105,7 +105,7 @@ function Counter() {
   <img src="/assets/home/productive.svg" alt="productive" loading="lazy" width="54" height="54">
 
   <div>
-    <h2>即刻生产</h2>
+    <h3>即刻生产</h3>
     <p>
       轻量在不牺牲生产性的情况下才有意义。Preact 可让您即刻部署到生产环境，甚至还提供了一些附加功能：
     </p>
@@ -121,7 +121,7 @@ function Counter() {
   <img src="/assets/home/compatible.svg" alt="compatible" loading="lazy" width="54" height="54">
 
   <div>
-    <h2>生态兼容</h2>
+    <h3>生态兼容</h3>
     <p>
       虚拟 DOM 组件让其复用易如反掌——无论是按钮，还是数据提供方，Preact 的设计都能让您轻松、无缝地借用来自 React 生态中的许多组件。
     </p>
@@ -133,13 +133,13 @@ function Counter() {
 
 
 <section class="home-top">
-    <h1>『码』上见分晓！</h1>
+    <h2>『码』上见分晓！</h2>
 </section>
 
 
 <section class="home-split">
     <div>
-        <h2>待办事项</h2>
+        <h3>待办事项</h3>
         <pre><code class="lang-jsx">
 // --repl
 export default class TodoList extends Component {
@@ -174,7 +174,7 @@ render(&lt;TodoList /&gt;, document.getElementById("app"));
         </code></pre>
     </div>
     <div>
-        <h2>实际示例</h2>
+        <h3>实际示例</h3>
         <pre repl="false"><code class="lang-jsx">
 import TodoList from './todo-list';
 
@@ -188,7 +188,7 @@ render(&lt;TodoList /&gt;, document.body);
 
 <section class="home-split">
     <div>
-        <h2>获取 GitHub 标星数</h2>
+        <h3>获取 GitHub 标星数</h3>
         <pre><code class="lang-jsx">
 // --repl
 export default class Stars extends Component {
@@ -210,7 +210,7 @@ render(&lt;Stars /&gt;, document.getElementById("app"));
         </code></pre>
     </div>
     <div>
-        <h2>实际示例</h2>
+        <h3>实际示例</h3>
         <pre repl="false"><code class="lang-jsx">
 import Stars from './stars';
 
@@ -227,7 +227,7 @@ render(
 
 
 <section class="home-top">
-    <h1>准备入坑了？</h1>
+    <h2>准备入坑了？</h2>
 </section>
 
 

--- a/src/style/home.css
+++ b/src/style/home.css
@@ -13,7 +13,8 @@ main .markup {
 		margin: 60px auto;
 		max-width: 984px;
 
-		h1 {
+		h1,
+		h2 {
 			font-size: 7.3vw;
 			text-align: center;
 			font-weight: lighter;
@@ -61,7 +62,7 @@ main .markup {
 		/* The following nodes are created inside the markdown files.
 		To make the authoring experience easier we select and style them
 		based on the type instead of forcing content creators to add classes. */
-		h2 {
+		h3 {
 			font-size: 220%;
 			letter-spacing: 0.01em;
 			font-weight: 300;
@@ -114,7 +115,8 @@ main .markup {
 			flex-direction: row;
 		}
 
-		h2 {
+		h3 {
+			font-size: 1.8rem;
 			font-weight: inherit;
 		}
 
@@ -136,7 +138,7 @@ main .markup {
 			max-width: 600px;
 			margin: auto;
 
-			> div:last-child > h2 {
+			> div:last-child > h3 {
 				margin-bottom: 0;
 				font-size: 20px;
 				border-bottom: none;

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -47,7 +47,11 @@ a {
 }
 
 h1,
-h2 {
+h2,
+h3,
+h4,
+h5,
+h6 {
 	color: var(--color-heading);
 }
 


### PR DESCRIPTION
Whether or not multiple `<h1>` are "valid" is quite murky at the moment, as while the WHATWG HTML spec says it's a-ok if they're in `<section>`s, reality is that a lot of browsers and accessibility tools don't quite follow or acknowledge the nesting "as they should" (with some arguments being that the spec is problematic and should not be followed). This has been the case for well over a decade now and is mostly in a stand-still from my understanding.

It's easy enough for us to "correct" anyhow, a single `<h1>` for the entire page followed by `<h2>` for the rest conveys the meaning we need.