### PR TITLE
feat: Codemods for Upgrading from Preact 8.x

### DIFF
--- a/content/en/guide/v10/upgrade-guide.md
+++ b/content/en/guide/v10/upgrade-guide.md
@@ -259,8 +259,6 @@ As much as we tried, we always ran into edge-cases with third-party libraries wr
 ```
  npx codemod preact/X/libraryAuthors-attribute-node-children-renaming
 ```
-
-
 ### Adjacent text nodes are not joined anymore
 
 In Preact 8.x we had this feature where we would join adjacent text notes as an optimization. This doesn't hold true for X anymore because we're not diffing directly against the dom anymore. In fact we noticed that it hurt performance in X which is why we removed it. Take the following example:

--- a/content/en/guide/v10/upgrade-guide.md
+++ b/content/en/guide/v10/upgrade-guide.md
@@ -78,6 +78,26 @@ The `Portal` component is now part of `preact/compat`.
 2. Import `createPortal` from `preact/compat`
 
 ## Getting your code ready
+---
+### Codemods
+
+To help with the upgrade, we've collaborated with the team at codemod.com to publish a set of codemods that will automatically update your codebase from Preact 8.x. These codemods streamline the migration process by automating common code transformations.
+
+
+Run all codemods listed in this guide with the Preact X codemod recipe:
+
+  ```     npx codemod preact/X/migration-recipe```
+
+This will run the following codemods:
+ - `replace-this-state-with-prevstate`
+  - `props-children-to-child-array`
+  - `update-preact-import-source`
+  - `default-import-to-namespace-import`
+
+Each of these codemods automates the changes listed in this migration guide.
+For a complete list of available Preact codemods and further details, 
+see the [codemod registry](https://codemod.com/registry?author=manishjha-04&q=Preact).
+
 
 ### Using named exports
 
@@ -95,6 +115,11 @@ import { h, Component } from "preact";
 ```
 
 _Note: This change doesn't affect `preact/compat`. It still has both named and a default export to remain compatible with react._
+
+**Codemod** for using named exports
+```
+  npx codemod preact/X/default-import-to-namespace-import
+```
 
 ### `render()` always diffs existing children
 
@@ -178,6 +203,11 @@ function Foo(props) {
 }
 ```
 
+**Codemod** for `props.children` to `childArray`
+```
+ npx codemod preact/X/props-children-to-child-array
+```
+
 ### Don't access `this.state` synchronously
 
 In Preact X the state of a component will no longer be mutated synchronously. This means that reading from `this.state` right after a `setState` call will return the previous values. Instead you should use a callback function to modify state that depends on the previous values.
@@ -193,6 +223,11 @@ this.setState(prevState => {
   // Alternatively return `null` here to abort the state update
   return { counter: prevState.counter + 1 };
 });
+```
+
+**Codemod** for `setState` callback
+```
+ npx codemod preact/X/replace-this-state-with-prevstate
 ```
 
 ### `dangerouslySetInnerHTML` will skip diffing of children
@@ -219,6 +254,12 @@ We renamed/moved the following properties:
 - `children` -> `props.children`
 
 As much as we tried, we always ran into edge-cases with third-party libraries written for react. This change to our `vnode` shape removed many difficult to spot bugs and makes our `compat` code a lot cleaner.
+
+**Codemod** for renaming properties
+```
+ npx codemod preact/X/libraryAuthors-attribute-node-children-renaming
+```
+
 
 ### Adjacent text nodes are not joined anymore
 

--- a/content/en/guide/v10/upgrade-guide.md
+++ b/content/en/guide/v10/upgrade-guide.md
@@ -81,8 +81,7 @@ The `Portal` component is now part of `preact/compat`.
 ---
 ### Codemods
 
-To help with the upgrade, we've collaborated with the team at codemod.com to publish a set of codemods that will automatically update your codebase from Preact 8.x. These codemods streamline the migration process by automating common code transformations.
-
+To assist with the upgrade, a set of codemods is available to automatically update your codebase from Preact 8.x. These codemods automate common code transformations to streamline the migration process.
 
 Run all codemods listed in this guide with the Preact X codemod recipe:
 

--- a/content/en/guide/v10/upgrade-guide.md
+++ b/content/en/guide/v10/upgrade-guide.md
@@ -78,14 +78,14 @@ The `Portal` component is now part of `preact/compat`.
 2. Import `createPortal` from `preact/compat`
 
 ## Getting your code ready
----
 ### Codemods
 
 To assist with the upgrade, a set of codemods is available to automatically update your codebase from Preact 8.x. These codemods automate common code transformations to streamline the migration process.
 
 Run all codemods listed in this guide with the Preact X codemod recipe:
 
-  ```     npx codemod preact/X/migration-recipe```
+```bash
+npx codemod preact/X/migration-recipe
 
 This will run the following codemods:
  - `replace-this-state-with-prevstate`
@@ -116,9 +116,9 @@ import { h, Component } from "preact";
 _Note: This change doesn't affect `preact/compat`. It still has both named and a default export to remain compatible with react._
 
 **Codemod** for using named exports
-```
-  npx codemod preact/X/default-import-to-namespace-import
-```
+
+```bash
+npx codemod preact/X/default-import-to-namespace-import
 
 ### `render()` always diffs existing children
 
@@ -203,9 +203,9 @@ function Foo(props) {
 ```
 
 **Codemod** for `props.children` to `childArray`
-```
- npx codemod preact/X/props-children-to-child-array
-```
+
+```bash
+npx codemod preact/X/props-children-to-child-array
 
 ### Don't access `this.state` synchronously
 
@@ -225,9 +225,9 @@ this.setState(prevState => {
 ```
 
 **Codemod** for `setState` callback
-```
+
+```bash
  npx codemod preact/X/replace-this-state-with-prevstate
-```
 
 ### `dangerouslySetInnerHTML` will skip diffing of children
 
@@ -255,9 +255,9 @@ We renamed/moved the following properties:
 As much as we tried, we always ran into edge-cases with third-party libraries written for react. This change to our `vnode` shape removed many difficult to spot bugs and makes our `compat` code a lot cleaner.
 
 **Codemod** for renaming properties
-```
- npx codemod preact/X/libraryAuthors-attribute-node-children-renaming
-```
+
+```bash
+npx codemod preact/X/libraryAuthors-attribute-node-children-renaming
 ### Adjacent text nodes are not joined anymore
 
 In Preact 8.x we had this feature where we would join adjacent text notes as an optimization. This doesn't hold true for X anymore because we're not diffing directly against the dom anymore. In fact we noticed that it hurt performance in X which is why we removed it. Take the following example:

--- a/content/en/guide/v10/upgrade-guide.md
+++ b/content/en/guide/v10/upgrade-guide.md
@@ -78,27 +78,6 @@ The `Portal` component is now part of `preact/compat`.
 2. Import `createPortal` from `preact/compat`
 
 ## Getting your code ready
----
-### Codemods
-
-To assist with the upgrade, a set of codemods is available to automatically update your codebase from Preact 8.x. These codemods automate common code transformations to streamline the migration process.
-
-Run all codemods listed in this guide with the Preact X codemod recipe:
-
-  ```bash     
-  npx codemod preact/X/migration-recipe
-  ```
-
-This will run the following codemods:
- - `replace-this-state-with-prevstate`
-  - `props-children-to-child-array`
-  - `update-preact-import-source`
-  - `default-import-to-namespace-import`
-
-Each of these codemods automates the changes listed in this migration guide.
-For a complete list of available Preact codemods and further details, 
-see the [codemod registry](https://codemod.com/registry?author=manishjha-04&q=Preact).
-
 
 ### Using named exports
 
@@ -117,10 +96,7 @@ import { h, Component } from "preact";
 
 _Note: This change doesn't affect `preact/compat`. It still has both named and a default export to remain compatible with react._
 
-**Codemod** for using named exports
-```bash
-  npx codemod preact/X/default-import-to-namespace-import
-```
+
 
 ### `render()` always diffs existing children
 
@@ -204,10 +180,7 @@ function Foo(props) {
 }
 ```
 
-**Codemod** for `props.children` to `childArray`
-```bash
- npx codemod preact/X/props-children-to-child-array
-```
+
 
 ### Don't access `this.state` synchronously
 
@@ -226,10 +199,7 @@ this.setState(prevState => {
 });
 ```
 
-**Codemod** for `setState` callback
-```bash
- npx codemod preact/X/replace-this-state-with-prevstate
-```
+
 
 ### `dangerouslySetInnerHTML` will skip diffing of children
 
@@ -256,10 +226,7 @@ We renamed/moved the following properties:
 
 As much as we tried, we always ran into edge-cases with third-party libraries written for react. This change to our `vnode` shape removed many difficult to spot bugs and makes our `compat` code a lot cleaner.
 
-**Codemod** for renaming properties
-```bash
- npx codemod preact/X/libraryAuthors-attribute-node-children-renaming
-```
+
 ### Adjacent text nodes are not joined anymore
 
 In Preact 8.x we had this feature where we would join adjacent text notes as an optimization. This doesn't hold true for X anymore because we're not diffing directly against the dom anymore. In fact we noticed that it hurt performance in X which is why we removed it. Take the following example:
@@ -277,4 +244,42 @@ console.log(<div>foo{"bar"}</div>);
 //   div
 //     text
 //     text
+```
+### Codemods
+
+To assist with the upgrade, a set of codemods is available to automatically update your codebase from Preact 8.x. These codemods automate common code transformations to streamline the migration process.
+
+Run all codemods listed in this guide with the Preact X codemod recipe:
+
+  ```bash     
+  npx codemod preact/X/migration-recipe
+  ```
+
+This will run the following codemods:
+ - `replace-this-state-with-prevstate`
+  - `props-children-to-child-array`
+  - `update-preact-import-source`
+  - `default-import-to-namespace-import`
+
+Each of these codemods automates the changes listed in this migration guide.
+For a complete list of available Preact codemods and further details, 
+see the [codemod registry](https://codemod.com/registry?author=manishjha-04&q=Preact).
+
+For using named exports
+```bash
+  npx codemod preact/X/default-import-to-namespace-import
+```
+For `props.children` to `childArray`
+```bash
+ npx codemod preact/X/props-children-to-child-array
+```
+
+For `setState` callback
+```bash
+ npx codemod preact/X/replace-this-state-with-prevstate
+```
+
+For renaming properties
+```bash
+ npx codemod preact/X/libraryAuthors-attribute-node-children-renaming
 ```

--- a/content/en/guide/v10/upgrade-guide.md
+++ b/content/en/guide/v10/upgrade-guide.md
@@ -78,14 +78,16 @@ The `Portal` component is now part of `preact/compat`.
 2. Import `createPortal` from `preact/compat`
 
 ## Getting your code ready
+---
 ### Codemods
 
 To assist with the upgrade, a set of codemods is available to automatically update your codebase from Preact 8.x. These codemods automate common code transformations to streamline the migration process.
 
 Run all codemods listed in this guide with the Preact X codemod recipe:
 
-```bash
-npx codemod preact/X/migration-recipe
+  ```bash     
+  npx codemod preact/X/migration-recipe
+  ```
 
 This will run the following codemods:
  - `replace-this-state-with-prevstate`
@@ -116,9 +118,9 @@ import { h, Component } from "preact";
 _Note: This change doesn't affect `preact/compat`. It still has both named and a default export to remain compatible with react._
 
 **Codemod** for using named exports
-
 ```bash
-npx codemod preact/X/default-import-to-namespace-import
+  npx codemod preact/X/default-import-to-namespace-import
+```
 
 ### `render()` always diffs existing children
 
@@ -203,9 +205,9 @@ function Foo(props) {
 ```
 
 **Codemod** for `props.children` to `childArray`
-
 ```bash
-npx codemod preact/X/props-children-to-child-array
+ npx codemod preact/X/props-children-to-child-array
+```
 
 ### Don't access `this.state` synchronously
 
@@ -225,9 +227,9 @@ this.setState(prevState => {
 ```
 
 **Codemod** for `setState` callback
-
 ```bash
  npx codemod preact/X/replace-this-state-with-prevstate
+```
 
 ### `dangerouslySetInnerHTML` will skip diffing of children
 
@@ -255,9 +257,9 @@ We renamed/moved the following properties:
 As much as we tried, we always ran into edge-cases with third-party libraries written for react. This change to our `vnode` shape removed many difficult to spot bugs and makes our `compat` code a lot cleaner.
 
 **Codemod** for renaming properties
-
 ```bash
-npx codemod preact/X/libraryAuthors-attribute-node-children-renaming
+ npx codemod preact/X/libraryAuthors-attribute-node-children-renaming
+```
 ### Adjacent text nodes are not joined anymore
 
 In Preact 8.x we had this feature where we would join adjacent text notes as an optimization. This doesn't hold true for X anymore because we're not diffing directly against the dom anymore. In fact we noticed that it hurt performance in X which is why we removed it. Take the following example:


### PR DESCRIPTION
**🚀 Feature Proposal**

Building codemods for Upgrading from Preact 8.x
Looking forward to add these and help Preact users have a smooth migration experience.

**Motivation**
The motivation to create codemods is that it would streamline the process for millions of users, and also ensure that the application stays efficient and secure while leveraging the latest advancements in Preact.

**Example**
These codemods would help migrate from Preact 8.x  real quick as running :


> `npx codemod preact/X/migration-recipe `

which would include all the codemods.