### PR TITLE
chore: Address some 404's

### DIFF
--- a/src/assets/.well-known/traffic-advice
+++ b/src/assets/.well-known/traffic-advice
@@ -1,0 +1,4 @@
+[{
+  "user_agent": "prefetch-proxy",
+  "fraction": 1.0
+}]

--- a/src/assets/_headers
+++ b/src/assets/_headers
@@ -14,3 +14,6 @@
     Link:""
 /*.atom
     Link:""
+/.well-known/traffic-advice
+    Link:""
+    Content-Type: application/trafficadvice+json

--- a/src/assets/_redirects
+++ b/src/assets/_redirects
@@ -9,5 +9,4 @@
 /guide/extending-component /guide/v8/extending-component
 /guide/unit-testing-with-enzyme /guide/v10/unit-testing-with-enzyme
 /guide/progressive-web-apps /guide/v8/progressive-web-apps
-/content/* /content/*
 /* /404/index.html 404

--- a/vite.config.js
+++ b/vite.config.js
@@ -53,6 +53,24 @@ export default defineConfig({
 				reloadPageOnChange: true
 			}
 		}),
+		viteStaticCopy({
+			// Safari will always request both `apple-touch-icon.png` and
+			// `apple-touch-icon-precomposed.png` regardless of any set path via `<link>`
+			// tags. The latter serves no purpose since iOS 7.0, but as Safari still
+			// requests it, we may as well provide it to get this out of our 404 stats.
+			targets: [
+				{
+					src: './src/assets/app-icon.png',
+					dest: './',
+					rename: 'apple-touch-icon.png'
+				},
+				{
+					src: './src/assets/app-icon.png',
+					dest: './',
+					rename: 'apple-touch-icon-precomposed.png'
+				}
+			]
+		}),
 		netlifyPlugin(),
 		spaFallbackMiddlewarePlugin(),
 		htmlRoutingMiddlewarePlugin(),


### PR DESCRIPTION
This PR tries to address some of the 404's we're seeing, fixing them where appropriate (see below for the Netlify stats). None of these should be impacting users though.

- `/content/*`

Not necessarily a problem, but caused by the `/content/*` -> `/content/*` redirect we have (created in #371). Not quite sure about the original purpose, something to do with Netlify's serving of markdown, but we don't serve markdown anymore and this kinda screws with the stats.

Every missing translation gets redirected to `/content/*` which itself just 404s as it's a nonsense URL. We have existing fallback methods to handle this though, both for content fetching & routing, so we can just remove the redirect. As such, all of those requests will still 404 as they're legitimate requests for translations we just don't have, but we'll be able to see which precise resources are 404'ing which can be useful.

It's also a bit weird to see `/content/*` requested in the devtools, as FF (and probably Chrome?) show the redirected URL instead of the original request URL. Not a problem, but kinda weird when you come across it.

- `/apple-touch-icon.png` & `/apple-touch-icon-precomposed.png`

Safari (at least on iOS) will always request both of these when opening the share menu on any site, regardless of paths set by any `<link>` tags (if they even exist). `-precomposed` is entirely legacy these days, not used since iOS 7.0, but Safari has yet to remove it from the auto-fetch unfortunately. I figure adding it is fine to clean up the stats a tad.

Now that we're not a PWA the lack of an icon wouldn't matter too much but it's a nice-to-have for the few people who might have it added to their homescreens.

- `/.well-known/traffic-advice`

Part of the new "Private prefetch proxy" in Chrome, see: https://developer.chrome.com/blog/private-prefetch-proxy

I've set it to `1.0`, which allows 100% of the prefetch requests as that seems pretty reasonable & not problematic given our static hosting. Has to be served with the `application/trafficadvice+json` MIME, hence the addition to our `_headers`. See the [Traffic Control section](https://developer.chrome.com/blog/private-prefetch-proxy/#traffic)

---

![List of paths that Netlify states are 404'ing](https://github.com/user-attachments/assets/827625f0-355d-4e14-b330-8b1d9a088fc7)