### PR TITLE
refactor: Un-nest CSS keyframes

### DIFF
--- a/src/components/code-editor/style.module.css
+++ b/src/components/code-editor/style.module.css
@@ -22,12 +22,12 @@
 		div {
 			padding: 0 12px;
 		}
+	}
+}
 
-		@keyframes intro {
-			from {
-				transform: scaleY(0.001);
-				opacity: 0;
-			}
-		}
+@keyframes intro {
+	from {
+		transform: scaleY(0.001);
+		opacity: 0;
 	}
 }

--- a/src/components/controllers/tutorial/style.module.css
+++ b/src/components/controllers/tutorial/style.module.css
@@ -124,12 +124,6 @@
 					margin-bottom: 0;
 				}
 			}
-			@keyframes yay {
-				from {
-					opacity: 0;
-					transform: scale(0.6);
-				}
-			}
 
 			.codeContainer {
 				background: #282c34;
@@ -210,12 +204,6 @@
 		&.showCode .codeWindow {
 			animation: slideFromRight 250ms ease forwards 1;
 		}
-		@keyframes slideFromRight {
-			0% {
-				transform: translateX(100%);
-				opacity: 0;
-			}
-		}
 
 		.codeWindow {
 			height: 100%;
@@ -224,13 +212,6 @@
 			position: relative;
 			transition: opacity 1s ease;
 			overflow: auto;
-
-			@keyframes slideUp {
-				from {
-					opacity: 0;
-					transform: translateY(50%);
-				}
-			}
 
 			.rerun {
 				position: absolute;
@@ -332,4 +313,25 @@
 
 .output {
 	height: 100%;
+}
+
+@keyframes yay {
+	from {
+		opacity: 0;
+		transform: scale(0.6);
+	}
+}
+
+@keyframes slideFromRight {
+	0% {
+		transform: translateX(100%);
+		opacity: 0;
+	}
+}
+
+@keyframes slideUp {
+	from {
+		opacity: 0;
+		transform: translateY(50%);
+	}
 }

--- a/src/components/header/style.module.css
+++ b/src/components/header/style.module.css
@@ -224,14 +224,6 @@
 			transform-origin: 50% 0;
 			z-index: 750;
 
-			@keyframes menuOpen {
-				from {
-					opacity: 0;
-					transform: translateX(-50%) perspective(1000px) translateX(0.5px)
-						rotateX(-45deg);
-				}
-			}
-
 			a,
 			button,
 			span {
@@ -295,13 +287,6 @@
 					background: #333;
 					transform: none;
 					animation: menuExpand 250ms ease forwards 1;
-
-					@keyframes menuExpand {
-						from {
-							opacity: 0;
-							transform: scaleY(0.0001);
-						}
-					}
 
 					a,
 					button,
@@ -445,12 +430,6 @@
 		animation: pop 200ms forwards cubic-bezier(0.15, 1.05, 0.54, 1.29) 1;
 	}
 
-	@keyframes pop {
-		to {
-			transform: scale(1);
-		}
-	}
-
 	.hb1,
 	.hb2,
 	.hb3 {
@@ -500,5 +479,26 @@
 		.open & {
 			display: none;
 		}
+	}
+}
+
+@keyframes menuOpen {
+	from {
+		opacity: 0;
+		transform: translateX(-50%) perspective(1000px) translateX(0.5px)
+			rotateX(-45deg);
+	}
+}
+
+@keyframes pop {
+	to {
+		transform: scale(1);
+	}
+}
+
+@keyframes menuExpand {
+	from {
+		opacity: 0;
+		transform: scaleY(0.0001);
 	}
 }


### PR DESCRIPTION
Not an active issue at the moment to my knowledge (Chrome, FF, and Safari all appear to work fine), but was playing around with `lightningcss` (it's worse for us right now, seems to always expand `:is()` despite our targets) and learned that `@keyframes` is not allowed to be nested per the spec.

Un-nesting them makes more sense (they're global-ish names, after all, what would nesting do?) and gets us back to adhering to the spec so I figure it's a change for the better.