### PR TITLE
docs: Add explicit mention of `className` in content for Algolia

### DIFF
--- a/content/en/guide/v10/differences-to-react.md
+++ b/content/en/guide/v10/differences-to-react.md
@@ -95,7 +95,7 @@ Preact aims to closely match the DOM specification supported by all major browse
 <div className="foo" />
 ```
 
-Most Preact developers prefer to use `class` because it's shorter to write, but both are supported.
+Most Preact developers prefer to use `class` instead of `className` as it's shorter to write but both are supported.
 
 ### SVG inside JSX
 


### PR DESCRIPTION
Another search term we're getting a lot of misses on is `className`. Algolia excludes code blocks from its indexing (which is very reasonable) and it turns out codeblocks are the only place we use this.

Adding an explicit mention of it here makes the most sense to me, I would guess that users are trying to check that `class` is the exact same as `className` in their components.