### PR TITLE
refactor: Better utilize suspense in Tutorial

### DIFF
--- a/plugins/precompile-markdown/index.js
+++ b/plugins/precompile-markdown/index.js
@@ -52,6 +52,13 @@ function parseContent(content, path) {
 	// generate ToC from markdown
 	meta.toc = generateToc(content);
 
+	// extract tutorial setup, initial and final code blocks
+	if (/tutorial\/\d/.test(path)) {
+		const { markdown, tutorial } = extractTutorialCodeBlocks(content);
+		content = markdown;
+		meta.tutorial = tutorial;
+	}
+
 	return {
 		content,
 		meta
@@ -108,4 +115,30 @@ function generateToc(markdown) {
  */
 function sanitizeTitle(text) {
 	return text.replace(/\s*<!--.*-->\s*/, '');
+}
+
+/**
+ * Split out tutorial code blocks that will be fed into the REPL
+ *
+ * @param {string} markdown
+ */
+function extractTutorialCodeBlocks(markdown) {
+	const SETUP_CODE_REG = /```js:setup(.+?)```/s;
+	const INTITAL_CODE_REG = /```jsx:repl-initial(.+?)```/s;
+	const FINAL_CODE_REG = /```jsx:repl-final(.+?)```/s;
+
+	const tutorial = {};
+	[
+		['setup', SETUP_CODE_REG],
+		['initial', INTITAL_CODE_REG],
+		['final', FINAL_CODE_REG]
+	].forEach(([key, regex]) => {
+		const match = markdown.match(regex);
+		if (match) {
+			tutorial[key] = match[1].trim();
+			markdown = markdown.replace(regex, '');
+		}
+	});
+
+	return { markdown, tutorial };
 }

--- a/src/components/controllers/repl/error-overlay.jsx
+++ b/src/components/controllers/repl/error-overlay.jsx
@@ -1,7 +1,14 @@
 import { useReducer } from 'preact/hooks';
 import style from './error-overlay.module.css';
 
-export function ErrorOverlay({ class: c, name, message, stack }) {
+/**
+ * @param {Object} props
+ * @param {string} props.name
+ * @param {string} props.message
+ * @param {{functionName: string, line: number, column: number}[]} props.stack
+ * @param {string} [props.class]
+ */
+export function ErrorOverlay({ name, message, stack, class: c }) {
 	const [showStack, toggleStack] = useReducer(s => !s, false);
 	const hasStack = stack && stack.length > 0;
 

--- a/src/components/controllers/repl/errors.js
+++ b/src/components/controllers/repl/errors.js
@@ -1,6 +1,7 @@
 /**
  * Convert native error stack trace into an array of json-based frames.
  * @param {Error} err
+ * @returns {{ functionName: string, line: number, column: number}[]}
  */
 export function parseStackTrace(err) {
 	let include = true;

--- a/src/components/controllers/tutorial-page.jsx
+++ b/src/components/controllers/tutorial-page.jsx
@@ -1,13 +1,17 @@
 import { useRoute } from 'preact-iso';
+import { useEffect } from 'preact/hooks';
+import { Tutorial } from './tutorial';
 import { SolutionProvider } from './tutorial/contexts';
-import { useContent } from '../../lib/use-resource';
-import { useTitle, useDescription } from './utils';
 import { NotFound } from './not-found';
+import { useTitle, useDescription } from './utils';
+import { getContent } from '../../lib/content';
+import { useContent } from '../../lib/use-resource';
 import { useLanguage } from '../../lib/i18n';
 import { tutorialRoutes } from '../../lib/route-utils';
-import { Tutorial } from './tutorial';
 
-export default function TutorialPage({ loading }) {
+import style from './tutorial/style.module.css';
+
+export default function TutorialPage() {
 	const { params } = useRoute();
 	const { step } = params;
 
@@ -15,10 +19,10 @@ export default function TutorialPage({ loading }) {
 		return <NotFound />;
 	}
 
-	return <TutorialLayout loading={loading} />;
+	return <TutorialLayout />;
 }
 
-function TutorialLayout({ loading }) {
+function TutorialLayout() {
 	const { path, params } = useRoute();
 	const [lang] = useLanguage();
 
@@ -27,17 +31,23 @@ function TutorialLayout({ loading }) {
 	useDescription(meta.description);
 
 	// Preload the next chapter
-	// TODO: Webpack creates a circular dependency that
-	// it cannot resolve. Temporarily disabled
-	//useEffect(() => {
-	//	if (meta && meta.next) {
-	//		getContent([lang, meta.next]);
-	//	}
-	//}, [meta && meta.next, url]);
+	useEffect(() => {
+		if (meta && meta.next) {
+			getContent([lang, meta.next]);
+		}
+	}, [meta.next, path]);
 
 	return (
-		<SolutionProvider>
-			<Tutorial html={html} meta={meta} loading={loading} />
-		</SolutionProvider>
+		<div class={style.tutorial}>
+			<style>{`
+				main {
+					height: 100% !important;
+					overflow: hidden !important;
+				}
+			`}</style>
+			<SolutionProvider>
+				<Tutorial html={html} meta={meta} />
+			</SolutionProvider>
+		</div>
 	);
 }

--- a/src/components/controllers/tutorial/index.jsx
+++ b/src/components/controllers/tutorial/index.jsx
@@ -1,4 +1,4 @@
-import { Component, createRef, options } from 'preact';
+import { options } from 'preact';
 import {
 	useState,
 	useReducer,
@@ -10,380 +10,245 @@ import {
 } from 'preact/hooks';
 import { useRoute } from 'preact-iso';
 import { TutorialContext, SolutionContext } from './contexts';
-import cx from '../../../lib/cx';
-import style from './style.module.css';
 import { ErrorOverlay } from '../repl/error-overlay';
 import { parseStackTrace } from '../repl/errors';
-import widgets from '../../widgets';
+import cx from '../../../lib/cx';
 import { InjectPrerenderData } from '../../../lib/prerender-data';
+import { useResource } from '../../../lib/use-resource';
 import { useLanguage } from '../../../lib/i18n';
 import { Splitter } from '../../splitter';
 import config from '../../../config.json';
 import { MarkdownRegion } from '../markdown-region';
+import style from './style.module.css';
 
-const TUTORIAL_COMPONENTS = {
-	pre: TutorialCodeBlock,
-	Solution
-};
+const resultHandlers = new Set();
+const realmHandlers = new Set();
+const errorHandlers = new Set();
 
-export class Tutorial extends Component {
-	state = {
-		loading: true,
-		code: '',
-		error: null,
-		'repl-initial': '',
-		'repl-final': ''
-	};
+let resultCleanups, realmCleanups;
 
-	content = createRef();
-	runner = createRef();
+/**
+ * @typedef TutorialCode
+ * @property {string} setup
+ * @property {string} initial
+ * @property {string} final
+ */
 
-	static contextType = SolutionContext;
+/**
+ * @typedef TutorialMeta
+ * @property {boolean} [code]
+ * @property {boolean} [solvable]
+ * @property {TutorialCode} [tutorial]
+ */
 
-	resultHandlers = new Set();
-	realmHandlers = new Set();
-	errorHandlers = new Set();
-	useResult = fn => {
-		useEffect(() => {
-			this.resultHandlers.add(fn);
-			return () => this.resultHandlers.delete(fn);
-		}, [fn]);
-	};
-	useRealm = fn => {
-		useEffect(() => {
-			this.realmHandlers.add(fn);
-			let runner = this.runner.current;
-			if (runner && runner.realm && runner.realm.globalThis._require) {
-				this.onRealm(runner.realm);
-			}
-			return () => this.realmHandlers.delete(fn);
-		}, [fn]);
-	};
-	useError = fn => {
-		useEffect(() => {
-			this.errorHandlers.add(fn);
-			return () => this.errorHandlers.delete(fn);
-		}, [fn]);
-	};
-
-	componentWillReceiveProps({ html }) {
-		if (html !== this.props.html) {
-			this.setState({
-				code: '',
-				error: null,
-				'repl-initial': '',
-				'repl-final': ''
-			});
-			this.context.setSolved(false);
-		}
-	}
-
-	componentDidMount() {
-		Promise.all([
-			import(/* webpackChunkName: "editor" */ '../../code-editor'),
-			import(/* webpackChunkName: "runner" */ '../repl/runner')
-		]).then(([CodeEditor, Runner]) => {
-			this.CodeEditor = CodeEditor.default;
-			this.Runner = Runner.default;
-
-			// Load transpiler
-			this.Runner.worker.ping().then(() => {
-				this.setState({
-					loading: false
-				});
-			});
-		});
-	}
-
-	onError = error => {
-		this.errorHandlers.forEach(f => f(error));
-		if (this.state.error !== error) {
-			this.setState({ error });
-		}
-	};
-
-	onSuccess = () => {
-		if (this.resultCleanups) this.resultCleanups.forEach(f => f());
-		this.resultCleanups = [];
-		this.resultHandlers.forEach(f => {
-			let cleanup = f(this.runner.current);
-			if (cleanup) this.resultCleanups.push(cleanup);
-		});
-		if (this.state.error != null) {
-			this.setState({ error: null });
-		}
-	};
-
-	onRealm = realm => {
-		if (this.realmCleanups) this.realmCleanups.forEach(f => f());
-		this.realmCleanups = [];
-		// this.realmCleanups = Array.from(this.realmHandlers).map(f => f()).filter(Boolean);
-		this.realmHandlers.forEach(f => {
-			let cleanup = f(realm);
-			if (cleanup) this.realmCleanups.push(cleanup);
-		});
-	};
-
-	help = () => {
-		const solution = this.state['repl-final'];
-		this.setState({ code: solution });
-	};
-
-	clearError = () => {
-		this.setState({ error: null });
-	};
-
-	render({ html, meta, loading }, { code, error }) {
-		const state = {
-			html,
-			meta,
-			loading,
-			code,
-			error,
-			Runner: this.Runner,
-			CodeEditor: this.CodeEditor
-		};
-		return (
-			<TutorialContext.Provider value={this}>
-				<TutorialView {...state} clearError={this.clearError} />
-			</TutorialContext.Provider>
-		);
-	}
-}
-
-function TutorialView({
-	html,
-	meta,
-	loading,
-	code,
-	error,
-	Runner,
-	CodeEditor,
-	clearError
-}) {
-	const content = useRef(null);
-
-	const tutorial = useContext(TutorialContext);
-
+/**
+ * @param {{ html: string, meta: TutorialMeta }} props
+ */
+export function Tutorial({ html, meta }) {
+	const { path } = useRoute();
+	const [editorCode, setEditorCode] = useState(meta.tutorial?.initial || '');
+	const [error, setError] = useState(null);
 	const [showCodeOverride, toggleCode] = useReducer(s => !s, true);
 
-	const { path } = useRoute();
-	const [lang] = useLanguage();
-	const { solved } = useContext(SolutionContext);
+	const content = useRef(null);
+	const runner = useRef(null);
 
-	const solvable = meta.solvable === true;
+	const solutionCtx = useContext(SolutionContext);
+
 	const hasCode = meta.code !== false;
 	const showCode = showCodeOverride && hasCode;
-	const initialLoad = !html || !Runner || !CodeEditor;
 
-	// Scroll to the top after loading
+	// TODO: CodeMirror v5 cannot load in Node, and loading only the runner
+	// causes some bad jumping/pop-in. For the moment, this is the best option
+	if (typeof window === 'undefined') return null;
+
+	const { Runner, CodeEditor } = useResource(() => Promise.all([
+		import('../../code-editor'),
+		import('../repl/runner')
+	]).then(([CodeEditor, Runner]) => ({ CodeEditor: CodeEditor.default, Runner: Runner.default })), ['repl']);
+
 	useEffect(() => {
-		if (!loading && !initialLoad) {
+		if (meta.tutorial?.initial && editorCode !== meta.tutorial.initial) {
+			setEditorCode(meta.tutorial.initial);
+			solutionCtx.setSolved(false);
 			content.current.scrollTo(0, 0);
 		}
-	}, [path, loading, initialLoad]);
+	}, [html]);
 
-	const reRun = useCallback(() => {
-		let code = tutorial.state.code;
-		tutorial.setState({ code: code + ' ' }, () => {
-			tutorial.setState({ code });
+
+	const useResult = fn => {
+		useEffect(() => {
+			resultHandlers.add(fn);
+			return () => resultHandlers.delete(fn);
+		}, [fn]);
+	};
+	const useRealm = fn => {
+		useEffect(() => {
+			realmHandlers.add(fn);
+			let r = runner.current;
+			if (r && r.realm && r.realm.globalThis._require) {
+				onRealm(r.realm);
+			}
+			return () => realmHandlers.delete(fn);
+		}, [fn]);
+	};
+	const useError = fn => {
+		useEffect(() => {
+			errorHandlers.add(fn);
+			return () => errorHandlers.delete(fn);
+		}, [fn]);
+	};
+
+	const onError = error => {
+		errorHandlers.forEach(f => f(error));
+		setError(error);
+	};
+
+	const onSuccess = () => {
+		if (resultCleanups) resultCleanups.forEach(f => f());
+		resultCleanups = [];
+		resultHandlers.forEach(f => {
+			let cleanup = f(runner.current);
+			if (cleanup) resultCleanups.push(cleanup);
 		});
-	}, []);
+		setError(null);
+	};
+
+	const onRealm = realm => {
+		if (realmCleanups) realmCleanups.forEach(f => f());
+		realmCleanups = [];
+		// this.realmCleanups = Array.from(this.realmHandlers).map(f => f()).filter(Boolean);
+		realmHandlers.forEach(f => {
+			let cleanup = f(realm);
+			if (cleanup) realmCleanups.push(cleanup);
+		});
+	};
+
+	const help = () => meta.tutorial?.final && setEditorCode(meta.tutorial?.final);
 
 	return (
-		<ReplWrapper
-			loading={loading}
-			initialLoad={initialLoad}
-			solvable={solvable}
-			solved={solved}
-			showCode={showCode}
-		>
-			<Splitter
-				orientation="horizontal"
-				force={!showCode ? '100%' : undefined}
-				other={
-					<Splitter
-						orientation="vertical"
-						other={
-							<>
-								<div class={style.output} key="output">
-									{!initialLoad && (
-										<Runner
-											key={path}
-											ref={tutorial.runner}
-											onSuccess={tutorial.onSuccess}
-											onRealm={tutorial.onRealm}
-											onError={tutorial.onError}
-											code={code}
-											clear
-										/>
-									)}
-									{error && (
-										<div class={style.errorOverlayWrapper}>
-											<button class={style.close} onClick={clearError}>
-												close
-											</button>
-											<ErrorOverlay
-												key={'e:' + path}
-												class={style.error}
-												name={error.name}
-												message={error.message}
-												stack={parseStackTrace(error)}
-											/>
-											<button class={style.rerun} onClick={reRun}>
-												Re-run
-											</button>
-										</div>
-									)}
-								</div>
-								{hasCode && (
-									<button
-										class={style.toggleCode}
-										title="Toggle Code"
-										onClick={toggleCode}
-									>
-										<span>Toggle Code</span>
-									</button>
-								)}
-							</>
-						}
-					>
-						<div class={style.codeWindow}>
-							{!initialLoad && (
-								<CodeEditor
-									key="editor"
-									class={style.code}
-									value={code}
-									error={error}
-									onInput={(value) => tutorial.setState({ code: value })}
-								/>
-							)}
-						</div>
-					</Splitter>
-				}
-			>
-				<div class={style.tutorialWindow} ref={content}>
-					<MarkdownRegion
-						html={html}
-						meta={meta}
-						components={TUTORIAL_COMPONENTS}
-					/>
-
-					<div class={style.buttonContainer}>
-						{meta.prev && (
-							<a class={style.prevButton} href={meta.prev}>
-								{config.i18n.previous[lang] || config.i18n.previous.en}
-							</a>
-						)}
-						{tutorial.state['repl-final'] && (
-							<button
-								class={style.helpButton}
-								onClick={tutorial.help}
-								disabled={!showCode}
-								title="Show solution to this example"
-							>
-								{config.i18n.tutorial.solve[lang] ||
-									config.i18n.tutorial.solve.en}
-							</button>
-						)}
-						{meta.next && (
-							<a class={style.nextButton} href={meta.next}>
-								{meta.nextText || config.i18n.next[lang] || config.i18n.next.en}
-							</a>
-						)}
-					</div>
-				</div>
-			</Splitter>
-
-			<InjectPrerenderData
-				name={path}
-				data={{
-					html,
-					meta
-				}}
-			/>
-		</ReplWrapper>
-	);
-}
-
-const REPL_CSS = `
-	main {
-		height: 100% !important;
-		overflow: hidden !important;
-	}
-	footer {
-		display: none !important;
-	}
-`;
-
-function ReplWrapper({
-	loading,
-	solvable,
-	solved,
-	initialLoad,
-	showCode,
-	children
-}) {
-	return (
-		<div class={style.tutorial}>
-			<loading-bar showing={!!loading} />
-			<style>{REPL_CSS}</style>
+		<TutorialContext.Provider value={this}>
 			<div
 				class={cx(
 					style.tutorialWrapper,
-					solvable && style.solvable,
-					solved && style.solved,
-					initialLoad && style.loading,
+					meta.solvable && style.solvable,
+					solutionCtx.solved && style.solved,
 					showCode && style.showCode
 				)}
 			>
-				{children}
+				<Splitter
+					orientation="horizontal"
+					force={!showCode ? '100%' : undefined}
+					other={
+						// TODO: CodeMirror v5 cannot load in Node, and loading only the runner
+						// causes some bad jumping/pop-in. For the moment, this is the best option
+						typeof window === 'undefined'
+							? null
+							: <Splitter
+									orientation="vertical"
+									other={
+										<>
+											<div class={style.output}>
+												{error && (
+													<ErrorOverlay
+														name={error.name}
+														message={error.message}
+														stack={parseStackTrace(error)}
+													/>
+												)}
+												<Runner
+													ref={runner}
+													onSuccess={onSuccess}
+													onRealm={onRealm}
+													onError={onError}
+													code={editorCode}
+												/>
+											</div>
+											{hasCode && (
+												<button
+													class={style.toggleCode}
+													title="Toggle Code"
+													onClick={toggleCode}
+												>
+													<span>Toggle Code</span>
+												</button>
+											)}
+										</>
+									}
+							  >
+								<div class={style.codeWindow}>
+									<CodeEditor
+										class={style.code}
+										value={editorCode}
+										error={error}
+										onInput={setEditorCode}
+									/>
+								</div>
+							</Splitter>
+					}
+				>
+					<div class={style.tutorialWindow} ref={content}>
+						<MarkdownRegion
+							html={html}
+							meta={meta}
+							components={TUTORIAL_COMPONENTS}
+						/>
+
+						{meta.tutorial?.setup &&
+							<TutorialSetupBlock
+								code={meta.tutorial.setup}
+								runner={runner}
+								useResult={useResult}
+								useRealm={useRealm}
+								useError={useError}
+							/>
+						}
+
+						<ButtonContainer meta={meta} showCode={showCode} help={help} />
+					</div>
+				</Splitter>
+
+				<InjectPrerenderData
+					name={path}
+					data={{ html, meta }}
+				/>
 			</div>
-			<div
-				class={cx(
-					style.loadingOverlay,
-					typeof window !== 'undefined' && loading && style.loading
-				)}
-			>
-				<h4>Loading...</h4>
-			</div>
+		</TutorialContext.Provider>
+	);
+}
+
+function ButtonContainer({ meta, showCode, help }) {
+	const [lang] = useLanguage();
+
+	return (
+		<div class={style.buttonContainer}>
+			{meta.prev && (
+				<a class={style.prevButton} href={meta.prev}>
+					{config.i18n.previous[lang] || config.i18n.previous.en}
+				</a>
+			)}
+			{meta.solvable && (
+				<button
+					class={style.helpButton}
+					onClick={help}
+					disabled={!showCode}
+					title="Show solution to this example"
+				>
+					{config.i18n.tutorial.solve[lang] ||
+						config.i18n.tutorial.solve.en}
+				</button>
+			)}
+			{meta.next && (
+				<a class={style.nextButton} href={meta.next}>
+					{meta.nextText || config.i18n.next[lang] || config.i18n.next.en}
+				</a>
+			)}
 		</div>
 	);
 }
 
-/** Handles all code blocks (and <pre>'s) in tutorial markup */
-function TutorialCodeBlock(props) {
-	const tutorial = useContext(TutorialContext);
-	const child = [].concat(props.children)[0];
-
-	// not a code block
-	if (!child || child.type !== 'code') {
-		return <pre {...props} />;
-	}
-
-	const text = [].concat(child.props.children).join('');
-	const code = text.replace(/(^\s+|\s+$)/g, '');
-	const cl = child.props.class || '';
-
-	// Block Type: ```js:setup
-	if (/setup/.test(cl)) {
-		return <TutorialSetupBlock code={code} />;
-	}
-
-	// Block Type: ```jsx:repl-initial  /  ```jsx:repl-final
-	const repl = cl.match(/repl-(initial|final)/g);
-	if (repl) {
-		tutorial.setState({ [repl[0]]: code + '\n' });
-		if (repl[0] === 'repl-initial') tutorial.setState({ code: code + '\n' });
-		return null;
-	}
-
-	props.repl = props.repl === true || props.repl === 'true';
-	return <widgets.CodeBlock {...props} />;
-}
-
 /** Handles running ```js:setup code blocks */
-function TutorialSetupBlock({ code }) {
+function TutorialSetupBlock({ code, runner, useResult, useRealm, useError }) {
 	// Only run when we get new setup code.
 	// Note: we run setup code as a component to allow hook usage:
 	const Setup = useCallback(() => {
@@ -391,7 +256,7 @@ function TutorialSetupBlock({ code }) {
 
 		const tutorial = useContext(TutorialContext);
 		const solutionCtx = useContext(SolutionContext);
-		const require = m => tutorial.runner.current.realm.globalThis._require(m);
+		const require = m => runner.current.realm.globalThis._require(m);
 
 		const fn = new Function(
 			'options',
@@ -418,11 +283,11 @@ function TutorialSetupBlock({ code }) {
 			useEffect,
 			useRef,
 			useMemo,
-			tutorial.useResult,
-			tutorial.useRealm,
-			tutorial.useError,
+			useResult,
+			useRealm,
+			useError,
 			solutionCtx,
-			tutorial.runner.current && tutorial.runner.current.realm,
+			runner.current && runner.current.realm,
 			require
 		);
 
@@ -432,6 +297,10 @@ function TutorialSetupBlock({ code }) {
 	return <Setup />;
 }
 
+const TUTORIAL_COMPONENTS = {
+	Solution
+};
+
 /** Shows a solution banner when the chapter is solved */
 function Solution({ children }) {
 	const { solved } = useContext(SolutionContext);
@@ -440,7 +309,7 @@ function Solution({ children }) {
 	useEffect(() => {
 		if (solved) {
 			requestAnimationFrame(() => {
-				ref.current.scrollIntoView({ behavior: 'smooth' });
+				ref.current && ref.current.scrollIntoView({ behavior: 'smooth' });
 			});
 		}
 	}, [solved]);

--- a/src/components/controllers/tutorial/style.module.css
+++ b/src/components/controllers/tutorial/style.module.css
@@ -242,18 +242,6 @@
 			transition: opacity 1s ease;
 			overflow: auto;
 
-			.error {
-				position: absolute;
-				left: 0;
-				right: 0;
-				bottom: 0;
-				margin: 0;
-				height: auto;
-				border-top: 2px solid var(--color-error-heading);
-				padding: 10px;
-				box-shadow: 0 0 5px rgba(0, 0, 0, 0.5);
-				animation: slideUp 300ms ease forwards 1;
-			}
 			@keyframes slideUp {
 				from {
 					opacity: 0;
@@ -356,41 +344,6 @@
 				transform: rotate(0deg);
 			}
 		}
-	}
-
-	.loadingOverlay {
-		position: absolute;
-		left: 75%;
-		top: 75%;
-		width: 160px;
-		margin: -40px 0 0 -80px;
-		background: var(--color-page-bg);
-		color: var(--color-heading);
-		box-shadow: 5px 5px 0 rgba(0, 0, 0, 0.2);
-		text-align: center;
-		opacity: 0;
-		transform: translateY(50%);
-		transition: all 500ms ease;
-		z-index: 100;
-		pointer-events: none;
-
-		&.loading {
-			opacity: 0.75;
-			transform: none;
-			transition: all 150ms ease;
-		}
-
-		h4 {
-			color: #999;
-			font-size: 16px;
-			font-weight: normal;
-		}
-	}
-
-	&:not(.showCode) .loadingOverlay,
-	&.initialLoad .loadingOverlay {
-		left: 50%;
-		top: 50%;
 	}
 }
 

--- a/src/components/controllers/tutorial/style.module.css
+++ b/src/components/controllers/tutorial/style.module.css
@@ -1,20 +1,3 @@
-.errorOverlayWrapper {
-	position: absolute;
-	top: 0;
-	left: 0;
-	bottom: 0;
-	right: 0;
-	height: 100%;
-	display: flex;
-}
-
-.close {
-	position: absolute;
-	top: 1rem;
-	right: 1rem;
-	z-index: 10;
-}
-
 .tutorial {
 	position: absolute;
 	left: 0;

--- a/src/components/routes.jsx
+++ b/src/components/routes.jsx
@@ -29,7 +29,7 @@ export default function Routes() {
 						const component = route === '/repl' ? Repl : Page;
 						return <Route key={route} path={route} component={component} />;
 					})}
-				<Route path="/tutorial/:step?" component={() => <TutorialPage loading={loading} />} />
+				<Route path="/tutorial/:step?" component={TutorialPage} />
 				<Route path="/guide/:version/:name" component={DocPage} />
 				<Route path="/blog/:slug" component={BlogPage} />
 				<Route default component={NotFound} />

--- a/src/lib/prerender-data.jsx
+++ b/src/lib/prerender-data.jsx
@@ -1,7 +1,5 @@
 const TYPE = 'text/pd';
 
-const noop = () => {};
-
 const prerenderNodes = typeof window !== 'undefined' && document.querySelectorAll(`[type="${TYPE}"]`);
 const prerenderData = {};
 
@@ -24,20 +22,19 @@ export function getPrerenderData(name) {
 	}
 }
 
-export const InjectPrerenderData = typeof window !== 'undefined'
-	? function InjectPrerenderData({ name, data }) {
-			const content = JSON.stringify(data).replace(
-				/<(_*)\/script>/g,
-				'<$1_/script>'
-			);
-			return (
-				<script
-					type={TYPE}
-					data-pd={name}
-					dangerouslySetInnerHTML={{
-						__html: content
-					}}
-				/>
-			);
-	  }
-	: noop;
+export function InjectPrerenderData({ name, data }) {
+	if (typeof window === 'undefined') return null;
+	const content = JSON.stringify(data).replace(
+		/<(_*)\/script>/g,
+		'<$1_/script>'
+	);
+	return (
+		<script
+			type={TYPE}
+			data-pd={name}
+			dangerouslySetInnerHTML={{
+				__html: content
+			}}
+		/>
+	);
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -10,6 +10,9 @@ import { spaFallbackMiddlewarePlugin } from './plugins/spa-fallback-middleware.j
 import { htmlRoutingMiddlewarePlugin } from './plugins/html-routing-middleware.js';
 import { rssFeedPlugin } from './plugins/rss-feed.js';
 
+// TODO: Should we do this for all routes, rely on discovery a bit less?
+import { tutorialRoutes } from './src/lib/route-utils.js';
+
 export default defineConfig({
 	publicDir: 'src/assets',
 	optimizeDeps: {
@@ -32,7 +35,8 @@ export default defineConfig({
 				additionalPrerenderRoutes: [
 					'/404',
 					'/guide/v8/getting-started',
-					'/branding'
+					'/branding',
+					...Object.keys(tutorialRoutes)
 				]
 			}
 		}),


### PR DESCRIPTION
This should be the last of the vite & preact-iso migration changes, sorry it took so long for me to land.

Better utilizes suspense, so now we can just rely on the router loading state -- no longer is there any loading of the REPL/Code Editor separately post-mount. This also fixes the full unmount of the route when navigating between tutorial steps, structure is now preserved & content is simply swapped out. Feels a lot smoother.

Certainly let me know if any issues are spotted -- I spent a fair bit of time going through different situations manually but this is the most complex page we have by a fair margin, which is why it was left for last.