### PR TITLE
docs: TS switch from `type` to `interfaces`

### DIFF
--- a/content/en/guide/v10/typescript.md
+++ b/content/en/guide/v10/typescript.md
@@ -99,7 +99,7 @@ There are different ways to type components in Preact. Class components have gen
 Typing regular function components is as easy as adding type information to the function arguments.
 
 ```tsx
-type MyComponentProps = {
+interface MyComponentProps {
   name: string;
   age: number;
 };
@@ -116,7 +116,7 @@ function MyComponent({ name, age }: MyComponentProps) {
 You can set default props by setting a default value in the function signature.
 
 ```tsx
-type GreetingProps = {
+interface GreetingProps {
   name?: string; // name is optional!
 }
 
@@ -147,7 +147,7 @@ const Card: FunctionComponent<{ title: string }> = ({ title, children }) => {
 ```tsx
 import { h, ComponentChildren } from "preact";
 
-type ChildrenProps = {
+interface ChildrenProps {
   title: string;
   children: ComponentChildren;
 }
@@ -168,12 +168,12 @@ Preact's `Component` class is typed as a generic with two generic type variables
 
 ```tsx
 // Types for props
-type ExpandableProps = {
+interface ExpandableProps {
   title: string;
 };
 
 // Types for state
-type ExpandableState = {
+interface ExpandableState {
   toggled: boolean;
 };
 
@@ -335,7 +335,7 @@ function App() {
 Or you work without default values and use bind the generic type variable to bind context to a certain type:
 
 ```tsx
-type AppContextValues = {
+interface AppContextValues {
   authenticated: boolean;
   lang: string;
   theme: string;
@@ -448,13 +448,13 @@ For the `useReducer` hook, TypeScript tries to infer as many types as possible f
 
 ```typescript
 // The state type for the reducer function
-type StateType = {
+interface StateType {
   count: number;
 }
 
 // An action type, where the `type` can be either
 // "reset", "decrement", "increment"
-type ActionType = {
+interface ActionType {
   type: "reset" | "decrement" | "increment";
 }
 

--- a/content/ru/guide/v10/typescript.md
+++ b/content/ru/guide/v10/typescript.md
@@ -98,7 +98,7 @@ TypeScript включает в себя полноценный JSX-компил�
 Типизация компонентов регулярных функций осуществляется просто — добавлением информации о типе к аргументам функции.
 
 ```tsx
-type MyComponentProps = {
+interface MyComponentProps {
   name: string;
   age: number;
 };
@@ -115,7 +115,7 @@ function MyComponent({ name, age }: MyComponentProps) {
 Параметры по умолчанию можно установить, задав в сигнатуре функции значение по умолчанию.
 
 ```tsx
-type GreetingProps = {
+interface GreetingProps {
   name?: string; // необязательный параметр!
 };
 
@@ -145,7 +145,7 @@ const Card: FunctionComponent<{ title: string }> = ({ title, children }) => {
 ```tsx
 import { h, ComponentChildren } from 'preact';
 
-type ChildrenProps = {
+interface ChildrenProps {
   title: string;
   children: ComponentChildren;
 };
@@ -166,12 +166,12 @@ function Card({ title, children }: ChildrenProps) {
 
 ```tsx
 // Типы для props
-type ExpandableProps = {
+interface ExpandableProps {
   title: string;
 };
 
 // Типы для state
-type ExpandableState = {
+interface ExpandableState {
   toggled: boolean;
 };
 
@@ -327,7 +327,7 @@ function App() {
 Или вы работаете без значений по умолчанию и используете привязку переменной универсального типа для привязки контекста к определённому типу:
 
 ```tsx
-type AppContextValues = {
+interface AppContextValues {
   authenticated: boolean;
   lang: string;
   theme: string;
@@ -440,13 +440,13 @@ function TextInputWithFocusButton() {
 
 ```typescript
 // Тип состояния для функции редуктора
-type StateType = {
+interface StateType {
   count: number;
 };
 
 // Тип действия, где `type` может быть любым
 // "reset", "decrement", "increment"
-type ActionType = {
+interface ActionType {
   type: 'reset' | 'decrement' | 'increment';
 };
 


### PR DESCRIPTION
These days the TypeScript recommends to use the `interface` keyword instead of `type` in their docs:

https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes.html

> You’ll see that there are two syntaxes for building types: Interfaces and Types. You should prefer interface. Use type when you need specific features.

For typing component props whether you use `type` or `interface` hardly matters, since the differences mainly show up when you combine or extend types which is rare with props. That said it's better for us to align with the TS docs.