### PR TITLE
refactor: Move REPL query safety check into runner

### DIFF
--- a/src/components/controllers/repl-page.jsx
+++ b/src/components/controllers/repl-page.jsx
@@ -40,7 +40,7 @@ async function getInitialCode(query) {
 	const { route } = useLocation();
 	let code;
 	if (query.code)  {
-		code = querySafetyCheck() && base64ToText(query.code);
+		code = base64ToText(query.code);
 	} else if (query.example) {
 		code = await fetchExample(query.example);
 		if (!code) {
@@ -61,13 +61,4 @@ async function getInitialCode(query) {
 	}
 
 	return code;
-}
-
-function querySafetyCheck() {
-    return (
-		!document.referrer ||
-		document.referrer.indexOf(location.origin) === 0 ||
-		// eslint-disable-next-line no-alert
-		confirm('Are you sure you want to run the code contained in this link?')
-    );
 }

--- a/src/components/controllers/repl/runner.jsx
+++ b/src/components/controllers/repl/runner.jsx
@@ -136,8 +136,8 @@ export default class Runner extends Component {
 
 	async execute(transpiled, isFallback) {
 		// TODO: This is much better implemented as a dialog within the frame.
-		// `confirm` unforutnately is a window-level modal, so if there the
-		// input code is especially long, it could be hidden outside the page.
+		// `confirm` unforutnately is a window-level modal, so when/if the
+		// code extends down past the window edge, the user can't see it.
 		//
 		// Using `<dialog>` as a frame-level modal would let the user check the
 		// code in full before running it, though browser support is maybe not

--- a/src/components/controllers/repl/runner.jsx
+++ b/src/components/controllers/repl/runner.jsx
@@ -24,6 +24,8 @@ export default class Runner extends Component {
 
 	frame = createRef();
 
+	userUpdated = false;
+
 	shouldComponentUpdate() {
 		return false;
 	}
@@ -60,6 +62,7 @@ export default class Runner extends Component {
 
 	componentWillReceiveProps({ code, setup }) {
 		if (code !== this.props.code || setup !== this.props.setup) {
+			this.userUpdated = true;
 			this.run();
 		}
 	}
@@ -132,6 +135,24 @@ export default class Runner extends Component {
 	}
 
 	async execute(transpiled, isFallback) {
+		// TODO: This is much better implemented as a dialog within the frame.
+		// `confirm` unforutnately is a window-level modal, so if there the
+		// input code is especially long, it could be hidden outside the page.
+		//
+		// Using `<dialog>` as a frame-level modal would let the user check the
+		// code in full before running it, though browser support is maybe not
+		// ideal yet.
+		if (
+			new URLSearchParams(location.search).get('code') &&
+			document.referrer &&
+			document.referrer.indexOf(location.origin) !== 0 &&
+			!this.userUpdated
+		) {
+			// eslint-disable-next-line no-alert
+			const confirmed = confirm('Are you sure you want to run the code contained in this link?');
+			if (!confirmed) return;
+		}
+
 		if (this.didError && !isFallback) {
 			await this.rebuild();
 		} else {


### PR DESCRIPTION
I've been linking to a few REPL examples over the past few days, and one thing that's slightly bothering me is that we show the confirmation/warning for running untrusted code _before_ showing the code itself. The user has to gauge whether they trust whoever provided the link rather than if they trust the code (or copy the query into a base64 decoder and read that, I suppose).

This isn't perfect (see the `TODO:` I left behind), but it moves the confirmation check further ahead into the REPL runner itself. This lets the user (partially) see the code populated in the editor pane before they're forced to accept or refuse.

Before             |  After
:-------------------------:|:-------------------------:
![before](https://github.com/user-attachments/assets/ae4cf5bc-c7a3-4ea4-bad9-7860988fa75d)  | ![after](https://github.com/user-attachments/assets/1168f37f-8766-44e2-92d4-89b22f3dd5df)