### PR TITLE
fix: Match tutorial loading state to Router

### DIFF
--- a/src/components/controllers/tutorial-page.jsx
+++ b/src/components/controllers/tutorial-page.jsx
@@ -7,7 +7,7 @@ import { useLanguage } from '../../lib/i18n';
 import { tutorialRoutes } from '../../lib/route-utils';
 import { Tutorial } from './tutorial';
 
-export default function TutorialPage() {
+export default function TutorialPage({ loading }) {
 	const { params } = useRoute();
 	const { step } = params;
 
@@ -15,10 +15,10 @@ export default function TutorialPage() {
 		return <NotFound />;
 	}
 
-	return <TutorialLayout />;
+	return <TutorialLayout loading={loading} />;
 }
 
-function TutorialLayout() {
+function TutorialLayout({ loading }) {
 	const { path, params } = useRoute();
 	const [lang] = useLanguage();
 
@@ -37,7 +37,7 @@ function TutorialLayout() {
 
 	return (
 		<SolutionProvider>
-			<Tutorial html={html} meta={meta} />
+			<Tutorial html={html} meta={meta} loading={loading} />
 		</SolutionProvider>
 	);
 }

--- a/src/components/controllers/tutorial/index.jsx
+++ b/src/components/controllers/tutorial/index.jsx
@@ -134,7 +134,7 @@ export class Tutorial extends Component {
 		this.setState({ error: null });
 	};
 
-	render({ html, meta }, { loading, code, error }) {
+	render({ html, meta, loading }, { code, error }) {
 		const state = {
 			html,
 			meta,
@@ -175,7 +175,6 @@ function TutorialView({
 	const solvable = meta.solvable === true;
 	const hasCode = meta.code !== false;
 	const showCode = showCodeOverride && hasCode;
-	loading = !html || (showCode && (!Runner || !CodeEditor));
 	const initialLoad = !html || !Runner || !CodeEditor;
 
 	// Scroll to the top after loading

--- a/src/components/routes.jsx
+++ b/src/components/routes.jsx
@@ -29,7 +29,7 @@ export default function Routes() {
 						const component = route === '/repl' ? Repl : Page;
 						return <Route key={route} path={route} component={component} />;
 					})}
-				<Route path="/tutorial/:step?" component={TutorialPage} />
+				<Route path="/tutorial/:step?" component={() => <TutorialPage loading={loading} />} />
 				<Route path="/guide/:version/:name" component={DocPage} />
 				<Route path="/blog/:slug" component={BlogPage} />
 				<Route default component={NotFound} />


### PR DESCRIPTION
Admittedly this is a bit of a hack, but the tutorial pages have their own loading state which isn't quite correct anymore and is therefore creating a bit of jank when you switch between the steps (`/01-vdom` -> `/02-events`). This solution probably isn't perfect but it improves the situation quite a bit (from my testing, lmk if anyone sees anything different) for the time being until I get to properly refactor it.

I didn't touch the tutorial much during the preact-cli/preact-router -> vite/preact-iso refactor, probably just needs a bit of a touch up to align with the other pages but that'll take some time. For now, this drilling seems to help.