### PR TITLE
fix: broken image on Components page

### DIFF
--- a/content/en/guide/v10/components.md
+++ b/content/en/guide/v10/components.md
@@ -96,7 +96,7 @@ In order to have the clock's time update every second, we need to know when `<Cl
 
 Here's a visual overview of how they relate to each other (originally posted in [a tweet](https://web.archive.org/web/20191118010106/https://twitter.com/dan_abramov/status/981712092611989509) by Dan Abramov):
 
-![Diagram of component lifecycle methods](/assets/guide/components-lifecycle-diagram.png)
+![Diagram of component lifecycle methods](/guide/components-lifecycle-diagram.png)
 
 ### Error Boundaries
 


### PR DESCRIPTION
I previously added this image, but it seems it's broken, maybe because assets no longer are (or never were?) contained in a `/assets` directory. Removing `/assets` from the image `src` should fix this.