### PR TITLE
chore: fix typos in testing library and web components pages

### DIFF
--- a/content/en/guide/v10/preact-testing-library.md
+++ b/content/en/guide/v10/preact-testing-library.md
@@ -108,7 +108,7 @@ With a full DOM environment in place, we can verify our DOM nodes directly. Comm
 
 ### Using Content
 
-The Testing Library philosophy is that the "the more your tests resemble the way your software is used, the more confidence they can give you".
+The Testing Library philosophy is that "the more your tests resemble the way your software is used, the more confidence they can give you".
 
 The recommended way to interact with a page is by finding elements the way a user does, through the text content.
 

--- a/content/en/guide/v10/web-components.md
+++ b/content/en/guide/v10/web-components.md
@@ -163,7 +163,7 @@ register(FullName, 'full-name');
 
 ### Passing slots as props
 
-The `register()` function has a fourth parameter to pass options. Currently only the `shadow` options is supported, which attaches a shadow DOM tree to the specified element. When enabled, this allows the use of named `<slot>` elements to forward the Custom Element's children to specific places in the shadow tree.
+The `register()` function has a fourth parameter to pass options. Currently only the `shadow` option is supported, which attaches a shadow DOM tree to the specified element. When enabled, this allows the use of named `<slot>` elements to forward the Custom Element's children to specific places in the shadow tree.
 
 ```jsx
 function TextSection({ heading, content }) {

--- a/content/en/guide/v10/web-components.md
+++ b/content/en/guide/v10/web-components.md
@@ -163,7 +163,7 @@ register(FullName, 'full-name');
 
 ### Passing slots as props
 
-The `register()` function has a fourth parameter to pass options. Currently only the `shadow` option is supported, which attaches a shadow DOM tree to the specified element. When enabled, this allows the use of named `<slot>` elements to forward the Custom Element's children to specific places in the shadow tree.
+The `register()` function has a fourth parameter to pass options; currently, only the `shadow` option is supported, which attaches a shadow DOM tree to the specified element. When enabled, this allows the use of named `<slot>` elements to forward the Custom Element's children to specific places in the shadow tree.
 
 ```jsx
 function TextSection({ heading, content }) {


### PR DESCRIPTION
I noticed a couple of typos while working through the docs, so here's a PR to fix them up.

https://preactjs.com/guide/v10/preact-testing-library#using-content

https://preactjs.com/guide/v10/web-components#passing-slots-as-props