### PR TITLE
fix: Ensure passed-in initial code overrides localStorage in REPL

### DIFF
--- a/src/components/controllers/repl/index.jsx
+++ b/src/components/controllers/repl/index.jsx
@@ -18,7 +18,7 @@ import REPL_CSS from './examples/style.css?raw';
 export function Repl({ code }) {
 	const { route } = useLocation();
 	const { query } = useRoute();
-	const [editorCode, setEditorCode] = useStoredValue('preact-www-repl-code', code);
+	const [editorCode, setEditorCode] = useStoredValue('preact-www-repl-code', code, true);
 	const [runnerCode, setRunnerCode] = useState(editorCode);
 	const [error, setError] = useState(null);
 	const [copied, setCopied] = useState(false);


### PR DESCRIPTION
Our `useStoredValue` hook defaults to preferring localStorage which we do not want as [we already have a defined list of fallback values](https://github.com/preactjs/preact-www/blob/77476f289ed406580761a03187bc538178812414/src/components/controllers/repl-page.jsx#L34-L39), namely, with query params (`?code` or `?example`) taking precedence.

As such, this bug breaks an attempt to load a code sample from a link if the user has previously used our REPL.