### PR TITLE
fix: REPL style insert in FireFox

### DIFF
--- a/src/components/controllers/repl/runner.jsx
+++ b/src/components/controllers/repl/runner.jsx
@@ -112,16 +112,25 @@ export default class Runner extends Component {
 			onError: this.commitError
 		});
 		this.realm.globalThis.fetch = cachedFetch;
-		let doc = this.realm.globalThis.document;
-		let style = doc.createElement('style');
-		style.appendChild(
-			doc.createTextNode(`
-				html { font: 100%/1.3 system-ui, sans-serif; background: none; }
-				${this.props.css || ''}
-			`)
-		);
-		doc.head.appendChild(style);
-		createRoot(doc);
+
+		const insertStyles = () => {
+			const doc = this.realm.globalThis.document,
+				style = doc.createElement('style');
+
+			style.appendChild(
+				doc.createTextNode(`
+					html { font: 100%/1.3 system-ui, sans-serif; background: none; }
+					${this.props.css || ''}
+				`)
+			);
+			doc.head.appendChild(style);
+
+			createRoot(doc);
+		};
+
+		this.frame.current.contentDocument.readyState !== 'complete'
+			? this.frame.current.onload = insertStyles
+			: insertStyles();
 	}
 
 	async execute(transpiled, isFallback) {

--- a/src/components/controllers/repl/runner.jsx
+++ b/src/components/controllers/repl/runner.jsx
@@ -116,7 +116,6 @@ export default class Runner extends Component {
 		const insertStyles = () => {
 			const doc = this.realm.globalThis.document,
 				style = doc.createElement('style');
-
 			style.appendChild(
 				doc.createTextNode(`
 					html { font: 100%/1.3 system-ui, sans-serif; background: none; }
@@ -124,7 +123,6 @@ export default class Runner extends Component {
 				`)
 			);
 			doc.head.appendChild(style);
-
 			createRoot(doc);
 		};
 


### PR DESCRIPTION
Fixes #1161 

The information on this is a bit lacking, but it seems FireFox asynchronously creates the iframe doc once appended into the parent whereas Chrome and Safari do it synchronously, then, upon loading, FireFox will replace the inserted document if it's already been altered? Not 100% on that, but this seems to do the trick.