### PR TITLE
fix: Ensure tutorial errors are displayed

### DIFF
--- a/src/components/controllers/tutorial/index.jsx
+++ b/src/components/controllers/tutorial/index.jsx
@@ -95,7 +95,7 @@ export class Tutorial extends Component {
 		});
 	}
 
-	onError = ({ error }) => {
+	onError = error => {
 		this.errorHandlers.forEach(f => f(error));
 		if (this.state.error !== error) {
 			this.setState({ error });


### PR DESCRIPTION
From #1150, was left in a stash :/

Tutorial errors are swallowed & not displayed to the user because of this.