### PR TITLE
fix: docsearch

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -16,9 +16,9 @@
 	},
 	"repo": "preact",
 	"docsearch": {
-		"apiKey": "2a2ff54c5bfa1eea173cdfbe8a0bcace",
+		"apiKey": "842e1531d4af13c18b4718c456e386b2",
 		"indexName": "preact",
-		"appId": "BH4D9OD16A"
+		"appId": "AEYPSKMUO3"
 	},
 	"i18n": {
 		"next": {


### PR DESCRIPTION
Not quite sure what has been going on here but we've not been getting updated search entries for 2+ years now (so no mention of signals, for example, will come up).

They key was always the same, only changing appId last year as we bumped versions... still not quite sure how we could have working results, but outdated, as it was pointing at the correct application. Swapping in my (newly granted) key & appId seems to get search back on track though which I'm pretty pleased to see working again.