### PR TITLE
fix: Initializing user language

### DIFF
--- a/src/lib/i18n.jsx
+++ b/src/lib/i18n.jsx
@@ -43,9 +43,10 @@ export function LanguageProvider({ children }) {
 	useEffect(() => {
 		const localStorageLang = localStorageGet('lang');
 		const navigatorLang = getNavigatorLanguage(config.languages);
+		const userLang = query.lang || localStorageLang || navigatorLang || 'en';
 
-		setLang(query.lang || localStorageLang || navigatorLang || 'en');
-		document.documentElement.lang = lang;
+		setLang(userLang);
+		document.documentElement.lang = userLang;
 	}, []);
 
 	const setAndUpdateHtmlAttr = (lang) => {


### PR DESCRIPTION
Was using the default/previous render's `lang` instead of the newly derived value to set on the document element.

As such, `/?lang=es` (for example) wouldn't update the `lang` attribute on the root `<html>`