### PR TITLE
refactor: Only debounce REPL runner on user input

### DIFF
--- a/src/components/controllers/repl/index.jsx
+++ b/src/components/controllers/repl/index.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'preact/hooks';
+import { useEffect, useState } from 'preact/hooks';
 import { useLocation, useRoute } from 'preact-iso';
 import { Splitter } from '../../splitter';
 import { EXAMPLES, fetchExample } from './examples';
@@ -18,6 +18,7 @@ export function Repl({ code }) {
 	const { route } = useLocation();
 	const { query } = useRoute();
 	const [editorCode, setEditorCode] = useStoredValue('preact-www-repl-code', code);
+	const [runnerCode, setRunnerCode] = useState(editorCode);
 	const [error, setError] = useState(null);
 	const [copied, setCopied] = useState(false);
 
@@ -38,6 +39,7 @@ export function Repl({ code }) {
 		fetchExample(slug)
 			.then(code => {
 				setEditorCode(code);
+				setRunnerCode(code);
 				route(`/repl?example=${encodeURIComponent(slug)}`, true);
 		});
 	};
@@ -51,6 +53,13 @@ export function Repl({ code }) {
 			route('/repl', true);
 		}
 	};
+
+	useEffect(() => {
+		const delay = setTimeout(() => {
+			setRunnerCode(editorCode);
+		}, 250);
+		return () => clearTimeout(delay);
+	}, [editorCode]);
 
 	const share = () => {
 		// No reason to share semi-sketchy btoa'd code if there's
@@ -125,7 +134,7 @@ export function Repl({ code }) {
 								onError={setError}
 								onSuccess={() => setError(null)}
 								css={REPL_CSS}
-								code={editorCode}
+								code={runnerCode}
 							/>
 						</div>
 					}

--- a/src/components/controllers/repl/runner.jsx
+++ b/src/components/controllers/repl/runner.jsx
@@ -65,24 +65,20 @@ export default class Runner extends Component {
 	}
 
 	run() {
-		if (this.timer) return;
-		this.timer = setTimeout(() => {
-			let { code, setup } = this.props;
-			// onRealm must be called after imports but before user code:
-			const fullSetup = `if (self._onRealm) self._onRealm();${setup || ''}\n`;
-			this.running = worker
-				.process(code, fullSetup)
-				.then(transpiled => this.execute(transpiled))
-				.then(this.commitResult)
-				.catch(this.commitError)
-				.then(() => {
-					this.running = null;
-					this.timer = null;
-					if (this.props.code !== code || this.props.setup !== setup) {
-						this.run();
-					}
-				});
-		}, 500);
+		let { code, setup } = this.props;
+		// onRealm must be called after imports but before user code:
+		const fullSetup = `if (self._onRealm) self._onRealm();${setup || ''}\n`;
+		this.running = worker
+			.process(code, fullSetup)
+			.then(transpiled => this.execute(transpiled))
+			.then(this.commitResult)
+			.catch(this.commitError)
+			.then(() => {
+				this.running = null;
+				if (this.props.code !== code || this.props.setup !== setup) {
+					this.run();
+				}
+			});
 	}
 
 	async rebuild() {

--- a/src/components/controllers/tutorial/index.jsx
+++ b/src/components/controllers/tutorial/index.jsx
@@ -47,6 +47,7 @@ let resultCleanups, realmCleanups;
 export function Tutorial({ html, meta }) {
 	const { path } = useRoute();
 	const [editorCode, setEditorCode] = useState(meta.tutorial?.initial || '');
+	const [runnerCode, setRunnerCode] = useState(editorCode);
 	const [error, setError] = useState(null);
 	const [showCodeOverride, toggleCode] = useReducer(s => !s, true);
 
@@ -73,10 +74,18 @@ export function Tutorial({ html, meta }) {
 	useEffect(() => {
 		if (meta.tutorial?.initial && editorCode !== meta.tutorial.initial) {
 			setEditorCode(meta.tutorial.initial);
+			setRunnerCode(meta.tutorial.initial);
 			solutionCtx.setSolved(false);
 			content.current.scrollTo(0, 0);
 		}
 	}, [meta.tutorial?.initial]);
+
+	useEffect(() => {
+		const delay = setTimeout(() => {
+			setRunnerCode(editorCode);
+		}, 250);
+		return () => clearTimeout(delay);
+	}, [editorCode]);
 
 
 	const useResult = fn => {
@@ -160,7 +169,7 @@ export function Tutorial({ html, meta }) {
 											onSuccess={onSuccess}
 											onRealm={onRealm}
 											onError={onError}
-											code={editorCode}
+											code={runnerCode}
 										/>
 									</div>
 									{hasCode && (


### PR DESCRIPTION
Closes #1159

Instead of debouncing the REPL runner by 500ms across the board, limit it to user interaction. This lets us switch examples in the REPL or pages in the tutorial faster -- the former is especially relevant, as dynamically pulling modules from `esm.sh` means there often will be a delay anyhow. Decreasing the baseline delay is therefore quite useful to make the editor seem faster & more fluid.