### PR TITLE
fix: links to useContext hook

### DIFF
--- a/content/en/guide/v10/context.md
+++ b/content/en/guide/v10/context.md
@@ -52,7 +52,7 @@ function App() {
 render(<App />, document.getElementById("app"));
 ```
 
-> An easier way to use context is via the [useContext](/guide/v10/hooks#usecontext) hook.
+> An easier way to use context is via the [useContext](/guide/v10/hooks/#usecontext) hook.
 
 ## Legacy Context API
 

--- a/content/ja/guide/v10/context.md
+++ b/content/ja/guide/v10/context.md
@@ -47,7 +47,7 @@ function App() {
 }
 ```
 
-> [useContext](/guide/v10/hooks#context)フックを使うと簡単にコンテキストを扱うことができます。
+> [useContext](/guide/v10/hooks/#usecontext)フックを使うと簡単にコンテキストを扱うことができます。
 
 ## 古いコンテキストAPI
 

--- a/content/pt-br/guide/v10/context.md
+++ b/content/pt-br/guide/v10/context.md
@@ -43,7 +43,7 @@ function App() {
 }
 ```
 
-> Uma maneira mais fácil de usar o contexto é através do [useContext](/guide/v10/hooks#usecontext) hook.
+> Uma maneira mais fácil de usar o contexto é através do [useContext](/guide/v10/hooks/#usecontext) hook.
 
 ## Legacy Context API
 

--- a/content/ru/guide/v10/context.md
+++ b/content/ru/guide/v10/context.md
@@ -56,7 +56,7 @@ function App() {
 render(<App />, document.getElementById('app'));
 ```
 
-> Более простой способ использовать контекст — использовать хук [useContext](/guide/v10/hooks#usecontext).
+> Более простой способ использовать контекст — использовать хук [useContext](/guide/v10/hooks/#usecontext).
 
 ## Устаревший API контекста
 

--- a/content/zh/guide/v10/context.md
+++ b/content/zh/guide/v10/context.md
@@ -50,7 +50,7 @@ function App() {
 render(<App />, document.getElementById("app"));
 ```
 
-> 另一种简单的方法是使用 [useContext](/guide/v10/hooks#usecontext) 钩子。
+> 另一种简单的方法是使用 [useContext](/guide/v10/hooks/#usecontext) 钩子。
 
 ## 旧版上下文 API
 


### PR DESCRIPTION
interesting observation: When opening the links in a new tab, they work. But simply clicking on them yields a 404 page.

![grafik](https://github.com/preactjs/preact-www/assets/92720311/cc2e9b8f-6285-4ecd-9226-c77c48cbf811)
