### PR TITLE
refactor: Rewrite Refs doc

### DIFF
--- a/content/en/guide/v10/hooks.md
+++ b/content/en/guide/v10/hooks.md
@@ -290,30 +290,9 @@ function Foo() {
 render(<Foo />, document.getElementById("app"));
 ```
 
-```jsx
-// --repl
-import { render } from 'preact';
-import { useRef } from 'preact/hooks';
-// --repl-before
-function Counter() {
-	const count = useRef(0);
-
-	const onClick = () => {
-		count.current++;
-		console.log(count.current);
-	};
-
-	return (
-		<button onClick={onClick}>
-			Increment
-		</button>
-	);
-}
-// --repl-after
-render(<Counter />, document.getElementById('app'));
-```
-
 > Be careful not to confuse `useRef` with `createRef`.
+
+> See [Refs](/guide/v10/refs) for more information & examples.
 
 ## useContext
 

--- a/content/en/guide/v10/hooks.md
+++ b/content/en/guide/v10/hooks.md
@@ -267,7 +267,7 @@ const onClick = useCallback(
 
 ## useRef
 
-To get a reference to a DOM node inside a functional components there is the `useRef` hook. It works similar to [createRef](/guide/v10/refs#createref).
+To create a stable reference to a DOM node or a value that persists between renders, we can use the `useRef` hook. It works similarly to [createRef](/guide/v10/refs#createref).
 
 ```jsx
 // --repl
@@ -288,6 +288,29 @@ function Foo() {
 }
 // --repl-after
 render(<Foo />, document.getElementById("app"));
+```
+
+```jsx
+// --repl
+import { render } from 'preact';
+import { useRef } from 'preact/hooks';
+// --repl-before
+function Counter() {
+	const count = useRef(0);
+
+	const onClick = () => {
+		count.current++;
+		console.log(count.current);
+	};
+
+	return (
+		<button onClick={onClick}>
+			Increment
+		</button>
+	);
+}
+// --repl-after
+render(<Counter />, document.getElementById('app'));
 ```
 
 > Be careful not to confuse `useRef` with `createRef`.

--- a/content/en/guide/v10/refs.md
+++ b/content/en/guide/v10/refs.md
@@ -1,6 +1,6 @@
 ---
 name: References
-description: 'References are a way of creating stable values that are local to a component instance but exist outside of the normal component lifecycle.'
+description: 'Refs are a way of creating stable values that are local to a component instance and persist across renders.'
 ---
 
 # References

--- a/content/en/guide/v10/refs.md
+++ b/content/en/guide/v10/refs.md
@@ -1,13 +1,15 @@
 ---
 name: References
-description: 'References can be used to access raw DOM nodes that Preact has rendered'
+description: 'References are a way of creating stable values that are local to a component instance but exist outside of the normal component lifecycle.'
 ---
 
 # References
 
-There will always be scenarios where you need a direct reference to the DOM-Element or Component that was rendered by Preact. Refs allow you to do just that.
+References, or refs for short, are a way of creating and referencing stable values that are local to a component instance but exist outside of the normal component lifecycle.
 
-A typical use case for it is measuring the actual size of a DOM node. While it's possible to get the reference to the component instance via `ref` we don't generally recommend it. It will create a hard coupling between a parent and a child which breaks the composability of the component model. In most cases it's more natural to just pass the callback as a prop instead of trying to call the method of a class component directly.
+There are many scenarios in which you may need to save a value within a component but updating it should not trigger rerenders like state or props would. This is where refs come in.
+
+Most often you'll see refs used with DOM nodes to facilitate imperative manipulation of the DOM, but they can also be used to store stable, local values in a component. You may track a previous state value, or keep a reference to an interval or timeout ID. Importantly, refs should not be used for rendering, instead used in event handlers or side effects in most cases.
 
 ---
 
@@ -30,7 +32,7 @@ class Foo extends Component {
     console.log(this.ref.current);
     // Logs: [HTMLDivElement]
   }
-  
+
   render() {
     return <div ref={this.ref}>foo</div>
   }
@@ -38,6 +40,8 @@ class Foo extends Component {
 // --repl-after
 render(<Foo />, document.getElementById("app"));
 ```
+
+> For those using hooks, you'll want [useRef](/guide/v10/hooks#useref) instead, which works very similarly.
 
 ## Callback Refs
 
@@ -55,7 +59,7 @@ class Foo extends Component {
     console.log(this.ref);
     // Logs: [HTMLDivElement]
   }
-  
+
   render() {
     return <div ref={this.setRef}>foo</div>
   }

--- a/content/en/guide/v10/refs.md
+++ b/content/en/guide/v10/refs.md
@@ -19,8 +19,9 @@ Most often you'll see refs used to facilitate imperative manipulation of the DOM
 
 There are two ways to create refs in Preact, depending on your preferred component style: `createRef` (class components) and `useRef` (function components/hooks). Both APIs fundamentally work the same way: they create a stable, plain object with a `current` property, optionally initialized to a value.
 
+<tab-group tabString="Classes, Hooks">
+
 ```jsx
-// Class components
 import { createRef } from "preact";
 
 class MyComponent extends Component {
@@ -32,7 +33,6 @@ class MyComponent extends Component {
 ```
 
 ```jsx
-// Function components
 import { useRef } from "preact/hooks";
 
 function MyComponent() {
@@ -43,9 +43,13 @@ function MyComponent() {
 }
 ```
 
+</tab-group>
+
 ## Using Refs to Access DOM Nodes
 
 The most common use case for refs is to access the underlying DOM node of a component. This is useful for imperative DOM manipulation, such as measuring elements, calling native methods on various elements (such as `.focus()` or `.play()`), and integrating with third-party libraries written in vanilla JS. In the following examples, upon rendering, Preact will assign the DOM node to the `current` property of the ref object, making it available for use after the component has mounted.
+
+<tab-group tabString="Classes, Hooks">
 
 ```jsx
 // --repl
@@ -86,9 +90,14 @@ function MyInput() {
 render(<MyInput />, document.getElementById("app"));
 ```
 
+</tab-group>
+
 ### Callback Refs
 
 Another way to use references is by passing a function to the `ref` prop, where the DOM node will be passed as an argument.
+
+
+<tab-group tabString="Classes, Hooks">
 
 ```jsx
 // --repl
@@ -132,6 +141,8 @@ function MyInput() {
 render(<MyInput />, document.getElementById("app"));
 ```
 
+</tab-group>
+
 > If the provided ref callback is unstable (such as one that's defined inline, as shown above), and _does not_ return a cleanup function, **it will be called twice** upon all rerenders: once with `null` and then once with the actual reference. This is a common issue and the `createRef`/`useRef` APIs make this a little easier by forcing the user to check if `ref.current` is defined.
 >
 > A stable function, for comparison, could be a method on the class component instance, a function defined outside of the component, or a function created with `useCallback`, for example.
@@ -141,6 +152,8 @@ render(<MyInput />, document.getElementById("app"));
 Refs aren't limited to storing DOM nodes, however; they can be used to store any type of value that you may need.
 
 In the following example, we store the ID of an interval in a ref to be able to start & stop it independently.
+
+<tab-group tabString="Classes, Hooks">
 
 ```jsx
 // --repl
@@ -213,3 +226,5 @@ function SimpleClock() {
 // --repl-after
 render(<SimpleClock />, document.getElementById("app"));
 ```
+
+</tab-group>

--- a/content/en/guide/v10/refs.md
+++ b/content/en/guide/v10/refs.md
@@ -19,7 +19,7 @@ Most often you'll see refs used to facilitate imperative manipulation of the DOM
 
 There are two ways to create refs in Preact, depending on your preferred component style: `createRef` (class components) and `useRef` (function components/hooks). Both APIs fundamentally work the same way: they create a stable, plain object with a `current` property, optionally initialized to a value.
 
-<tab-group tabString="Classes, Hooks">
+<tab-group tabstring="Classes, Hooks">
 
 ```jsx
 import { createRef } from "preact";
@@ -49,7 +49,7 @@ function MyComponent() {
 
 The most common use case for refs is to access the underlying DOM node of a component. This is useful for imperative DOM manipulation, such as measuring elements, calling native methods on various elements (such as `.focus()` or `.play()`), and integrating with third-party libraries written in vanilla JS. In the following examples, upon rendering, Preact will assign the DOM node to the `current` property of the ref object, making it available for use after the component has mounted.
 
-<tab-group tabString="Classes, Hooks">
+<tab-group tabstring="Classes, Hooks">
 
 ```jsx
 // --repl
@@ -97,7 +97,7 @@ render(<MyInput />, document.getElementById("app"));
 Another way to use references is by passing a function to the `ref` prop, where the DOM node will be passed as an argument.
 
 
-<tab-group tabString="Classes, Hooks">
+<tab-group tabstring="Classes, Hooks">
 
 ```jsx
 // --repl
@@ -153,7 +153,7 @@ Refs aren't limited to storing DOM nodes, however; they can be used to store any
 
 In the following example, we store the ID of an interval in a ref to be able to start & stop it independently.
 
-<tab-group tabString="Classes, Hooks">
+<tab-group tabstring="Classes, Hooks">
 
 ```jsx
 // --repl

--- a/content/en/guide/v10/refs.md
+++ b/content/en/guide/v10/refs.md
@@ -5,11 +5,9 @@ description: 'References are a way of creating stable values that are local to a
 
 # References
 
-References, or refs for short, are a way of creating and referencing stable values that are local to a component instance but exist outside of the normal component lifecycle.
+References, or refs for short, are stable, local values that persist across component renders but don't trigger rerenders like state or props would when they change.
 
-There are many scenarios in which you may need to save a value within a component but updating it should not trigger rerenders like state or props would. This is where refs come in.
-
-Most often you'll see refs used with DOM nodes to facilitate imperative manipulation of the DOM, but they can also be used to store stable, local values in a component. You may track a previous state value, or keep a reference to an interval or timeout ID. Importantly, refs should not be used for rendering, instead used in event handlers or side effects in most cases.
+Most often you'll see refs used to facilitate imperative manipulation of the DOM but they can be used to store any arbitrary local value that you need to be kept stable. You may use them to track a previous state value, keep a reference to an interval or timeout ID, or simply a counter value. Importantly, refs should not be used for rendering logic, instead, consumed in lifecycle methods and event handlers only.
 
 ---
 
@@ -17,112 +15,201 @@ Most often you'll see refs used with DOM nodes to facilitate imperative manipula
 
 ---
 
-## createRef
+## Creating a Ref
 
-The `createRef` function will return a plain object with just one property: `current`. Whenever the `render` method is called, Preact will assign the DOM node or component to `current`.
+There are two ways to create refs in Preact, depending on your preferred component style: `createRef` (class components) and `useRef` (function components/hooks). Both APIs fundamentally work the same way: they create a stable, plain object with a `current` property, optionally initialized to a value.
+
+```jsx
+// Class components
+import { createRef } from "preact";
+
+class MyComponent extends Component {
+  countRef = createRef();
+  inputRef = createRef(null);
+
+  // ...
+}
+```
+
+```jsx
+// Function components
+import { useRef } from "preact/hooks";
+
+function MyComponent() {
+  const countRef = useRef();
+  const inputRef = useRef(null);
+
+  // ...
+}
+```
+
+## Using Refs to Access DOM Nodes
+
+The most common use case for refs is to access the underlying DOM node of a component. This is useful for imperative DOM manipulation, such as measuring elements, calling native methods on various elements (such as `.focus()` or `.play()`), and integrating with third-party libraries written in vanilla JS. In the following examples, upon rendering, Preact will assign the DOM node to the `current` property of the ref object, making it available for use after the component has mounted.
 
 ```jsx
 // --repl
 import { render, Component, createRef } from "preact";
 // --repl-before
-class Foo extends Component {
-  ref = createRef();
+class MyInput extends Component {
+  ref = createRef(null);
 
   componentDidMount() {
     console.log(this.ref.current);
-    // Logs: [HTMLDivElement]
+    // Logs: [HTMLInputElement]
   }
 
   render() {
-    return <div ref={this.ref}>foo</div>
+    return <input ref={this.ref} />;
   }
 }
 // --repl-after
-render(<Foo />, document.getElementById("app"));
+render(<MyInput />, document.getElementById("app"));
 ```
 
-> For those using hooks, you'll want [useRef](/guide/v10/hooks#useref) instead, which works very similarly.
+```jsx
+// --repl
+import { render } from "preact";
+import { useRef, useEffect } from "preact/hooks";
+// --repl-before
+function MyInput() {
+  const ref = useRef(null);
 
-## Callback Refs
+  useEffect(() => {
+    console.log(ref.current);
+    // Logs: [HTMLInputElement]
+  }, []);
 
-Another way to get the reference to an element can be done by passing a function callback. It's a little more to type, but it works in a similar fashion as `createRef`.
+  return <input ref={ref} />;
+}
+// --repl-after
+render(<MyInput />, document.getElementById("app"));
+```
+
+### Callback Refs
+
+Another way to use references is by passing a function to the `ref` prop, where the DOM node will be passed as an argument.
 
 ```jsx
 // --repl
 import { render, Component } from "preact";
 // --repl-before
-class Foo extends Component {
-  ref = null;
-  setRef = (dom) => this.ref = dom;
-
-  componentDidMount() {
-    console.log(this.ref);
-    // Logs: [HTMLDivElement]
-  }
-
+class MyInput extends Component {
   render() {
-    return <div ref={this.setRef}>foo</div>
-  }
-}
-// --repl-after
-render(<Foo />, document.getElementById("app"));
-```
-
-> If the ref callback is defined as an inline function it will be called twice. Once with `null` and then with the actual reference. This is a common error and the `createRef` API makes this a little easier by forcing user to check if `ref.current` is defined.
-
-## Putting it all together
-
-Let's say we have a scenario where we need to get the reference to a DOM node to measure its width and height. We have a simple component where we need to replace the placeholder values with the actual measured ones.
-
-```jsx
-class Foo extends Component {
-  // We want to use the real width from the DOM node here
-  state = {
-    width: 0,
-    height: 0,
-  };
-
-  render(_, { width, height }) {
-    return <div>Width: {width}, Height: {height}</div>;
-  }
-}
-```
-
-Measurement only makes sense once the `render` method has been called and the component is mounted into the DOM. Before that the DOM node won't exist and there wouldn't make much sense to try to measure it.
-
-```jsx
-// --repl
-import { render, Component } from "preact";
-// --repl-before
-class Foo extends Component {
-  state = {
-    width: 0,
-    height: 0,
-  };
-
-  ref = createRef();
-
-  componentDidMount() {
-    // For safety: Check if a ref was supplied
-    if (this.ref.current) {
-      const dimensions = this.ref.current.getBoundingClientRect();
-      this.setState({
-        width: dimensions.width,
-        height: dimensions.height,
-      });
-    }
-  }
-
-  render(_, { width, height }) {
     return (
-      <div ref={this.ref}>
-        Width: {width}, Height: {height}
+      <input ref={(dom) => {
+        console.log('Mounted:', dom);
+
+        // As of Preact 10.23.0, you can optionally return a cleanup function
+        return () => {
+          console.log('Unmounted:', dom);
+        };
+      }} />
+    );
+  }
+}
+// --repl-after
+render(<MyInput />, document.getElementById("app"));
+```
+
+```jsx
+// --repl
+import { render } from "preact";
+// --repl-before
+function MyInput() {
+  return (
+    <input ref={(dom) => {
+      console.log('Mounted:', dom);
+
+      // As of Preact 10.23.0, you can optionally return a cleanup function
+      return () => {
+        console.log('Unmounted:', dom);
+      };
+    }} />
+  );
+}
+// --repl-after
+render(<MyInput />, document.getElementById("app"));
+```
+
+> If the provided ref callback is unstable (such as one that's defined inline, as shown above), and _does not_ return a cleanup function, **it will be called twice** upon all rerenders: once with `null` and then once with the actual reference. This is a common issue and the `createRef`/`useRef` APIs make this a little easier by forcing the user to check if `ref.current` is defined.
+>
+> A stable function, for comparison, could be a method on the class component instance, a function defined outside of the component, or a function created with `useCallback`, for example.
+
+## Using Refs to Store Local Values
+
+Refs aren't limited to storing DOM nodes, however; they can be used to store any type of value that you may need.
+
+In the following example, we store the ID of an interval in a ref to be able to start & stop it independently.
+
+```jsx
+// --repl
+import { render, Component, createRef } from "preact";
+// --repl-before
+class SimpleClock extends Component {
+  state = {
+    time: Date.now(),
+  };
+  intervalId = createRef(null);
+
+  startClock = () => {
+    this.setState({ time: Date.now() });
+    this.intervalId.current = setInterval(() => {
+      this.setState({ time: Date.now() });
+    }, 1000);
+  };
+
+  stopClock = () => {
+    clearInterval(this.intervalId.current);
+  };
+
+
+  render(_, { time }) {
+    const formattedTime = new Date(time).toLocaleTimeString();
+
+    return (
+      <div>
+        <button onClick={this.startClock}>Start Clock</button>
+        <time dateTime={formattedTime}>{formattedTime}</time>
+        <button onClick={this.stopClock}>Stop Clock</button>
       </div>
     );
   }
 }
 // --repl-after
-render(<Foo />, document.getElementById("app"));
+render(<SimpleClock />, document.getElementById("app"));
 ```
 
-That's it! Now the component will always display the width and height when it's mounted.
+```jsx
+// --repl
+import { render } from "preact";
+import { useState, useRef } from "preact/hooks";
+// --repl-before
+function SimpleClock() {
+  const [time, setTime] = useState(Date.now());
+  const intervalId = useRef(null);
+
+  const startClock = () => {
+    setTime(Date.now());
+    intervalId.current = setInterval(() => {
+      setTime(Date.now());
+    }, 1000);
+  };
+
+  const stopClock = () => {
+    clearInterval(intervalId.current);
+  };
+
+  const formattedTime = new Date(time).toLocaleTimeString();
+
+  return (
+    <div>
+      <button onClick={startClock}>Start Clock</button>
+      <time dateTime={formattedTime}>{formattedTime}</time>
+      <button onClick={stopClock}>Stop Clock</button>
+    </div>
+  );
+}
+// --repl-after
+render(<SimpleClock />, document.getElementById("app"));
+```

--- a/src/components/tab-group/index.jsx
+++ b/src/components/tab-group/index.jsx
@@ -1,0 +1,72 @@
+import { useState, useId } from 'preact/hooks';
+
+import style from './style.module.css';
+
+/**
+ * Used in markdown files to switch between different API styles, i.e,
+ * Class Components and Hooks. This displays either-or, not both at once,
+ * so it's not necessarily meant for directly comparing API styles.
+ *
+ * @param {Object} props
+ * @param {string} props.tabstring - Comma-separated list of tab names
+ * @param {Array<import('preact').Component | string>} props.children - Array of JSX elements
+ */
+export default function TabGroup({ tabstring, children }) {
+	const [activeTab, setActiveTab] = useState(0);
+	const id = useId();
+
+	// Removes the empty strings caused by newlines in our HTML in markdown
+	children = children.filter(s => typeof s !== 'string' || s.trim() !== '');
+	const tabs = tabstring.split(',').map(s => s.trim());
+
+	// Adapted from MDN tabs example:
+	// https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role#example
+	const onKeyDown = (e) => {
+		const tabContainer = e.currentTarget;
+		let focusedTabIndex = activeTab;
+
+		if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+			if (e.key == 'ArrowRight') {
+				focusedTabIndex++;
+				if (focusedTabIndex >= tabs.length) focusedTabIndex = 0;
+			} else if (e.key == 'ArrowLeft') {
+				focusedTabIndex--;
+				if (focusedTabIndex < 0) focusedTabIndex = tabs.length - 1;
+			}
+
+			setActiveTab(focusedTabIndex);
+			tabContainer.children[focusedTabIndex].focus();
+		}
+	};
+
+	return (
+		<div>
+			<div class={style.tabs} role="tablist" aria-label="API Styles" aria-orientation="horizontal" onKeyDown={onKeyDown}>
+				{tabs.map((tab, i) => (
+					<button
+						class={style.tab}
+						onClick={() => setActiveTab(i)}
+						role="tab"
+						id={`tab-${id}-${tabs[i]}`}
+						aria-controls={`panel-${id}-${tabs[i]}`}
+						aria-selected={activeTab == i ? 'true' : 'false'}
+						tabIndex={activeTab == i ? 0 : -1}
+					>
+						{tab}
+					</button>
+				))}
+			</div>
+			{children.map((child, i) => (
+				<div
+					role="tabpanel"
+					id={`panel-${id}-${tabs[i]}`}
+					aria-labelledby={`tab-${id}-${tabs[i]}`}
+					tabIndex={0}
+					hidden={activeTab != i}
+				>
+					{child}
+				</div>
+			))}
+		</div>
+	);
+}

--- a/src/components/tab-group/index.jsx
+++ b/src/components/tab-group/index.jsx
@@ -18,7 +18,7 @@ export default function TabGroup({ tabstring, children }) {
 	const [activeTab, setActiveTab] = useState(0);
 	const id = useId();
 
-	// Removes the empty strings caused by newlines in our HTML in markdown
+	// Filters the empty lines around our codeblocks in the markdown docs
 	children = children.filter(s => typeof s !== 'string' || s.trim() !== '');
 	const tabs = tabstring.split(',').map(s => s.trim());
 

--- a/src/components/tab-group/index.jsx
+++ b/src/components/tab-group/index.jsx
@@ -7,6 +7,9 @@ import style from './style.module.css';
  * Class Components and Hooks. This displays either-or, not both at once,
  * so it's not necessarily meant for directly comparing API styles.
  *
+ * Primarily adopted from MDN's tabs example:
+ * https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role#example
+ *
  * @param {Object} props
  * @param {string} props.tabstring - Comma-separated list of tab names
  * @param {Array<import('preact').Component | string>} props.children - Array of JSX elements
@@ -19,8 +22,6 @@ export default function TabGroup({ tabstring, children }) {
 	children = children.filter(s => typeof s !== 'string' || s.trim() !== '');
 	const tabs = tabstring.split(',').map(s => s.trim());
 
-	// Adapted from MDN tabs example:
-	// https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role#example
 	const onKeyDown = (e) => {
 		const tabContainer = e.currentTarget;
 		let focusedTabIndex = activeTab;

--- a/src/components/tab-group/style.module.css
+++ b/src/components/tab-group/style.module.css
@@ -1,0 +1,23 @@
+.tabs {
+	display: flex;
+
+	.tab {
+		cursor: pointer;
+		padding: .2rem .4rem;
+		font-weight: 700;
+		font-size: 1.2rem;
+		display: inline-flex;
+		background-color: transparent;
+		border: none;
+		border-bottom: 2px solid transparent;
+		border-radius: 5px;
+
+		&[aria-selected='true'] {
+			border-bottom: 2px solid var(--color-brand);
+		}
+
+		&:hover {
+			background-color: rgba(255, 255, 255, 0.05);
+		}
+	}
+}

--- a/src/components/tab-group/style.module.css
+++ b/src/components/tab-group/style.module.css
@@ -5,7 +5,7 @@
 		cursor: pointer;
 		padding: .2rem .4rem;
 		font-weight: 700;
-		font-size: 1.2rem;
+		font-size: 1rem;
 		display: inline-flex;
 		background-color: transparent;
 		border: none;

--- a/src/components/widgets.js
+++ b/src/components/widgets.js
@@ -7,6 +7,7 @@ import BlogOverview from './blog-overview';
 import Sponsors from './sponsors';
 import WeAreUsing from './we-are-using';
 import Branding from './branding';
+import TabGroup from './tab-group';
 
 export default {
 	Toc,
@@ -17,5 +18,6 @@ export default {
 	Sponsors,
 	Logo,
 	WeAreUsing,
-	Branding
+	Branding,
+	TabGroup
 };


### PR DESCRIPTION
I've found the refs doc rather lacking for a while, hope this is an improvement. Notably, it adds hooks examples, mentions values other than DOM nodes, and mentions the new cleanup functions added in 10.23.

Should address #1001 too, I expanded the warning for the callback refs section to (hopefully) clarify that a bit better.

Edit: Will try to do something similar to the Context doc, either during more gaps in holiday celebrations or in the next couple of weeks.