### PR TITLE
fix: Module Netlify functions needs to have a default export

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -34,7 +34,7 @@ export async function prerender() {
 		globalThis.DOMParser = DOMParser;
 
 		// fetch latest release data
-		const { handler } = await import('./lambda/release.js');
+		const { default: handler } = await import('./lambda/release.js');
 		const { version, url } = JSON.parse((await handler()).body);
 		globalThis.prerenderPreactVersion = version;
 		globalThis.prerenderPreactReleaseUrl = url;

--- a/src/lambda/release.js
+++ b/src/lambda/release.js
@@ -1,6 +1,6 @@
-export const handler = async event => {
+export default async function handler(req, _context) {
 	const { version, url } = await fetchRelease(
-		`preactjs/${event?.queryStringParameters.repo || 'preact'}`
+		`preactjs/${req?.queryStringParameters.repo || 'preact'}`
 	);
 
 	return {
@@ -14,7 +14,7 @@ export const handler = async event => {
 			'Cache-Control': 'public, max-age=3600, stale-if-error=86400'
 		}
 	};
-};
+}
 
 function checkStatus(r) {
 	if (!r.ok) {

--- a/src/lambda/repo.js
+++ b/src/lambda/repo.js
@@ -1,6 +1,6 @@
-export const handler = async event => {
+export default async function handler(req, _context) {
 	const result = await repoInfo(
-		event.queryStringParameters.repo || 'preactjs/preact'
+		req.queryStringParameters.repo || 'preactjs/preact'
 	);
 	return {
 		statusCode: 200,
@@ -10,7 +10,7 @@ export const handler = async event => {
 			'Cache-Control': 'public, max-age=3600, stale-if-error=86400'
 		}
 	};
-};
+}
 
 function checkStatus(r) {
 	if (!r.ok) {


### PR DESCRIPTION
Apparently [module functions need to have a default export](https://docs.netlify.com/functions/get-started/?fn-language=js#write-a-function-2) while [CJS functions used `exports.handler`](https://docs.netlify.com/functions/lambda-compatibility/?fn-language=js#synchronous-function-format-2)