### PR TITLE
fix: Ensure text is centered on 'we are using' page

### DIFF
--- a/src/components/we-are-using/style.module.css
+++ b/src/components/we-are-using/style.module.css
@@ -1,6 +1,8 @@
-[name='/about/we-are-using'] h1,
-[name='/about/we-are-using'] p {
-	text-align: center;
+content-region[name*='/about/we-are-using'] {
+	h1,
+	p {
+		text-align: center;
+	}
 }
 
 html .root {


### PR DESCRIPTION
From Slack: https://preact.slack.com/archives/C3NMBSJKH/p1710520457800869?thread_ts=1710518686.332509&cid=C3NMBSJKH

`name` was exact so `/about/we-are-using/` didn't match :facepalm:

The reproduction is that going to the site and then navigating via the menu would land the user on `/about/we-are-using`, but if you refreshed, that'd become `/about/we-are-using/`