### PR TITLE
refactor: Fix lighthouse accessibility issue in footer links

### DIFF
--- a/src/components/footer/style.module.css
+++ b/src/components/footer/style.module.css
@@ -12,7 +12,25 @@
 		margin-left: 0.625rem;
 	}
 
+	/**
+	 * Ideally kept sync'd with the markdown links:
+	 * https://github.com/preactjs/preact-www/blob/f68e65aadbd19b042921cc175aa256f3aa248768/src/style/markdown.css#L18
+   */
 	a {
 		color: var(--color-footer-link);
+		text-decoration-skip-ink: auto;
+		text-decoration: underline;
+		text-decoration-color: var(--color-table-border);
+		text-decoration-thickness: 1px;
+
+		&:hover,
+		&:focus {
+			text-decoration-color: currentColor;
+		}
+
+		&:hover,
+		&:focus {
+			color: var(--color-link-hover);
+		}
 	}
 }

--- a/src/style/markdown.css
+++ b/src/style/markdown.css
@@ -29,7 +29,7 @@
 
 		&:hover,
 		&:focus {
-			color: #ff89ff;
+			color: var(--color-link-hover);
 		}
 	}
 

--- a/src/style/variables.css
+++ b/src/style/variables.css
@@ -13,6 +13,7 @@
 	--color-brand-triplet: 103, 58, 184;
 	--color-brand-light: #8f61e1;
 	--color-link: #673ab8;
+	--color-link-hover: #ff89ff;
 	--color-btn: #673ab8;
 	--color-btn-secondary: #673ab8;
 	--color-btn-background: #eee;


### PR DESCRIPTION
Can see this from local lighthouse runs or [pagespeed insights](https://pagespeed.web.dev/analysis/https-preactjs-com/7ipoxsksca?form_factor=mobile).

![temp](https://github.com/user-attachments/assets/b3c169b6-10d1-4bc0-8965-313298162a05)

While the message seems to suggest a contrast issue, this isn't actually the case -- our contrast ratios are 6.53:1 & 6.01:1 w/ light & dark preferences respectively, both hitting the WCAG AA standards. In fact, changing this to #fff on #000 still does nothing to dismiss the message. The actual issue, which I found unclear at least, is that links aren't meant to rely on color alone and so we need text decoration here. Reasonable enough.
