### PR TITLE
fix: Ensure consistent padding on mobile in header

### DIFF
--- a/src/components/controllers/repl/style.module.css
+++ b/src/components/controllers/repl/style.module.css
@@ -8,6 +8,10 @@
 	background: #eee;
 	overflow: hidden;
 
+	@media (max-height: 431px) {
+		top: var(--header-height);
+	}
+
 	.toolbar {
 		position: relative;
 		top: 0;

--- a/src/components/controllers/style.module.css
+++ b/src/components/controllers/style.module.css
@@ -62,6 +62,10 @@ content-region h1 {
 	position: relative;
 	min-height: calc(100vh - var(--header-and-banner-height));
 	width: 100%;
+
+	@media (max-height: 431px) {
+		min-height: calc(100vh - var(--header-height));
+	}
 }
 
 .oldDocsWarning {
@@ -72,6 +76,10 @@ content-region h1 {
 	position: sticky;
 	top: var(--header-and-banner-height);
 	z-index: 100; /* Else code blocks would layer on top */
+
+	@media (max-height: 431px) {
+		top: var(--header-height);
+	}
 
 	a {
 		font-weight: bold;

--- a/src/components/sidebar/style.module.css
+++ b/src/components/sidebar/style.module.css
@@ -105,9 +105,17 @@
 			position: sticky;
 			height: calc(100vh - var(--header-and-banner-height));
 			overflow: auto;
+
+			@media (max-height: 431px) {
+				height: calc(100vh - var(--header-height));
+			}
 		}
 		top: var(--header-and-banner-height);
 		padding-bottom: 0;
 		width: 100%;
+
+		@media (max-height: 431px) {
+			top: var(--header-height);
+		}
 	}
 }

--- a/src/style/docsearch.css
+++ b/src/style/docsearch.css
@@ -52,6 +52,10 @@
 .DocSearch-Modal {
 	top: var(--header-and-banner-height) !important;
 	box-shadow: none;
+
+	@media (max-height: 431px) {
+		top: var(--header-height) !important;
+	}
 }
 
 .DocSearch-Search-Icon,

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -103,6 +103,10 @@ div.highlight-container {
 		min-height: 95%;
 		padding-top: var(--header-and-banner-height);
 		display: block; /* Fix IE11 layout */
+
+		@media (max-height: 431px) {
+			padding-top: var(--header-height);
+		}
 	}
 }
 

--- a/src/style/markdown.css
+++ b/src/style/markdown.css
@@ -390,8 +390,16 @@
 		/* fix anchor target positioning to account for fixed header */
 		scroll-margin-top: var(--header-and-banner-height);
 
+		@media (max-height: 431px) {
+			scroll-margin-top: var(--header-height);
+		}
+
 		content-region[name*='v8'] & {
 			scroll-margin-top: calc(var(--header-and-banner-height) + 3.25rem);
+
+			@media (max-height: 431px) {
+				scroll-margin-top: calc(var(--header-height) + 3.25rem);
+			}
 		}
 
 		a.fragment-link {


### PR DESCRIPTION
Missed in #1131

The Ukraine banner hides with short displays ports (such as a phone turned sideways) but the extra height was only accounted for on the tutorial, where this was requested. I guess I forgot to grep through and add queries elsewhere, yikes.