### PR TITLE
fix: Support unicode in REPL query param

### DIFF
--- a/src/components/controllers/repl-page.jsx
+++ b/src/components/controllers/repl-page.jsx
@@ -1,5 +1,6 @@
 import { useLocation, useRoute } from 'preact-iso';
 import { Repl } from './repl';
+import { base64ToText } from './repl/query-encode.js';
 import { fetchExample } from './repl/examples';
 import { useContent, useResource } from '../../lib/use-resource';
 import { useTitle, useDescription } from './utils';
@@ -39,7 +40,7 @@ async function getInitialCode(query) {
 	const { route } = useLocation();
 	let code;
 	if (query.code)  {
-		code = querySafetyCheck(atob(query.code));
+		code = querySafetyCheck() && base64ToText(query.code);
 	} else if (query.example) {
 		code = await fetchExample(query.example);
 		if (!code) {
@@ -62,13 +63,11 @@ async function getInitialCode(query) {
 	return code;
 }
 
-async function querySafetyCheck(code) {
+function querySafetyCheck() {
     return (
 		!document.referrer ||
 		document.referrer.indexOf(location.origin) === 0 ||
 		// eslint-disable-next-line no-alert
 		confirm('Are you sure you want to run the code contained in this link?')
-    )
-		? code
-		: undefined;
+    );
 }

--- a/src/components/controllers/repl/index.jsx
+++ b/src/components/controllers/repl/index.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'preact/hooks';
 import { useLocation, useRoute } from 'preact-iso';
 import { Splitter } from '../../splitter';
+import { textToBase64 } from './query-encode.js';
 import { EXAMPLES, fetchExample } from './examples';
 import { ErrorOverlay } from './error-overlay';
 import { useStoredValue } from '../../../lib/localstorage';
@@ -67,7 +68,7 @@ export function Repl({ code }) {
 		if (!query.example) {
 			// We use `history.replaceState` here as the code is only relevant on mount.
 			// There's no need to notify the router of the change.
-			history.replaceState(null, null, `/repl?code=${encodeURIComponent(btoa(editorCode))}`);
+			history.replaceState(null, null, `/repl?code=${encodeURIComponent(textToBase64(editorCode))}`);
 		}
 
 		try {

--- a/src/components/controllers/repl/query-encode.js
+++ b/src/components/controllers/repl/query-encode.js
@@ -1,0 +1,19 @@
+/**
+ * Encode text to base64 with unicode support
+ *
+ * @param {string} text
+ */
+export function textToBase64(text) {
+	const bytes = new TextEncoder().encode(text);
+	return btoa(String.fromCharCode(...bytes));
+}
+
+/**
+ * Decode text from base64 with unicode support
+ *
+ * @param {string} base64
+ */
+export function base64ToText(base64) {
+	const bytes = Uint8Array.from(atob(base64), c => c.charCodeAt(0));
+	return new TextDecoder().decode(bytes);
+}


### PR DESCRIPTION
The `Todo List (Signals)` example has a couple of emojis which `atob` and `btoa` will of course trip on.