### PR TITLE
refactor: Hide banner on short viewports (like rotated phones)

### DIFF
--- a/src/components/controllers/tutorial/style.module.css
+++ b/src/components/controllers/tutorial/style.module.css
@@ -18,11 +18,17 @@
 .tutorial {
 	position: absolute;
 	left: 0;
-	top: 96px;
+	top: var(--header-and-banner-height);
 	bottom: 0;
 	height: auto;
 	width: 100%;
 	overflow: hidden;
+
+	@media (max-height: 431px) {
+		& {
+			top: var(--header-height);
+		}
+	}
 
 	:global(.markup) {
 		p:first-of-type {

--- a/src/components/header/style.module.css
+++ b/src/components/header/style.module.css
@@ -11,6 +11,12 @@
 	b {
 		color: #ffd600;
 	}
+
+	@media (max-height: 431px) {
+		& {
+			display: none;
+		}
+	}
 }
 
 .outer {


### PR DESCRIPTION
Closes #847

First two are from this PR preview, last is from the linked issue:

With hidden toolbar |  Without | Previous State
:-------------------------:|:-------------------------:|:-------------------------:
![image](https://github.com/preactjs/preact-www/assets/33403762/b07a85af-e168-4902-b29d-ac592a4790d0) | ![image](https://github.com/preactjs/preact-www/assets/33403762/72e8b8f4-40b5-4a5a-8c17-af0016849568) | ![Image](https://user-images.githubusercontent.com/114060/167424789-22e9ab98-2bd3-4ad1-bbfb-772bb6c0cb19.jpg)

Not sure if all mobile browsers can hide their toolsbars (that's Safari from me), but we've at least reclaimed a good portion of screen real estate. Maybe we could do some sort of expanding/collapsing header too (or in place of this), but that'd need some more thought & work.

Hopefully this isn't problematic, it's only hiding the banner in a pretty specific situation when vertical height is pretty badly needed.