### PR TITLE
fix: Sidebar going off screen on mobile

### DIFF
--- a/src/components/sidebar/style.module.css
+++ b/src/components/sidebar/style.module.css
@@ -66,7 +66,6 @@
 	right: 0;
 	top: 5.25rem;
 	z-index: 450;
-	height: 100%;
 	overflow-y: auto;
 	background: var(--color-sidebar-bg);
 


### PR DESCRIPTION
I noticed on mobile our sidebar goes off the screen a bit, making it a bit difficult to tap on the bottom few options. We have padding that's meant to accommodate for this but also a faulty `height` value set which causes issues. Easy fix though.

Both of these screenshots are scrolled as far down as possible, hence the issue:

Before             |  After
:-------------------------:|:-------------------------:
![before](https://github.com/user-attachments/assets/d281e9f3-5fed-4fed-8e87-4aa5167af3cf) | ![after](https://github.com/user-attachments/assets/e39bbb2d-f896-48e7-bf22-d2fc05105504)

