### PR TITLE
fix: Prerender data

### DIFF
--- a/src/lib/prerender-data.jsx
+++ b/src/lib/prerender-data.jsx
@@ -10,7 +10,7 @@ import { useContext } from 'preact/hooks';
  */
 export function getFallbackData() {
 	if (typeof window === 'undefined') return {};
-	const el = document.getElementById('preact-prerender-data');
+	const el = document.getElementById('prerender-data');
 	if (!el) return {};
 	const data = JSON.parse(el.textContent);
 	return data;


### PR DESCRIPTION
Missed in #1260, sorry

`vite-prerender-plugin` uses a more generic ID as it's not necessarily tied to Preact. Data was still getting injected, but not found correctly, leading to a flash of the version number in the header