### PR TITLE
fix: Ensure Netlify routes to `/404` when it cannot find static HTML for a page

### DIFF
--- a/src/assets/_redirects
+++ b/src/assets/_redirects
@@ -10,4 +10,4 @@
 /guide/unit-testing-with-enzyme /guide/v10/unit-testing-with-enzyme
 /guide/progressive-web-apps /guide/v10/progressive-web-apps
 /content/* /content/*
-/* /index.html 200
+/* /404/index.html 404

--- a/src/components/content-region/index.jsx
+++ b/src/components/content-region/index.jsx
@@ -70,7 +70,7 @@ export default function ContentRegion({ content, components, ...props }) {
 	}, [props.current]);
 
 	return (
-		<content-region name={props.current} data-page-nav={hasNav}>
+		<content-region name={props.current} data-page-nav={hasNav} can-edit={props.canEdit}>
 			{content && (
 				<TocContext.Provider value={{ toc: props.toc }}>
 					<Markup

--- a/src/components/controllers/markdown-region.jsx
+++ b/src/components/controllers/markdown-region.jsx
@@ -24,6 +24,7 @@ export function MarkdownRegion({ html, meta, components }) {
 				content={html}
 				toc={meta.toc}
 				components={components}
+				canEdit={canEdit}
 			/>
 		</>
 	);

--- a/src/components/controllers/style.module.css
+++ b/src/components/controllers/style.module.css
@@ -7,7 +7,7 @@
 		margin-bottom: 4rem;
 	}
 
-	content-region:not([name='/']) :global(.markup) {
+	content-region[can-edit='true'] :global(.markup) {
 		margin-top: 2.5rem;
 
 		@media (max-width: 600px) {

--- a/src/components/controllers/style.module.css
+++ b/src/components/controllers/style.module.css
@@ -7,7 +7,7 @@
 		margin-bottom: 4rem;
 	}
 
-	content-region[can-edit='true'] :global(.markup) {
+	content-region[can-edit] :global(.markup) {
 		margin-top: 2.5rem;
 
 		@media (max-width: 600px) {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,18 +1,15 @@
 /// <reference types="vite/client" />
 
-import preact from 'preact';
-
-declare module "preact" {
-	namespace JSX {
+declare global {
+	namespace preact.JSX {
 		interface IntrinsicElements {
-			'loading-bar': LoadingBarProps;
+			'loading-bar': { showing: boolean };
+			'content-region': { name: string; 'data-page-nav': boolean; 'can-edit': boolean, children: any };
 		}
 	}
+	var prerenderPreactVersion: string;
+	var prerenderPreactReleaseUrl: string;
 }
 
-interface LoadingBarProps extends preact.JSX.HTMLAttributes<HTMLElement> {
-	showing: boolean;
-}
 
-declare var prerenderPreactVersion: string;
-declare var prerenderPreactReleaseUrl: string;
+export {}


### PR DESCRIPTION
Fixes two hydration issues on the 404/not found page:
  - The Preact logo/home nav in the header is missing 
  - The content overlaps the 'Edit this Page' link, making it unclickable