### PR TITLE
chore: Remove duplicate docsearch CSS import

### DIFF
--- a/src/style/variables.css
+++ b/src/style/variables.css
@@ -1,5 +1,3 @@
-@import '@docsearch/css';
-
 :root {
 	--vh: 100vh;
 	--header-height: 3.5rem;


### PR DESCRIPTION
Bah, went to close my editor and it asked if I really wanted to throw away this change. Was meant to be in #1053, it (correctly) lives [here now](https://github.com/preactjs/preact-www/blob/72353ed91c6e6ea157965ef733a1a695e04213fa/src/style/docsearch.css#L1)

It looks to be correctly dedupded, there's no stylesheet bloat, but I don't trust that will always be the case.