### PR TITLE
docs: Fix HTM example in 'No build workflows'

### DIFF
--- a/content/en/guide/v10/no-build-workflows.md
+++ b/content/en/guide/v10/no-build-workflows.md
@@ -149,6 +149,6 @@ function Counter() {
 		</div>
 	`;
 }
-// --repl-after
-render(<Counter />, document.getElementById('app'));
+
+render(html`<${Counter} />`, document.getElementById('app'));
 ```


### PR DESCRIPTION
It worked as it was, but this addresses two things:

1. Bit silly to use JSX within the render call for a `htm` example (oops)
2. Some users get a bit stuck with how to refer to components using `htm`, and whilst the example does show using components already (`<${Button}>`), I figure an additional sample is good as it can be easy to miss in the component return. As such, I removed the `// --repl-after` comment so that it shows up in the code block on the docs page.