### PR TITLE
fix: Home examples

### DIFF
--- a/content/de/index.md
+++ b/content/de/index.md
@@ -175,8 +175,7 @@ render(&lt;TodoList /&gt;, document.getElementById("app"));
     <div>
         <h3>Laufendes Beispiel</h3>
         <pre repl="false"><code class="lang-jsx">
-import ToDoList from './todo-list';
-
+import ToDoList from './todo-list';<br>
 render(&lt;ToDoList /&gt;, document.body);
         </code></pre>
         <div class="home-demo">
@@ -212,8 +211,7 @@ render(&lt;Stars /&gt;, document.getElementById("app"));
     <div>
         <h3>Laufendes Beispiel</h3>
         <pre repl="false"><code class="lang-jsx">
-import Stars from './stars';
-
+import Stars from './stars';<br>
 render(
     &lt;Stars repo="developit/preact" /&gt;,
     document.body

--- a/content/en/index.md
+++ b/content/en/index.md
@@ -172,8 +172,7 @@ render(&lt;TodoList /&gt;, document.getElementById("app"));
     <div>
         <h3>Running Example</h3>
         <pre repl="false"><code class="lang-jsx">
-import TodoList from './todo-list';
-
+import TodoList from './todo-list';<br>
 render(&lt;TodoList /&gt;, document.body);
         </code></pre>
         <div class="home-demo">
@@ -208,8 +207,7 @@ render(&lt;Stars /&gt;, document.getElementById("app"));
     <div>
         <h3>Running Example</h3>
         <pre repl="false"><code class="lang-jsx">
-import Stars from './stars';
-
+import Stars from './stars';<br>
 render(
     &lt;Stars repo="preactjs/preact" /&gt;,
     document.body

--- a/content/es/index.md
+++ b/content/es/index.md
@@ -181,8 +181,7 @@ render(&lt;TodoList /&gt;, document.getElementById("app"));
     <div>
         <h3>Ejemplo corriendo</h3>
         <pre repl="false"><code class="lang-jsx">
-import TodoList from './todo-list';
-
+import TodoList from './todo-list';<br>
 render(&lt;TodoList /&gt;, document.body);
         </code></pre>
         <div class="home-demo">
@@ -218,8 +217,7 @@ render(&lt;Stars /&gt;, document.getElementById("app"));
     <div>
         <h3>Ejemplo corriendo</h3>
         <pre repl="false"><code class="lang-jsx">
-import Stars from './stars';
-
+import Stars from './stars';<br>
 render(
     &lt;Stars repo="developit/preact" /&gt;,
     document.body

--- a/content/fr/index.md
+++ b/content/fr/index.md
@@ -174,8 +174,7 @@ render(&lt;TodoList /&gt;, document.getElementById("app"));
     <div>
         <h3>Exemple interactif</h3>
         <pre repl="false"><code class="lang-jsx">
-import TodoList from './todo-list';
-
+import TodoList from './todo-list';<br>
 render(&lt;TodoList /&gt;, document.body);
         </code></pre>
         <div class="home-demo">
@@ -211,8 +210,7 @@ render(&lt;Stars /&gt;, document.getElementById("app"));
     <div>
         <h3>Exemple fonctionnel</h3>
         <pre repl="false"><code class="lang-jsx">
-import Stars from './stars';
-
+import Stars from './stars';<br>
 render(
     &lt;Stars repo="developit/preact" /&gt;,
     document.body

--- a/content/it/index.md
+++ b/content/it/index.md
@@ -181,8 +181,7 @@ render(&lt;TodoList /&gt;, document.getElementById("app"));
     <div>
         <h3>Esempio in esecuzione</h3>
         <pre repl="false"><code class="lang-jsx">
-import TodoList from './todo-list';
-
+import TodoList from './todo-list';<br>
 render(&lt;TodoList /&gt;, document.body);
         </code></pre>
         <div class="home-demo">
@@ -218,8 +217,7 @@ render(&lt;Stars /&gt;, document.getElementById("app"));
     <div>
         <h3>Esempio in esecuzione</h3>
         <pre repl="false"><code class="lang-jsx">
-import Stars from './stars';
-
+import Stars from './stars';<br>
 render(
     &lt;Stars repo="developit/preact" /&gt;,
     document.body

--- a/content/ja/index.md
+++ b/content/ja/index.md
@@ -171,8 +171,7 @@ render(&lt;TodoList /&gt;, document.getElementById("app"));
     <div>
         <h3>実行結果</h3>
         <pre repl="false"><code class="lang-jsx">
-import TodoList from './todo-list';
-
+import TodoList from './todo-list';<br>
 render(&lt;TodoList /&gt;, document.body);
         </code></pre>
         <div class="home-demo">
@@ -207,8 +206,7 @@ render(&lt;Stars /&gt;, document.getElementById("app"));
     <div>
         <h3>実行結果</h3>
         <pre repl="false"><code class="lang-jsx">
-import Stars from './stars';
-
+import Stars from './stars';<br>
 render(
     &lt;Stars repo="preactjs/preact" /&gt;,
     document.body

--- a/content/kr/index.md
+++ b/content/kr/index.md
@@ -167,8 +167,7 @@ render(&lt;TodoList /&gt;, document.getElementById("app"));
     <div>
         <h3>실행 예시</h3>
         <pre repl="false"><code class="lang-jsx">
-import TodoList from './todo-list';
-
+import TodoList from './todo-list';<br>
 render(&lt;TodoList /&gt;, document.body);
         </code></pre>
         <div class="home-demo">
@@ -203,8 +202,7 @@ render(&lt;Stars /&gt;, document.getElementById("app"));
     <div>
         <h3>실행 예시</h3>
         <pre repl="false"><code class="lang-jsx">
-import Stars from './stars';
-
+import Stars from './stars';<br>
 render(
     &lt;Stars repo="preactjs/preact" /&gt;,
     document.body

--- a/content/pt-br/index.md
+++ b/content/pt-br/index.md
@@ -171,8 +171,7 @@ render(&lt;TodoList /&gt;, document.getElementById("app"));
     <div>
         <h3>Exemplo em ação</h3>
         <pre repl="false"><code class="lang-jsx">
-import TodoList from './todo-list';
-
+import TodoList from './todo-list';<br>
 render(&lt;TodoList /&gt;, document.body);
         </code></pre>
         <div class="home-demo">
@@ -208,8 +207,7 @@ render(&lt;Stars /&gt;, document.getElementById("app"));
     <div>
         <h3>Exemplo em ação</h3>
         <pre repl="false"><code class="lang-jsx">
-import Stars from './stars';
-
+import Stars from './stars';<br>
 render(
     &lt;Stars repo="developit/preact" /&gt;,
     document.body

--- a/content/ru/index.md
+++ b/content/ru/index.md
@@ -170,8 +170,7 @@ render(&lt;TodoList /&gt;, document.getElementById("app"));
     <div>
         <h3>Пример выполнения</h3>
         <pre repl="false"><code class="lang-jsx">
-import TodoList from './todo-list';
-
+import TodoList from './todo-list';<br>
 render(&lt;TodoList /&gt;, document.body);
 </code></pre>
 
@@ -208,11 +207,10 @@ render(&lt;Stars /&gt;, document.getElementById("app"));
     <div>
         <h3>Пример выполнения</h3>
         <pre repl="false"><code class="lang-jsx">
-import Stars from './stars';
-
+import Stars from './stars';<br>
 render(
-&lt;Stars repo="preactjs/preact" /&gt;,
-document.body
+    &lt;Stars repo="preactjs/preact" /&gt;,
+    document.body
 );
 </code></pre>
 

--- a/content/tr/index.md
+++ b/content/tr/index.md
@@ -183,8 +183,7 @@ render(&lt;TodoList /&gt;, document.getElementById("app"));
     <div>
         <h3>Çalışan Örnek</h3>
         <pre repl="false"><code class="lang-jsx">
-import TodoList from './todo-list';
-
+import TodoList from './todo-list';<br>
 render(&lt;TodoList /&gt;, document.body);
         </code></pre>
         <div class="home-demo">
@@ -220,8 +219,7 @@ render(&lt;Stars /&gt;, document.getElementById("app"));
     <div>
         <h3>Çalışan Örnek</h3>
         <pre repl="false"><code class="lang-jsx">
-import Stars from './stars';
-
+import Stars from './stars';<br>
 render(
     &lt;Stars repo="developit/preact" /&gt;,
     document.body

--- a/content/zh/index.md
+++ b/content/zh/index.md
@@ -175,8 +175,7 @@ render(&lt;TodoList /&gt;, document.getElementById("app"));
     <div>
         <h3>实际示例</h3>
         <pre repl="false"><code class="lang-jsx">
-import TodoList from './todo-list';
-
+import TodoList from './todo-list';<br>
 render(&lt;TodoList /&gt;, document.body);
         </code></pre>
         <div class="home-demo">
@@ -211,8 +210,7 @@ render(&lt;Stars /&gt;, document.getElementById("app"));
     <div>
         <h3>实际示例</h3>
         <pre repl="false"><code class="lang-jsx">
-import Stars from './stars';
-
+import Stars from './stars';<br>
 render(
     &lt;Stars repo="preactjs/preact" /&gt;,
     document.body

--- a/src/components/code-block/index.jsx
+++ b/src/components/code-block/index.jsx
@@ -101,8 +101,11 @@ const CodeBlock = props => {
 		const lang = (child.props.class || '').match(
 			/(?:lang|language)-([a-z]+)/
 		)[1];
-		const firstChild = getChild(child.props);
-		const code = String(firstChild || '').replace(/(^\s+|\s+$)/g, '');
+		// Slight hack to facilitate multi-line code blocks, w/ blank lines, in HTML in Markdown.
+		// Blank lines are an end condition to the code block, so we instead use a `<br>`
+		// which then requires a conversion back to `\n` for the code content.
+		const children = child.props.children.map(el => el.type == 'br' ? '\n' : el).join('');
+		const code = children.replace(/(^\s+|\s+$)/g, '');
 		return <HighlightedCodeBlock {...props} code={code} lang={lang} />;
 	}
 

--- a/src/style/home.css
+++ b/src/style/home.css
@@ -160,9 +160,12 @@ main .markup {
 		background: #f8f8f8;
 		border: 2px solid #ddd;
 
-		label {
-			color: #444;
+		@media (prefers-color-scheme: dark) {
+			background: #2c3037;
+			border-color: #555;
+		}
 
+		label {
 			span:first-child {
 				display: block;
 			}


### PR DESCRIPTION
`marked` is, unfortunately, turning this:

```html
<div>
    <pre repl="false"><code class="lang-jsx">
import TodoList from './todo-list';

render(&lt;TodoList /&gt;, document.body);
    </code></pre>
</div>
```

into this:

```html
<div>
    <pre repl="false"><code class="lang-jsx">
import TodoList from './todo-list';

<p>render(&lt;TodoList /&gt;, document.body);
    </code></pre></p>
</div>
```

Which breaks the code blocks pretty badly, cutting off everything after the first blank line. This is due to the fact that blank lines are an exit condition in Markdown, so the second line on out is then a paragraph.

To fix this, I've swapped out the blank lines with a `<br>`, and then in our `CodeBlock` component, made sure it could handle multiple children (as it normally just grabbed the first).

This should only impact the examples we have on the home page.

---

Additionally, I corrected the styles for the rendered examples as they were very hard to read if the user had a dark scheme preference.