### PR TITLE
Fix `useContext` example jsx

### DIFF
--- a/content/en/guide/v10/hooks.md
+++ b/content/en/guide/v10/hooks.md
@@ -321,7 +321,7 @@ function App() {
   )
 }
 // --repl-after
-render(<Foo />, document.getElementById("app"));
+render(<App />, document.getElementById("app"));
 ```
 
 ## Side-Effects

--- a/content/es/guide/v10/hooks.md
+++ b/content/es/guide/v10/hooks.md
@@ -321,7 +321,7 @@ function App() {
   )
 }
 // --repl-after
-render(<Foo />, document.getElementById("app"));
+render(<App />, document.getElementById("app"));
 ```
 
 ## Efectos secundarios

--- a/content/ru/guide/v10/hooks.md
+++ b/content/ru/guide/v10/hooks.md
@@ -318,7 +318,7 @@ function App() {
   );
 }
 // --repl-after
-render(<Foo />, document.getElementById('app'));
+render(<App />, document.getElementById('app'));
 ```
 
 ## Побочные эффекты


### PR DESCRIPTION
## What is changing?
This fixes the jsx examples for `useContext` so that it is valid.  The current examples use `Foo` which is an unknown component.