### PR TITLE
docs: Warn about using Preact in mixed CJS/ESM codebase without bundler

### DIFF
--- a/content/en/guide/v10/getting-started.md
+++ b/content/en/guide/v10/getting-started.md
@@ -169,6 +169,8 @@ be seen in NextJS. To fix this, we can use aliases directly in our `package.json
 }
 ```
 
+> **Warning**: Preact is not recommended for use in a mixed CJS/ESM codebase running directly in Node without a bundler, as there's a risk that Preact's singletons could be loaded twice. If your first-party code or any dependencies will try to load both the CJS and ESM versions of Preact, you must use a bundler to alias imports of Preact to always resolve to either the CJS or ESM versions.
+
 #### Aliasing in Parcel
 
 Parcel uses the standard `package.json` file to read configuration options under


### PR DESCRIPTION
I proposed this in https://github.com/preactjs/preact/issues/4648 but didn't hear back from a maintainer one way or another. I'm hoping to have a discussion about how to document this, as this was a really frustrating thing to discover independently.