### PR TITLE
chore: Add preconnect link tag for google analytics

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
 		<meta property="og:image" content="https://preactjs.com/app-icon.png">
 		<meta name="twitter:card" content="summary">
 		<link href="https://esm.sh" rel="preconnect" crossorigin="anonymous">
+		<link href="https://www.google-analytics.com" rel="preconnect" crossorigin="anonymous">
 	</head>
 	<body class="banner">
 		<div id="app"></div>


### PR DESCRIPTION
For the few people not using an ad blocker as well as various perf tools.