### PR TITLE
fix: Table of Contents with subsequent headers

### DIFF
--- a/content/en/guide/v10/context.md
+++ b/content/en/guide/v10/context.md
@@ -19,8 +19,6 @@ There are two ways to use context in Preact: via the newer `createContext` API a
 
 ## Modern Context API
 
-<!-- Load bearing comment, else marked eats the following heading -->
-
 ### Creating a Context
 
 To create a new context, we use the `createContext` function. This function takes an initial state as an argument and returns an object with two component properties: `Provider`, to make the context available to descendants, and `Consumer`, to access the context value (primarily in class components).

--- a/plugins/precompile-markdown/index.js
+++ b/plugins/precompile-markdown/index.js
@@ -150,7 +150,7 @@ function applyEmoji(content) {
 
 /* generate ToC from markdown */
 function generateToc(markdown) {
-	const MARKDOWN_TITLE = /(?:^|\n\n)\s*(#{1,6})\s+(.+)\n+/g;
+	const MARKDOWN_TITLE = /(?:^|\n\n)\s*(#{1,6})\s+(.+)/g;
 
 	const toc = [];
 	let token;


### PR DESCRIPTION
Tracked down the issue w/ that load-bearing comment: that trailing `\n+` gobbles up all blank lines, not allowing the subsequent title to be detected (as we're not using the multiline flag). `marked` also removes extraneous newlines (as it should, IMO) so just inserting extra blank lines wouldn't help (it'd be super fiddly & error prone to rely on anyhow).

This can also be seen on the Hooks page, `useId` doesn't show up in the ToC at all.