### PR TITLE
Update lifecycle method parameters

### DIFF
--- a/content/en/guide/v10/components.md
+++ b/content/en/guide/v10/components.md
@@ -87,10 +87,10 @@ In order to have the clock's time update every second, we need to know when `<Cl
 | `componentWillMount()`        | (deprecated) before the component gets mounted to the DOM
 | `componentDidMount()`         | after the component gets mounted to the DOM
 | `componentWillUnmount()`      | prior to removal from the DOM
-| `componentWillReceiveProps(nextProps, context)` | before new props get accepted _(deprecated)_
+| `componentWillReceiveProps(nextProps, nextContext)` | before new props get accepted _(deprecated)_
 | `getDerivedStateFromProps(nextProps, prevState)` | just before `shouldComponentUpdate`. Use with care.
-| `shouldComponentUpdate(nextProps, nextState, context)` | before `render()`. Return `false` to skip render
-| `componentWillUpdate(nextProps, nextState, context)` | before `render()` _(deprecated)_
+| `shouldComponentUpdate(nextProps, nextState, nextContext)` | before `render()`. Return `false` to skip render
+| `componentWillUpdate(nextProps, nextState, nextContext)` | before `render()` _(deprecated)_
 | `getSnapshotBeforeUpdate(prevProps, prevState)` | called just before `render()`. return value is passed to `componentDidUpdate`.
 | `componentDidUpdate(prevProps, prevState, snapshot)` | after `render()`
 

--- a/content/en/guide/v10/components.md
+++ b/content/en/guide/v10/components.md
@@ -87,10 +87,10 @@ In order to have the clock's time update every second, we need to know when `<Cl
 | `componentWillMount()`        | (deprecated) before the component gets mounted to the DOM
 | `componentDidMount()`         | after the component gets mounted to the DOM
 | `componentWillUnmount()`      | prior to removal from the DOM
-| `componentWillReceiveProps(nextProps, nextState)` | before new props get accepted _(deprecated)_
-| `getDerivedStateFromProps(nextProps)` | just before `shouldComponentUpdate`. Use with care.
-| `shouldComponentUpdate(nextProps, nextState)` | before `render()`. Return `false` to skip render
-| `componentWillUpdate(nextProps, nextState)` | before `render()` _(deprecated)_
+| `componentWillReceiveProps(nextProps, context)` | before new props get accepted _(deprecated)_
+| `getDerivedStateFromProps(nextProps, prevState)` | just before `shouldComponentUpdate`. Use with care.
+| `shouldComponentUpdate(nextProps, nextState, context)` | before `render()`. Return `false` to skip render
+| `componentWillUpdate(nextProps, nextState, context)` | before `render()` _(deprecated)_
 | `getSnapshotBeforeUpdate(prevProps, prevState)` | called just before `render()`. return value is passed to `componentDidUpdate`.
 | `componentDidUpdate(prevProps, prevState, snapshot)` | after `render()`
 

--- a/content/en/guide/v10/components.md
+++ b/content/en/guide/v10/components.md
@@ -88,7 +88,7 @@ In order to have the clock's time update every second, we need to know when `<Cl
 | `componentDidMount()`         | after the component gets mounted to the DOM
 | `componentWillUnmount()`      | prior to removal from the DOM
 | `componentWillReceiveProps(nextProps, nextContext)` | before new props get accepted _(deprecated)_
-| `getDerivedStateFromProps(nextProps, prevState)` | just before `shouldComponentUpdate`. Use with care.
+| `getDerivedStateFromProps(nextProps, prevState)` | just before `shouldComponentUpdate`. Return object to update state or `null` to skip update. Use with care.
 | `shouldComponentUpdate(nextProps, nextState, nextContext)` | before `render()`. Return `false` to skip render
 | `componentWillUpdate(nextProps, nextState, nextContext)` | before `render()` _(deprecated)_
 | `getSnapshotBeforeUpdate(prevProps, prevState)` | called just before `render()`. return value is passed to `componentDidUpdate`.


### PR DESCRIPTION
Updated the parameters to match what's passed in by the code.

I went with just "context" rather than "nextContext", as it's shorter and still unambiguous.

Also wondering whether it would be helpful to specify the expected return value for `getDerivedStateFromProps`. Being new to Preact/React, I didn't know that it should return an object with the updated state.