### PR TITLE
fix: Convert old LESS functions to plain hex color in loading bar

### DIFF
--- a/src/style/index.css
+++ b/src/style/index.css
@@ -116,7 +116,7 @@ loading-bar {
 	top: -5px;
 	width: 100%;
 	height: 3px;
-	background: fade(darken(#f2777a, 10%), 50%);
+	background: #ee484c80;
 	transform: translateY(0);
 	transition: transform 1s ease, opacity 1s ease;
 	opacity: 0;


### PR DESCRIPTION
Happened to need to swipe the styling for our loading bar and noticed we still had these old (broken) LESS functions around.

Loaded up internet archive & grabbed the calculated color from there, I do think it looks much better with the background working.