### PR TITLE
fix: Anchor transparency when tabbing

### DIFF
--- a/src/components/footer/style.module.css
+++ b/src/components/footer/style.module.css
@@ -25,12 +25,8 @@
 
 		&:hover,
 		&:focus {
-			text-decoration-color: currentColor;
-		}
-
-		&:hover,
-		&:focus {
 			color: var(--color-link-hover);
+			text-decoration-color: currentColor;
 		}
 	}
 }

--- a/src/style/markdown.css
+++ b/src/style/markdown.css
@@ -419,6 +419,10 @@
 				svg {
 					display: block;
 				}
+
+				&:focus {
+					opacity: 1;
+				}
 			}
 
 			&:hover {

--- a/src/style/markdown.css
+++ b/src/style/markdown.css
@@ -29,17 +29,6 @@
 		}
 	}
 
-	a.anchor {
-		display: block;
-		padding-left: 30px;
-		margin-left: -30px;
-		cursor: pointer;
-		position: absolute;
-		top: 0;
-		left: 0;
-		bottom: 0;
-	}
-
 	h1,
 	h2,
 	h3,

--- a/src/style/markdown.css
+++ b/src/style/markdown.css
@@ -24,12 +24,8 @@
 
 		&:hover,
 		&:focus {
-			text-decoration-color: currentColor;
-		}
-
-		&:hover,
-		&:focus {
 			color: var(--color-link-hover);
+			text-decoration-color: currentColor;
 		}
 	}
 
@@ -55,10 +51,6 @@
 		font-weight: bold;
 		cursor: text;
 		position: relative;
-
-		&:hover a.anchor {
-			text-decoration: none;
-		}
 	}
 
 	h1,


### PR DESCRIPTION
When tabbing through a doc page, the anchor icons stay hidden as their opacity is only triggered on hover for the header. We should also increase the opacity on focus.

Also cleans up a couple tiny other issues I noticed