### PR TITLE
Update URL for Material UI Preact

### DIFF
--- a/content/en/about/libraries-addons.md
+++ b/content/en/about/libraries-addons.md
@@ -44,7 +44,7 @@ A collection of modules built to work wonderfully with Preact.
 
 ## GUI Toolkits
 
-- 🎴 [**@mui/material**](https://github.com/mui/material-ui/tree/master/examples/material-preact): the React UI library you always wanted. Follow your own design system, or start with Material Design.
+- 🎴 [**@mui/material**](https://github.com/mui/material-ui/tree/master/examples/material-ui-preact): the React UI library you always wanted. Follow your own design system, or start with Material Design.
 - :thumbsup: [**preact-material-components**](https://github.com/prateekbh/preact-material-components): Material Components for the Web (supersedes MDL)
 - :white_square_button: [**preact-mdl**](https://github.com/developit/preact-mdl): Use [MDL](https://getmdl.io) as Preact components
 - :rocket: [**preact-photon**](https://github.com/developit/preact-photon): build beautiful desktop UI with [photon](http://photonkit.com)

--- a/content/kr/about/libraries-addons.md
+++ b/content/kr/about/libraries-addons.md
@@ -45,7 +45,7 @@ Preact와 훌륭하게 동작하는 모듈 모음입니다.
 
 ## GUI 툴킷
 
-- 🎴 [**@mui/material**](https://github.com/mui/material-ui/tree/master/examples/material-preact): 여러분이 늘 원하던 React UI 라이브러리. 자체 디자인 시스템을 따르거나, Material Design으로 시작하세요.
+- 🎴 [**@mui/material**](https://github.com/mui/material-ui/tree/master/examples/material-ui-preact): 여러분이 늘 원하던 React UI 라이브러리. 자체 디자인 시스템을 따르거나, Material Design으로 시작하세요.
 - :thumbsup: [**preact-material-components**](https://github.com/prateekbh/preact-material-components): 웹을 위한 Material 컴포넌트 (MDL 대용)
 - :white_square_button: [**preact-mdl**](https://github.com/developit/preact-mdl): Preact 컴포넌트로 [MDL](https://getmdl.io) 사용
 - :rocket: [**preact-photon**](https://github.com/developit/preact-photon): [photon](http://photonkit.com)으로 아름다운 데스크톱 UI 빌드

--- a/content/ru/about/libraries-addons.md
+++ b/content/ru/about/libraries-addons.md
@@ -42,7 +42,7 @@ description: 'Коллекция библиотек и дополнений, к�
 
 ## Инструментальные средства графического интерфейса
 
-- 🎴 [**@mui/material**](https://github.com/mui/material-ui/tree/master/examples/material-preact): библиотека React UI, которую вы всегда хотели. Следуйте своей собственной системе дизайна или начните с Material Design.
+- 🎴 [**@mui/material**](https://github.com/mui/material-ui/tree/master/examples/material-ui-preact): библиотека React UI, которую вы всегда хотели. Следуйте своей собственной системе дизайна или начните с Material Design.
 - :thumbsup: [**preact-material-components**](https://github.com/prateekbh/preact-material-components): Материальные компоненты для Интернета (заменяют MDL)
 - :white_square_button: [**preact-mdl**](https://github.com/developit/preact-mdl): Используйте [MDL](https://getmdl.io) в качестве компонентов Preact
 - :rocket: [**preact-photon**](https://github.com/developit/preact-photon): Создание красивых пользовательских интерфейсов на рабочем столе с помощью [photon](http://photonkit.com)


### PR DESCRIPTION
Looks like this folder was renamed to add "UI" at some point, I've updated the URL accordingly 