### PR TITLE
Fix `useId` example comment

### DIFF
--- a/content/en/guide/v10/hooks.md
+++ b/content/en/guide/v10/hooks.md
@@ -450,7 +450,7 @@ const App = props => {
     document.getElementById(inputId).focus()
   }, [])
   
-  // Display a nice error message
+  // Display an input with a unique ID.
   return (
     <main id={mainId}>
       <input id={inputId}>


### PR DESCRIPTION
Currently the comment reads `// Display a nice error message`, which doesn't make sense, seems to be copied from the `useErrorBoundary` example?