### PR TITLE
fix: Bump preset-vite to dismiss repl sourcemap warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@codemirror/state": "^6.4.1",
         "@codemirror/view": "^6.28.1",
         "@docsearch/react": "^3.6.0",
-        "@preact/preset-vite": "^2.9.3",
+        "@preact/preset-vite": "^2.10.1",
         "@preact/signals": "^1.1.3",
         "@preact/signals-core": "^1.2.3",
         "@rollup/browser": "^3.18.0",
@@ -1393,9 +1393,10 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.21",
@@ -1531,12 +1532,11 @@
       }
     },
     "node_modules/@preact/preset-vite": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@preact/preset-vite/-/preset-vite-2.9.3.tgz",
-      "integrity": "sha512-uVDSKsFnPa/bmRTAcPiYpTvC04T1lhIH2ho3CJZLYibwcwliElS/i64iyATZkgR4DJxSc/JwOCSQS4IF/a03OQ==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@preact/preset-vite/-/preset-vite-2.10.1.tgz",
+      "integrity": "sha512-59lyGBXNfZIr5OOuBUB4/IB8AqF/ULbvYnyItgK/2BJnsGJqaeaJobRVtMp1129obHQuj8oZ/dVxB9inmH8Xig==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.22.13",
         "@babel/plugin-transform-react-jsx": "^7.22.15",
         "@babel/plugin-transform-react-jsx-development": "^7.22.5",
         "@prefresh/vite": "^2.4.1",
@@ -1544,10 +1544,7 @@
         "babel-plugin-transform-hook-names": "^1.0.2",
         "debug": "^4.3.4",
         "kolorist": "^1.8.0",
-        "magic-string": "0.30.5",
-        "node-html-parser": "^6.1.10",
-        "source-map": "^0.7.4",
-        "stack-trace": "^1.0.0-pre2"
+        "vite-prerender-plugin": "^0.5.3"
       },
       "peerDependencies": {
         "@babel/core": "7.x",
@@ -1582,29 +1579,10 @@
         }
       }
     },
-    "node_modules/@preact/preset-vite/node_modules/magic-string": {
-      "version": "0.30.5",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
-      "integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.15"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@preact/preset-vite/node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
-    "node_modules/@preact/preset-vite/node_modules/source-map": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
-      "engines": {
-        "node": ">= 8"
-      }
     },
     "node_modules/@preact/signals": {
       "version": "1.1.3",
@@ -5934,6 +5912,15 @@
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
     },
+    "node_modules/simple-code-frame": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/simple-code-frame/-/simple-code-frame-1.3.0.tgz",
+      "integrity": "sha512-MB4pQmETUBlNs62BBeRjIFGeuy/x6gGKh7+eRUemn1rCFhqo7K+4slPqsyizCbcbYLnaYqaoZ2FWsZ/jN06D8w==",
+      "license": "MIT",
+      "dependencies": {
+        "kolorist": "^1.6.0"
+      }
+    },
     "node_modules/slice-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
@@ -5960,6 +5947,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5981,13 +5977,14 @@
       }
     },
     "node_modules/source-map-support/node_modules/source-map": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
       "optional": true,
       "peer": true,
       "engines": {
-        "node": ">= 8"
+        "node": ">=0.10.0"
       }
     },
     "node_modules/sourcemap-codec": {
@@ -6005,6 +6002,7 @@
       "version": "1.0.0-pre2",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-1.0.0-pre2.tgz",
       "integrity": "sha512-2ztBJRek8IVofG9DBJqdy2N5kulaacX30Nz7xmkYF6ale9WBVmIy6mFBchvGX7Vx/MyjBhx+Rcxqrj+dbOnQ6A==",
+      "license": "MIT",
       "engines": {
         "node": ">=16"
       }
@@ -6688,6 +6686,29 @@
       },
       "engines": {
         "node": ">=14.14"
+      }
+    },
+    "node_modules/vite-prerender-plugin": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/vite-prerender-plugin/-/vite-prerender-plugin-0.5.8.tgz",
+      "integrity": "sha512-XAED6mSH3kAW09/kQTN+jHTdDlM1cdKjVpB3ME1hGspExu5rRiqVRxSA+i1iembvuTnklb7urCykFYVJrtDlxg==",
+      "license": "MIT",
+      "dependencies": {
+        "kolorist": "^1.8.0",
+        "magic-string": "^0.30.6",
+        "node-html-parser": "^6.1.12",
+        "simple-code-frame": "^1.3.0",
+        "source-map": "^0.7.4",
+        "stack-trace": "^1.0.0-pre2"
+      }
+    },
+    "node_modules/vite-prerender-plugin/node_modules/magic-string": {
+      "version": "0.30.17",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
     "node_modules/vite/node_modules/rollup": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@codemirror/state": "^6.4.1",
     "@codemirror/view": "^6.28.1",
     "@docsearch/react": "^3.6.0",
-    "@preact/preset-vite": "^2.9.3",
+    "@preact/preset-vite": "^2.10.1",
     "@preact/signals": "^1.1.3",
     "@preact/signals-core": "^1.2.3",
     "@rollup/browser": "^3.18.0",


### PR DESCRIPTION
Upon loading the REPL in Firefox with sourcemaps enabled in their devtools, users will be met with the following warnings:

```
Source map error: request failed with status 404
Resource URL: https://preactjs.com/assets/repl.worker-BMYdljCC.js
Source Map URL: repl.worker-BMYdljCC.js.map
```

```
Source map error: Error: URL constructor:  is not a valid URL.
Stack in the worker:resolveSourceMapURL@resource://devtools/client/shared/source-map-loader/utils/fetchSourceMap.js:56:22
getOriginalURLs@resource://devtools/client/shared/source-map-loader/source-map.js:73:24
workerHandler/</<@resource://devtools/client/shared/worker-utils.js:115:52
workerHandler/<@resource://devtools/client/shared/worker-utils.js:113:13

Resource URL: null
Source Map URL: null
```

Second one is sorta nonsense, and I don't quite know why FF chooses to surface it, but they both stem from the sourcemap comment not being stripped from the REPL worker (and we don't provide source maps, hence the 404). Was a bug in the prerenderer of `@preact/preset-vite`; it only stripped from chunks, not assets, so the worker snuck past. 

That was fixed in https://github.com/preactjs/preset-vite/pull/149 & later carried over to `vite-prerender-plugin`.