### PR TITLE
chore: Switch CDN preconnect over to esm.sh

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 		<link rel="alternate" type="application/atom+xml" href="https://preactjs.com/feed.atom">
 		<meta property="og:image" content="https://preactjs.com/app-icon.png">
 		<meta name="twitter:card" content="summary">
-		<link href="https://cdn.jsdelivr.net" rel="preconnect" crossorigin="anonymous">
+		<link href="https://esm.sh" rel="preconnect" crossorigin="anonymous">
 	</head>
 	<body class="banner">
 		<div id="app"></div>


### PR DESCRIPTION
This was a relic from when docsearch was loaded via CDN which hasn't been the case for a fairly long while now. Switching it over to esm.sh, however, could be useful for our REPL.