### PR TITLE
chore: Use correct CSS property for avoiding header overlap on scroll

### DIFF
--- a/src/style/markdown.css
+++ b/src/style/markdown.css
@@ -388,11 +388,10 @@
 	h5,
 	h6 {
 		/* fix anchor target positioning to account for fixed header */
-		&:target {
-			padding-top: var(--header-and-banner-height);
-		}
-		content-region[name*='v8'] &:target {
-			padding-top: calc(var(--header-and-banner-height) + 3.25rem);
+		scroll-margin-top: var(--header-and-banner-height);
+
+		content-region[name*='v8'] & {
+			scroll-margin-top: calc(var(--header-and-banner-height) + 3.25rem);
 		}
 
 		content-region[name*='guide'] & {


### PR DESCRIPTION
Credit to @lukewarlow 

The problem with the current implementation is that you get these big gutters upon scrolling back up in the page: 
![temp](https://github.com/preactjs/preact-www/assets/33403762/bc0924d0-39d6-481a-a316-9baf8a0ce971)
