### PR TITLE
fix: Ensure the 'Solve' button in the tutorial works

### DIFF
--- a/src/components/controllers/tutorial/index.jsx
+++ b/src/components/controllers/tutorial/index.jsx
@@ -8,7 +8,7 @@ import {
 	useMemo,
 	useCallback
 } from 'preact/hooks';
-import { useRoute } from 'preact-iso';
+import { useLocation, useRoute } from 'preact-iso';
 import { TutorialContext, SolutionContext } from './contexts';
 import { ErrorOverlay } from '../repl/error-overlay';
 import { parseStackTrace } from '../repl/errors';
@@ -45,7 +45,7 @@ let resultCleanups, realmCleanups;
  * @param {{ html: string, meta: TutorialMeta }} props
  */
 export function Tutorial({ html, meta }) {
-	const { path } = useRoute();
+	const { route, url } = useLocation();
 	const [editorCode, setEditorCode] = useState(meta.tutorial?.initial || '');
 	const [runnerCode, setRunnerCode] = useState(editorCode);
 	const [error, setError] = useState(null);
@@ -135,7 +135,12 @@ export function Tutorial({ html, meta }) {
 		});
 	};
 
-	const help = () => meta.tutorial?.final && setEditorCode(meta.tutorial?.final);
+	const help = () => {
+		if (meta.tutorial?.final) {
+			route(`${url}?solved=true`, true);
+			setEditorCode(meta.tutorial?.final);
+		}
+	};
 
 	return (
 		<TutorialContext.Provider value={this}>
@@ -188,7 +193,7 @@ export function Tutorial({ html, meta }) {
 									class={style.code}
 									value={editorCode}
 									error={error}
-									slug={path}
+									slug={url}
 									onInput={setEditorCode}
 								/>
 							</div>
@@ -217,7 +222,7 @@ export function Tutorial({ html, meta }) {
 				</Splitter>
 
 				<InjectPrerenderData
-					name={path}
+					name={url}
 					data={{ html, meta }}
 				/>
 			</div>

--- a/src/components/controllers/tutorial/index.jsx
+++ b/src/components/controllers/tutorial/index.jsx
@@ -137,7 +137,7 @@ export function Tutorial({ html, meta }) {
 
 	const help = () => {
 		if (meta.tutorial?.final) {
-			route(`${url}?solved=true`, true);
+			route(`${url}?solved`, true);
 			setEditorCode(meta.tutorial?.final);
 		}
 	};


### PR DESCRIPTION
re: https://x.com/danvitoriano/status/1815851188643926179

Missed in the CodeMirror 6 migration -- we're essentially now using a `slug` prop to determine when CodeMirror needs to swap out the code content vs letting its internal state continue to handle changes. As such, this PR adds a `?solved` redirect to address this.

Keep in mind that `solutionCtx.solved` can have additional requirements, like having the user click a button to test their new event handler, so we can't reuse it.