### PR TITLE
refactor: Wrap suspending pages w/ error boundaries, extract generic pages from doc pages

### DIFF
--- a/src/components/controllers/blog-page.jsx
+++ b/src/components/controllers/blog-page.jsx
@@ -1,4 +1,4 @@
-import { useRoute } from 'preact-iso';
+import { useRoute, ErrorBoundary } from 'preact-iso';
 import { useContent } from '../../lib/use-content';
 import { NotFound } from './not-found';
 import { MarkdownRegion } from './markdown-region';
@@ -7,14 +7,14 @@ import { blogRoutes } from '../../lib/route-utils';
 import style from './style.module.css';
 
 export default function BlogPage() {
-	const { params } = useRoute();
-	const { slug } = params;
+	const { slug } = useRoute().params;
+	const isValidRoute = blogRoutes[`/blog/${slug}`];
 
-	if (!blogRoutes[`/blog/${slug}`]) {
-		return <NotFound />;
-	}
-
-	return <BlogLayout />;
+	return (
+		<ErrorBoundary>
+			{isValidRoute ? <BlogLayout /> : <NotFound />}
+		</ErrorBoundary>
+	);
 }
 
 function BlogLayout() {

--- a/src/components/controllers/page.jsx
+++ b/src/components/controllers/page.jsx
@@ -1,14 +1,35 @@
-import { useRoute } from 'preact-iso';
+import { useRoute, ErrorBoundary } from 'preact-iso';
 import { navRoutes } from '../../lib/route-utils';
+import { useContent } from '../../lib/use-content';
 import { NotFound } from './not-found';
-import { DocLayout } from './doc-page';
+import { MarkdownRegion } from './markdown-region';
+import Footer from '../footer/index';
+import style from './style.module.css';
 
+// Supports generic pages like `/`, `/about/*`, `/blog`, etc.
 export function Page() {
 	const { path } = useRoute();
+	const isValidRoute = navRoutes[path];
 
-	if (!navRoutes[path]) {
-		return <NotFound />;
-	}
+	return (
+		<ErrorBoundary>
+			{isValidRoute ? <PageLayout /> : <NotFound />}
+		</ErrorBoundary>
+	);
+}
 
-	return <DocLayout />;
+export function PageLayout() {
+	const { path } = useRoute();
+	const { html, meta } = useContent(path === '/' ? 'index' : path);
+
+	return (
+		<div class={style.page}>
+			<div class={style.outer}>
+				<div class={style.inner}>
+					<MarkdownRegion html={html} meta={meta} />
+					<Footer />
+				</div>
+			</div>
+		</div>
+	);
 }

--- a/src/components/controllers/repl-page.jsx
+++ b/src/components/controllers/repl-page.jsx
@@ -1,4 +1,4 @@
-import { useLocation, useRoute } from 'preact-iso';
+import { useLocation, useRoute, ErrorBoundary } from 'preact-iso';
 import { Repl } from './repl';
 import { base64ToText } from './repl/query-encode.js';
 import { fetchExample } from './repl/examples';
@@ -22,7 +22,9 @@ export default function ReplPage() {
 					overflow: hidden !important;
 				}
 			`}</style>
-			<Repl code={code} />
+			<ErrorBoundary>
+				<Repl code={code} />
+			</ErrorBoundary>
 		</div>
 	);
 }

--- a/src/components/controllers/tutorial-page.jsx
+++ b/src/components/controllers/tutorial-page.jsx
@@ -1,4 +1,4 @@
-import { useRoute } from 'preact-iso';
+import { useRoute, ErrorBoundary } from 'preact-iso';
 import { useEffect } from 'preact/hooks';
 import { Tutorial } from './tutorial';
 import { SolutionProvider } from './tutorial/contexts';
@@ -9,14 +9,14 @@ import { tutorialRoutes } from '../../lib/route-utils';
 import style from './tutorial/style.module.css';
 
 export default function TutorialPage() {
-	const { params } = useRoute();
-	const { step } = params;
+	const { step } = useRoute().params;
+	const isValidRoute = tutorialRoutes[`/tutorial${step ? `/${step}` : ''}`];
 
-	if (!tutorialRoutes[`/tutorial${step ? `/${step}` : ''}`]) {
-		return <NotFound />;
-	}
-
-	return <TutorialLayout />;
+	return (
+		<ErrorBoundary>
+			{isValidRoute ? <TutorialLayout /> : <NotFound />}
+		</ErrorBoundary>
+	);
 }
 
 function TutorialLayout() {

--- a/src/components/routes.jsx
+++ b/src/components/routes.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'preact/hooks';
 import { Router, Route, lazy } from 'preact-iso';
 import { Page } from './controllers/page';
-import { DocPage } from './controllers/doc-page';
+import { GuidePage } from './controllers/guide-page';
 import { NotFound } from './controllers/not-found';
 import { navRoutes } from '../lib/route-utils';
 
@@ -9,8 +9,20 @@ export const ReplPage = lazy(() => import('./controllers/repl-page'));
 export const BlogPage = lazy(() => import('./controllers/blog-page'));
 export const TutorialPage = lazy(() => import('./controllers/tutorial-page'));
 
-// @ts-ignore
-const routeChange = url => typeof ga === 'function' && ga('send', 'pageview', url);
+const routeChange = url =>
+	// @ts-ignore
+	typeof ga === 'function' && ga('send', 'pageview', url);
+
+const genericRoutes = Object.keys(navRoutes)
+	.filter(
+		route =>
+			!route.startsWith('/guide') &&
+			!route.startsWith('/tutorial') &&
+			!route.startsWith('/repl')
+	)
+	.map(route => (
+		<Route key={route} path={route} component={Page} />
+	));
 
 export default function Routes() {
 	const [loading, setLoading] = useState(false);
@@ -22,16 +34,11 @@ export default function Routes() {
 				onLoadEnd={() => setLoading(false)}
 				onRouteChange={routeChange}
 			>
-				{Object.keys(navRoutes)
-					.filter(route => !route.startsWith('/guide'))
-					.filter(route => !route.startsWith('/tutorial'))
-					.map(route => {
-						const component = route === '/repl' ? ReplPage : Page;
-						return <Route key={route} path={route} component={component} />;
-					})}
+				{genericRoutes}
 				<Route path="/tutorial/:step?" component={TutorialPage} />
-				<Route path="/guide/:version/:name" component={DocPage} />
+				<Route path="/guide/:version/:name" component={GuidePage} />
 				<Route path="/blog/:slug" component={BlogPage} />
+				<Route path="/repl" component={ReplPage} />
 				<Route default component={NotFound} />
 			</Router>
 		</main>


### PR DESCRIPTION
Makes three changes:

- Wraps all routes w/ suspense data fetching in `<ErrorBoundary>`
  - Shouldn't really be an issue either way, the intermediaries are quite thin so rerendering them shouldn't be a problem, but a healthy sprinkle of boundaries cuts down on renders all the same
- Extracts common/generic pages from doc/guide pages
  - Generic pages like `/`, `/about/*`, `/blog`, etc. flowed through `DocPage`, leading to it having to distinguish guide from non-guide pages for the sidebar and the couple of doc warnings we have. Better to extract that out, easier to follow & understand.
- Extracts the 'Generic Routes' from being formed in-line in the `<Router>`
  - Completely static, no reason to ever recalculate that