### PR TITLE
fix: Disable touch actions when interacting w/ splitter component

### DIFF
--- a/src/components/splitter/splitter.module.css
+++ b/src/components/splitter/splitter.module.css
@@ -15,6 +15,7 @@
 	flex-direction: row;
 
 	& > .splitter {
+		touch-action: none;
 		cursor: col-resize;
 		left: var(--size, 50%);
 		top: 0;
@@ -40,6 +41,7 @@
 	flex-direction: column;
 
 	& > .splitter {
+		touch-action: none;
 		cursor: row-resize;
 		left: 0;
 		right: 0;


### PR DESCRIPTION
Interacting with the splitter component in the REPL/tutorial on mobile can be a bit fiddly at the moment as the page can scroll whilst the user is interacting with it. I'm over exaggerating it here but this video is a decent demonstration:

https://github.com/user-attachments/assets/1ae0545a-ec00-4c6a-a487-0bc341166681

Easy fix however, just need to set `touch-action` to `none` to disable standard pan/zoom touch interactions whilst the user is interacting with the splitter.