### PR TITLE
HOTFIX: Fix en getting-started.md

### DIFF
--- a/content/es/guide/v10/getting-started.md
+++ b/content/es/guide/v10/getting-started.md
@@ -7,7 +7,6 @@ permalink: '/guide/getting-started'
 
 Esta guía lo ayuda a comenzar a desarrollar aplicaciones Preact. Hay 3 formas populares de hacerlo.
 
-##
 
 Si recién está comenzando, le recomendamos ir con [preact-cli](#best-practices-powered-with-preact-cli).
 


### PR DESCRIPTION
Se ha corregido un error en el código Markdown ya que se mostraba el símbolo # en la vista previa de la documentación.