### PR TITLE
fix: Ensure `useContent` hook strips fragments from URL

### DIFF
--- a/src/lib/use-resource.js
+++ b/src/lib/use-resource.js
@@ -9,6 +9,7 @@ const CACHE = new Map();
  * @returns {{ html: string, meta: any }}
  */
 export function useContent([lang, url]) {
+	url = url.split('#')[0];
 	return useResource(
 		() => (PRERENDER ? getContentOnServer : getContent)([lang, url]),
 		[lang, url]


### PR DESCRIPTION
Supersedes #1099 

Easily seen by clicking the link `useContext` link beneath the [`createContext` example](https://preactjs.com/guide/v10/context#createcontext).

Scrolling to the link on navigation seems quite touchy still... trying to figure out a better system.