### PR TITLE
chore: Move all repo information to Contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,13 +14,38 @@ $ npm run dev
 
 At this point, you should have the site running at `http://localhost:8080`, ready for you to make any changes.
 
+## Application Structure
+
+This website is built as a [prerendered static app](https://developers.google.com/web/updates/2019/02/rendering-on-the-web#static-rendering), following the [Application Shell pattern](https://developers.google.com/web/fundamentals/architecture/app-shell).
+
+### Content
+
+Content is fetched and rendered on the fly from Markdown documents, similiar to how Jekyll and many other static site generators work. Each page on the site is a separate Markdown file, with optional YAML FrontMatter for specifying page metadata or layout information. Once fetched, the markdown content is then parsed using [`marked`](https://github.com/markedjs/marked) and rendered via [`preact-markup`](https://github.com/developit/preact-markup) to create the HTML you can read and interact with.
+
+### Custom Elements
+
+Since [`preact`](https://github.com/preactjs/preact) is used to render the Markdown content, we can make use of Custom Elements in our Markdown content to easily allow for dynamic or repated content, such as a generated Table of Contents or the Preact logo. These Elements are defined in [`src/components/widget.js`](./src/components/widget.js) and can be used like so:
+
+```md
+## Example Page
+
+<!-- Jumbotron and Logo are actually Preact components! -->
+<jumbotron>
+    <h1><logo text>Preact</logo></h1>
+</jumbotron>
+```
+
+### Navigation
+
+The navigation menu and route handling are controlled by [`src/config.json`](./src/config.json). Any new documents would need to be added to this file to be accessible via the site's navigation.
+
 ## Writing Content
 
-The written content on the site is authored in Markdown, found in the [`content`](./content) directory. Each page is a separate Markdown file, split up by language, and [`src/config.json`](./src/config.json) contains both the routing layout as well as general i18n labels. More information about how the site is built can be found in the [README.md](./README.md).
+The written content on the site is authored in Markdown, found in the [`content`](./content) directory and split up by language. Additionally, [`src/config.json`](./src/config.json) contains some i18n labels which you may need to alter if you were adding a new translated page.
 
-Please author and submit content **only in one language** _(generally your primary written language)_ to facilitate translation.
+Any and all content contributions are greatly appreciated, be that typo fixes or completely new translations.
 
-English is the site's default language and is generally the source for translations. Try to follow the existing formatting where possible and treat it (English) as the source of truth in most cases.
+Please author and submit content **only in one language** _(generally your primary written language)_ to facilitate translation. English is the site's default language and is generally the source for translations. Try to follow the existing formatting where possible and treat it (English) as the source of truth in most cases.
 
 ### German Version
 

--- a/README.md
+++ b/README.md
@@ -2,75 +2,22 @@
 
 [![Preact Slack Community](https://img.shields.io/badge/slack-Preact%20Slack%20Community-blue?logo=slack)](https://chat.preactjs.com/)
 
-Built with [preact-cli](https://github.com/preactjs/preact-cli)
-
 > :rocket: `master` is automatically deployed to [preactjs.com](https://preactjs.com)
 
 ---
 
-## Application Structure
+## Chat with Us
 
-This website is built as a [prerendered static app](https://developers.google.com/web/updates/2019/02/rendering-on-the-web#static-rendering), following the [Application Shell pattern](https://developers.google.com/web/fundamentals/architecture/app-shell).
+We have a [Slack community](https://chat.preactjs.com/) where you can chat with the Preact team and the wider Preact community. Come stop by to get support, ask questions, or just to introduce yourself!
 
-### Content
+## Issues
 
-Content is fetched and rendered on the fly from Markdown documents located in `content/`, similar to how Jekyll works.
-Documents can contain optional YAML FrontMatter for specifying page metadata or layout information.
-Once fetched, content is parsed using [marked] and rendered to VDOM via [preact-markup].
+If something doesn't look quite right, or maybe the wording is confusing, please let us know by opening an issue!
 
-### Custom Elements
+## Contributing
 
-Since [preact] is used to render the Markdown content, HTML contained in a document reference any of the Components listed in `src/components/widget.js` as Custom Elements, useful for dynamic content:
-
-```md
-## Example Page
-
-<!-- Jumbotron and Logo are actually Preact components! -->
-<jumbotron>
-    <h1><logo text>Preact</logo></h1>
-</jumbotron>
-```
-
-### Navigation
-
-Currently, the navigation menu and route handling is controlled by `src/config.json`.
-This is likely to change, but in the meantime it means any new pages must be linked from the `"nav"` section of the config.
-
----
-
-## Local Development
-
-### Clone & Install Dependencies
-
-```sh
-git clone https://github.com/preactjs/preact-www.git
-cd preact-www
-
-npm install
-```
-
-### Development Workflow
-
-**To start a live-reload development server:**
-
-```sh
-npm run dev
-```
-
-> Any time you make changes within the `src` directory, it will rebuild and even refresh your browser.
-
-**Generate a production build in `./build`:**
-
-```sh
-npm run build
-```
-
----
+Check out the [Contributing Guide](./CONTRIBUTING.md) for information on how to contribute to the site and work on it locally.
 
 ## License
 
-MIT
-
-[marked]: https://github.com/chjj/marked
-[preact]: https://github.com/preactjs/preact
-[preact-markup]: https://github.com/developit/preact-markup
+[MIT](./LICENSE)


### PR DESCRIPTION
Follow-up to #1102, moves all general repo information to `Contributing.md`. I realized past Ryan was wrong and splitting general architecture & contributing info in two separate docs was a bad call.

Mimicking some other projects, the ReadMe now contains a more obvious link to our Slack & encouragement for opening issues on spotting a bug or confusing language and whatnot.

Of course, verbiage suggestions welcome if anything seems like it could be better.