### PR TITLE
refactor: Add bash syntax highlighting

### DIFF
--- a/plugins/precompile-markdown/index.js
+++ b/plugins/precompile-markdown/index.js
@@ -180,7 +180,6 @@ function highlightCodeBlocks(data) {
 		const lang = child.getAttribute('class').replace('language-', '');
 
 		Prism.languages[lang] == null
-			// TODO: Bash is the only missing one at the moment
 			? console.warn(`No Prism highlighter for language: ${lang}`)
 			: child.innerHTML = Prism.highlight(code, Prism.languages[lang], lang);
 

--- a/plugins/precompile-markdown/prism.js
+++ b/plugins/precompile-markdown/prism.js
@@ -627,3 +627,162 @@ Prism.languages.tsx = Prism.languages.extend("jsx", typescript);
         value: n
     })
 })(Prism);
+
+(function(e) {
+    var t = "\\b(?:BASH|BASHOPTS|BASH_ALIASES|BASH_ARGC|BASH_ARGV|BASH_CMDS|BASH_COMPLETION_COMPAT_DIR|BASH_LINENO|BASH_REMATCH|BASH_SOURCE|BASH_VERSINFO|BASH_VERSION|COLORTERM|COLUMNS|COMP_WORDBREAKS|DBUS_SESSION_BUS_ADDRESS|DEFAULTS_PATH|DESKTOP_SESSION|DIRSTACK|DISPLAY|EUID|GDMSESSION|GDM_LANG|GNOME_KEYRING_CONTROL|GNOME_KEYRING_PID|GPG_AGENT_INFO|GROUPS|HISTCONTROL|HISTFILE|HISTFILESIZE|HISTSIZE|HOME|HOSTNAME|HOSTTYPE|IFS|INSTANCE|JOB|LANG|LANGUAGE|LC_ADDRESS|LC_ALL|LC_IDENTIFICATION|LC_MEASUREMENT|LC_MONETARY|LC_NAME|LC_NUMERIC|LC_PAPER|LC_TELEPHONE|LC_TIME|LESSCLOSE|LESSOPEN|LINES|LOGNAME|LS_COLORS|MACHTYPE|MAILCHECK|MANDATORY_PATH|NO_AT_BRIDGE|OLDPWD|OPTERR|OPTIND|ORBIT_SOCKETDIR|OSTYPE|PAPERSIZE|PATH|PIPESTATUS|PPID|PS1|PS2|PS3|PS4|PWD|RANDOM|REPLY|SECONDS|SELINUX_INIT|SESSION|SESSIONTYPE|SESSION_MANAGER|SHELL|SHELLOPTS|SHLVL|SSH_AUTH_SOCK|TERM|UID|UPSTART_EVENTS|UPSTART_INSTANCE|UPSTART_JOB|UPSTART_SESSION|USER|WINDOWID|XAUTHORITY|XDG_CONFIG_DIRS|XDG_CURRENT_DESKTOP|XDG_DATA_DIRS|XDG_GREETER_DATA_DIR|XDG_MENU_PREFIX|XDG_RUNTIME_DIR|XDG_SEAT|XDG_SEAT_PATH|XDG_SESSION_DESKTOP|XDG_SESSION_ID|XDG_SESSION_PATH|XDG_SESSION_TYPE|XDG_VTNR|XMODIFIERS)\\b",
+        a = {
+            pattern: /(^(["']?)\w+\2)[ \t]+\S.*/,
+            lookbehind: !0,
+            alias: "punctuation",
+            inside: null
+        },
+        n = {
+            bash: a,
+            environment: {
+                pattern: RegExp("\\$" + t),
+                alias: "constant"
+            },
+            variable: [{
+                pattern: /\$?\(\([\s\S]+?\)\)/,
+                greedy: !0,
+                inside: {
+                    variable: [{
+                        pattern: /(^\$\(\([\s\S]+)\)\)/,
+                        lookbehind: !0
+                    }, /^\$\(\(/],
+                    number: /\b0x[\dA-Fa-f]+\b|(?:\b\d+(?:\.\d*)?|\B\.\d+)(?:[Ee]-?\d+)?/,
+                    operator: /--|\+\+|\*\*=?|<<=?|>>=?|&&|\|\||[=!+\-*/%<>^&|]=?|[?~:]/,
+                    punctuation: /\(\(?|\)\)?|,|;/
+                }
+            }, {
+                pattern: /\$\((?:\([^)]+\)|[^()])+\)|`[^`]+`/,
+                greedy: !0,
+                inside: {
+                    variable: /^\$\(|^`|\)$|`$/
+                }
+            }, {
+                pattern: /\$\{[^}]+\}/,
+                greedy: !0,
+                inside: {
+                    operator: /:[-=?+]?|[!\/]|##?|%%?|\^\^?|,,?/,
+                    punctuation: /[\[\]]/,
+                    environment: {
+                        pattern: RegExp("(\\{)" + t),
+                        lookbehind: !0,
+                        alias: "constant"
+                    }
+                }
+            }, /\$(?:\w+|[#?*!@$])/],
+            entity: /\\(?:[abceEfnrtv\\"]|O?[0-7]{1,3}|U[0-9a-fA-F]{8}|u[0-9a-fA-F]{4}|x[0-9a-fA-F]{1,2})/
+        };
+    e.languages.bash = {
+        shebang: {
+            pattern: /^#!\s*\/.*/,
+            alias: "important"
+        },
+        comment: {
+            pattern: /(^|[^"{\\$])#.*/,
+            lookbehind: !0
+        },
+        "function-name": [{
+            pattern: /(\bfunction\s+)[\w-]+(?=(?:\s*\(?:\s*\))?\s*\{)/,
+            lookbehind: !0,
+            alias: "function"
+        }, {
+            pattern: /\b[\w-]+(?=\s*\(\s*\)\s*\{)/,
+            alias: "function"
+        }],
+        "for-or-select": {
+            pattern: /(\b(?:for|select)\s+)\w+(?=\s+in\s)/,
+            alias: "variable",
+            lookbehind: !0
+        },
+        "assign-left": {
+            pattern: /(^|[\s;|&]|[<>]\()\w+(?:\.\w+)*(?=\+?=)/,
+            inside: {
+                environment: {
+                    pattern: RegExp("(^|[\\s;|&]|[<>]\\()" + t),
+                    lookbehind: !0,
+                    alias: "constant"
+                }
+            },
+            alias: "variable",
+            lookbehind: !0
+        },
+        parameter: {
+            pattern: /(^|\s)-{1,2}(?:\w+:[+-]?)?\w+(?:\.\w+)*(?=[=\s]|$)/,
+            alias: "variable",
+            lookbehind: !0
+        },
+        string: [{
+            pattern: /((?:^|[^<])<<-?\s*)(\w+)\s[\s\S]*?(?:\r?\n|\r)\2/,
+            lookbehind: !0,
+            greedy: !0,
+            inside: n
+        }, {
+            pattern: /((?:^|[^<])<<-?\s*)(["'])(\w+)\2\s[\s\S]*?(?:\r?\n|\r)\3/,
+            lookbehind: !0,
+            greedy: !0,
+            inside: {
+                bash: a
+            }
+        }, {
+            pattern: /(^|[^\\](?:\\\\)*)"(?:\\[\s\S]|\$\([^)]+\)|\$(?!\()|`[^`]+`|[^"\\`$])*"/,
+            lookbehind: !0,
+            greedy: !0,
+            inside: n
+        }, {
+            pattern: /(^|[^$\\])'[^']*'/,
+            lookbehind: !0,
+            greedy: !0
+        }, {
+            pattern: /\$'(?:[^'\\]|\\[\s\S])*'/,
+            greedy: !0,
+            inside: {
+                entity: n.entity
+            }
+        }],
+        environment: {
+            pattern: RegExp("\\$?" + t),
+            alias: "constant"
+        },
+        variable: n.variable,
+        function: {
+            pattern: /(^|[\s;|&]|[<>]\()(?:add|apropos|apt|apt-cache|apt-get|aptitude|aspell|automysqlbackup|awk|basename|bash|bc|bconsole|bg|bzip2|cal|cargo|cat|cfdisk|chgrp|chkconfig|chmod|chown|chroot|cksum|clear|cmp|column|comm|composer|cp|cron|crontab|csplit|curl|cut|date|dc|dd|ddrescue|debootstrap|df|diff|diff3|dig|dir|dircolors|dirname|dirs|dmesg|docker|docker-compose|du|egrep|eject|env|ethtool|expand|expect|expr|fdformat|fdisk|fg|fgrep|file|find|fmt|fold|format|free|fsck|ftp|fuser|gawk|git|gparted|grep|groupadd|groupdel|groupmod|groups|grub-mkconfig|gzip|halt|head|hg|history|host|hostname|htop|iconv|id|ifconfig|ifdown|ifup|import|install|ip|java|jobs|join|kill|killall|less|link|ln|locate|logname|logrotate|look|lpc|lpr|lprint|lprintd|lprintq|lprm|ls|lsof|lynx|make|man|mc|mdadm|mkconfig|mkdir|mke2fs|mkfifo|mkfs|mkisofs|mknod|mkswap|mmv|more|most|mount|mtools|mtr|mutt|mv|nano|nc|netstat|nice|nl|node|nohup|notify-send|npm|nslookup|op|open|parted|passwd|paste|pathchk|ping|pkill|pnpm|podman|podman-compose|popd|pr|printcap|printenv|ps|pushd|pv|quota|quotacheck|quotactl|ram|rar|rcp|reboot|remsync|rename|renice|rev|rm|rmdir|rpm|rsync|scp|screen|sdiff|sed|sendmail|seq|service|sftp|sh|shellcheck|shuf|shutdown|sleep|slocate|sort|split|ssh|stat|strace|su|sudo|sum|suspend|swapon|sync|sysctl|tac|tail|tar|tee|time|timeout|top|touch|tr|traceroute|tsort|tty|umount|uname|unexpand|uniq|units|unrar|unshar|unzip|update-grub|uptime|useradd|userdel|usermod|users|uudecode|uuencode|v|vcpkg|vdir|vi|vim|virsh|vmstat|wait|watch|wc|wget|whereis|which|who|whoami|write|xargs|xdg-open|yarn|yes|zenity|zip|zsh|zypper)(?=$|[)\s;|&])/,
+            lookbehind: !0
+        },
+        keyword: {
+            pattern: /(^|[\s;|&]|[<>]\()(?:case|do|done|elif|else|esac|fi|for|function|if|in|select|then|until|while)(?=$|[)\s;|&])/,
+            lookbehind: !0
+        },
+        builtin: {
+            pattern: /(^|[\s;|&]|[<>]\()(?:\.|:|alias|bind|break|builtin|caller|cd|command|continue|declare|echo|enable|eval|exec|exit|export|getopts|hash|help|let|local|logout|mapfile|printf|pwd|read|readarray|readonly|return|set|shift|shopt|source|test|times|trap|type|typeset|ulimit|umask|unalias|unset)(?=$|[)\s;|&])/,
+            lookbehind: !0,
+            alias: "class-name"
+        },
+        boolean: {
+            pattern: /(^|[\s;|&]|[<>]\()(?:false|true)(?=$|[)\s;|&])/,
+            lookbehind: !0
+        },
+        "file-descriptor": {
+            pattern: /\B&\d\b/,
+            alias: "important"
+        },
+        operator: {
+            pattern: /\d?<>|>\||\+=|=[=~]?|!=?|<<[<-]?|[&\d]?>>|\d[<>]&?|[<>][&=]?|&[>&]?|\|[&|]?/,
+            inside: {
+                "file-descriptor": {
+                    pattern: /^\d/,
+                    alias: "important"
+                }
+            }
+        },
+        punctuation: /\$?\(\(?|\)\)?|\.\.|[{}[\];\\]/,
+        number: {
+            pattern: /(^|\s)(?:[1-9]\d*|0)(?:[.,]\d+)?\b/,
+            lookbehind: !0
+        }
+    }, a.inside = e.languages.bash;
+    for (var s = ["comment", "function-name", "for-or-select", "assign-left", "parameter", "string", "environment", "function", "keyword", "builtin", "boolean", "file-descriptor", "operator", "punctuation", "number"], o = n.variable[1].inside, i = 0; i < s.length; i++) o[s[i]] = e.languages.bash[s[i]];
+    e.languages.sh = e.languages.bash, e.languages.shell = e.languages.bash
+})(Prism);


### PR DESCRIPTION
It's our only missing highlight language, and now that Prism is server-only, I figure it's worth adding now (as it's a bit chonky).

The "Getting Started" & "Unit Testing with Enzyme" pages have a few examples to look at.