### PR TITLE
refactor: Rotate REPL to fit better on smaller screens (mobile)

### DIFF
--- a/src/components/controllers/repl/index.jsx
+++ b/src/components/controllers/repl/index.jsx
@@ -110,7 +110,7 @@ export function Repl({ code }) {
 			<div class={style.replWrapper}>
 				<ErrorBoundary>
 					<Splitter
-						orientation="horizontal"
+						orientation="auto"
 						other={
 							<div class={style.output}>
 								{error && (


### PR DESCRIPTION
The two vertical panes of the REPL makes it a bit tricky to use on mobile as the editor is only wide enough to display 15-20 characters at standard zoom (experience may vary a bit).

This PR adds a "auto" layout to the splitter, allowing it to determine the orientation depending on the screen size. Rather arbitrarily I've decided on 600px to be the cutoff point, anything less than that and the width is pretty punishing. As such, the REPL will now show as two stacked panes or two side-by-side panes depending on the width of the user's device which I think is a nice little improvement.

I've added a ResizeObserver too; not sure it's really needed, but saves from having to reload the page if the user does rotate orientation whilst the REPL is open. I figure it wouldn't be an unwelcome addition.

Before             |  After
:-------------------------:|:-------------------------:
![Before, two vertical panes with the editor taking up the left-hand 50% of the screen width and the REPL runner taking up the right 50% width](https://github.com/user-attachments/assets/6868337a-7f0a-451d-99ee-a5c36a3bcb96) | ![After, orientation flips to vertical so the editor is on top taking up 50% of the height and the runner taking up the bottom 50% of the screen height](https://github.com/user-attachments/assets/8e25b396-5f58-4f36-8734-1194bc973d3a)

---

Note: If you open your devtools to play with the screen width for testing this, you might notice that the header is a little broken at a couple points. We've added a few more links over the years and unfortunately now there's 2-3 different points in which content will wrap from the header and onto the page; I'm trying to fix it but it's quite challenging as we have a few different layers of wrappers and breakpoints which don't align very well. Might need some smarter CSS or a larger refactor of our header, TBD. Completely unrelated to this PR but wanted to mention it as it'll probably be noticed & raise an eyebrow if anyone tests this via browser devtools.