### PR TITLE
fix: Ensure language query params work again

### DIFF
--- a/src/components/controllers/blog-page.jsx
+++ b/src/components/controllers/blog-page.jsx
@@ -20,10 +20,10 @@ export default function BlogPage() {
 }
 
 function BlogLayout() {
-	const { url } = useLocation();
+	const { path } = useLocation();
 	const [lang] = useLanguage();
 
-	const { html, meta } = useContent([lang, url === '/' ? 'index' : url]);
+	const { html, meta } = useContent([lang, path === '/' ? 'index' : path]);
 	useTitle(meta.title);
 	useDescription(meta.description);
 

--- a/src/components/controllers/doc-page.jsx
+++ b/src/components/controllers/doc-page.jsx
@@ -24,14 +24,14 @@ export function DocPage() {
 }
 
 export function DocLayout() {
-	const { url } = useLocation();
+	const { path } = useLocation();
 	const [lang] = useLanguage();
 
-	const { html, meta } = useContent([lang, url === '/' ? 'index' : url]);
+	const { html, meta } = useContent([lang, path === '/' ? 'index' : path]);
 	useTitle(meta.title);
 	useDescription(meta.description);
 
-	const hasSidebar = meta.toc !== false && isDocPage(url);
+	const hasSidebar = meta.toc !== false && isDocPage(path);
 
 	return (
 		<div class={cx(style.page, hasSidebar && style.withSidebar)}>
@@ -53,9 +53,9 @@ export function DocLayout() {
 
 function OldDocsWarning() {
 	const { name, version } = useRoute().params;
-	const { url } = useLocation();
+	const { path } = useLocation();
 
-	if (!isDocPage(url) || version === LATEST_MAJOR) {
+	if (!isDocPage(path) || version === LATEST_MAJOR) {
 		return null;
 	}
 

--- a/src/components/controllers/markdown-region.jsx
+++ b/src/components/controllers/markdown-region.jsx
@@ -10,17 +10,17 @@ import BlogMeta from '../blog-meta';
  * @propery {any} [components]
  */
 export function MarkdownRegion({ html, meta, components }) {
-	const { url } = useLocation();
+	const { path } = useLocation();
 
-	const canEdit = url !== '/' && !url.startsWith('/tutorial');
-	const isBlogArticle = url.startsWith('/blog/');
+	const canEdit = path !== '/' && !path.startsWith('/tutorial');
+	const isBlogArticle = path.startsWith('/blog/');
 
 	return (
 		<>
 			{canEdit && <EditThisPage isFallback={meta.isFallback} />}
 			{isBlogArticle && <BlogMeta meta={meta} />}
 			<ContentRegion
-				current={url}
+				current={path}
 				content={html}
 				toc={meta.toc}
 				components={components}

--- a/src/components/controllers/tutorial-page.jsx
+++ b/src/components/controllers/tutorial-page.jsx
@@ -19,11 +19,11 @@ export default function TutorialPage() {
 }
 
 function TutorialLayout() {
-	const { url } = useLocation();
+	const { path } = useLocation();
 	const { params } = useRoute();
 	const [lang] = useLanguage();
 
-	const { html, meta } = useContent([lang, !params.step ? 'tutorial/index' : url]);
+	const { html, meta } = useContent([lang, !params.step ? 'tutorial/index' : path]);
 	useTitle(meta.title);
 	useDescription(meta.description);
 

--- a/src/components/edit-button/index.jsx
+++ b/src/components/edit-button/index.jsx
@@ -3,10 +3,9 @@ import { useLanguage } from '../../lib/i18n';
 import style from './style.module.css';
 
 export default function EditThisPage({ isFallback }) {
-	const { url } = useLocation();
+	let { path } = useLocation();
 	const [lang] = useLanguage();
 
-	let path = url.replace(/\/$/, '') || '/index';
 	path = !isFallback ? path + '.md' : '';
 	const editUrl = `https://github.com/preactjs/preact-www/tree/master/content/${lang}${path}`;
 	return (

--- a/src/components/sidebar/sidebar-nav.jsx
+++ b/src/components/sidebar/sidebar-nav.jsx
@@ -13,13 +13,7 @@ import style from './sidebar-nav.module.css';
  * @param {SidebarNavProps} props
  */
 export default function SidebarNav({ items, onClick }) {
-	let { url } = useLocation();
-
-	// Remove trailing slash to fix activeCss check below.
-	// Note that netlify will always append a slash to the url so that we end
-	// up with something like "foo/bar/?lang=de". That's why we first remove
-	// the search params before removing the trailing slash.
-	url = url.replace(/\?.*/, '').replace(/\/$/, '');
+	const { path } = useLocation();
 
 	return (
 		<nav
@@ -39,7 +33,7 @@ export default function SidebarNav({ items, onClick }) {
 											key={href}
 											href={href}
 											onClick={onClick}
-											isActive={href === url}
+											isActive={href === path}
 										>
 											{text}
 										</SidebarNavLink>
@@ -54,7 +48,7 @@ export default function SidebarNav({ items, onClick }) {
 						key={href}
 						href={href}
 						onClick={onClick}
-						isActive={href === url}
+						isActive={href === path}
 					>
 						{text}
 					</SidebarNavLink>

--- a/src/lib/i18n.jsx
+++ b/src/lib/i18n.jsx
@@ -1,5 +1,5 @@
 import { createContext } from 'preact';
-import { useContext, useState } from 'preact/hooks';
+import { useContext } from 'preact/hooks';
 import { useLocation } from 'preact-iso';
 import { useStoredValue } from './localstorage';
 import config from '../config.json';
@@ -41,11 +41,12 @@ export function getDefaultLanguage(available, override) {
 }
 
 export function LanguageProvider({ children }) {
-	const location = useLocation();
+	const { query } = useLocation();
 
 	const [lang, setLang] = useStoredValue(
 		'lang',
-		getDefaultLanguage(config.languages, location.query.lang) || 'en'
+		getDefaultLanguage(config.languages, query.lang) || 'en',
+		!!query.lang
 	);
 
 	return (

--- a/src/lib/localstorage.js
+++ b/src/lib/localstorage.js
@@ -18,11 +18,12 @@ export const localStorageSet = (key, value) => {
  * Automatically sync a value to localStorage
  * @param {string} key The key to store the data in
  * @param {any} initial Initial value when no localStorage entry was found
+ * @param {boolean} [force] Ignore stored value, use initial instead
  * @returns {[any, (v: any) => void]}
  */
-export function useStoredValue(key, initial) {
+export function useStoredValue(key, initial, force) {
 	let stored = localStorageGet(key);
-	if (stored == null) stored = initial;
+	if (force || stored == null) stored = initial;
 
 	const [value, setValue] = useState(stored);
 

--- a/src/lib/use-resource.js
+++ b/src/lib/use-resource.js
@@ -5,14 +5,13 @@ import { getContent, getContentOnServer } from './content.js';
 const CACHE = new Map();
 
 /**
- * @param {[ lang: string, url: string ]} args
+ * @param {[ lang: string, path: string ]} args
  * @returns {{ html: string, meta: any }}
  */
-export function useContent([lang, url]) {
-	url = url.split('#')[0];
+export function useContent([lang, path]) {
 	return useResource(
-		() => (PRERENDER ? getContentOnServer : getContent)([lang, url]),
-		[lang, url]
+		() => (PRERENDER ? getContentOnServer : getContent)([lang, path]),
+		[lang, path]
 	);
 }
 


### PR DESCRIPTION
Mostly missed in #1073, though also last night in #1100

Should use `path` in most of these cases, I blanked and didn't realize `useLocation` offers that which solves a few of our issues.