### PR TITLE
issue#1188 fixing malware link in demos & examples

### DIFF
--- a/content/en/about/demos-examples.md
+++ b/content/en/about/demos-examples.md
@@ -33,7 +33,7 @@ The audience participation Progressive Web App from Chrome Dev Summit 2016!
 Open-Source peach.cool app.  
 [Github Project](https://github.com/developit/nectarine)
 
-**[Web Maker](https://webmakerapp.com/app/)** :zap:
+**[Web Maker](https://webmaker.app/)** :zap:
 Blazing fast & offline frontend playground.
 [Github Project](https://github.com/chinchang/web-maker)
 

--- a/content/kr/about/demos-examples.md
+++ b/content/kr/about/demos-examples.md
@@ -33,7 +33,7 @@ Chrome Dev Summit 2016의 관중 참여형 점진적 웹 앱!
 오픈 소스 peach.cool 앱  
 [Github Project](https://github.com/developit/nectarine)
 
-**[Web Maker](https://webmakerapp.com/app/)** :zap:  
+**[Web Maker](https://webmaker.app/)** :zap:  
 매우 빠른 오프라인 프런트엔드 플레이그라운드  
 [Github Project](https://github.com/chinchang/web-maker)
 

--- a/content/ru/about/demos-examples.md
+++ b/content/ru/about/demos-examples.md
@@ -32,7 +32,7 @@ description: 'Коллекция демо-версий и примеров пр�
 Приложение peach.cool с открытым исходным кодом.
 [Проект Github](https://github.com/developit/nectarine)
 
-**[Web Maker](https://webmakerapp.com/app/)** :zap:
+**[Web Maker](https://webmaker.app/)** :zap:
 Удивительно быстрый и автономный фронтенд.
 [Проект Github](https://github.com/chinchang/web-maker)
 

--- a/content/zh/about/demos-examples.md
+++ b/content/zh/about/demos-examples.md
@@ -32,7 +32,7 @@ permalink: '/about/demos-examples'
 一款开源的 peach.cool app。
 [Github Project](https://github.com/developit/nectarine)
 
-**[Web Maker](https://webmakerapp.com/app/)** :zap:
+**[Web Maker](https://webmaker.app/)** :zap:
 急速并支持离线的前端游乐场。
 [Github Project](https://github.com/chinchang/web-maker)
 


### PR DESCRIPTION
Fixing webmakerapp malware link in content=>demos&examples