### PR TITLE
refactor: Add `nofollow` & `sponsored` to sponsor links

### DIFF
--- a/src/components/sponsors/index.jsx
+++ b/src/components/sponsors/index.jsx
@@ -65,7 +65,7 @@ export default function Sponsors() {
 function SponsorItem({ link, title, width, height, id }) {
 	return (
 		<li class={styles.sponsorItem}>
-			<a href={link} title={title} target="_blank" rel="noopener noreferrer">
+			<a href={link} title={title} target="_blank" rel="noopener noreferrer nofollow sponsored">
 				<svg aria-hidden viewBox={`0 0 ${width} ${height}`}>
 					<use href={`/assets/sponsor-icons.svg#${id}`} />
 				</svg>


### PR DESCRIPTION
[Google recommends `rel="sponsored"`](https://developers.google.com/search/docs/crawling-indexing/qualify-outbound-links), but that seems to be non-standard. `rel="nofollow"` was the previous recommendation, so I added that in too.