### PR TITLE
docs[translate] translate zh docs from en version in turorial

### DIFF
--- a/content/zh/tutorial/01-vdom.md
+++ b/content/zh/tutorial/01-vdom.md
@@ -169,25 +169,29 @@ useResult(function(result) {
 
 
 ```jsx:repl-initial
-import { createElement } from 'preact';
+import { createElement, render } from 'preact';
 
-export default function App() {
+function App() {
   return (
     <p class="big">Hello World!</p>
-  )
+  );
 }
+
+render(<App />, document.getElementById("app"));
 ```
 
 ```jsx:repl-final
-import { createElement } from 'preact';
+import { createElement, render } from 'preact';
 
-export default function App() {
+function App() {
   return (
     <p class="big" style={{ color: 'purple' }}>
       Hello <em>World</em>!
     </p>
-  )
+  );
 }
+
+render(<App />, document.getElementById("app"));
 ```
 
 [JSX]: https://en.wikipedia.org/wiki/JSX_(JavaScript)

--- a/content/zh/tutorial/03-components.md
+++ b/content/zh/tutorial/03-components.md
@@ -1,0 +1,272 @@
+---
+title: 组件
+prev: /tutorial/02-events
+next: /tutorial/04-state
+solvable: true
+---
+
+# 组件
+
+正如我们在本教程第一部分中提到的，虚拟DOM应用程序中的关键构建块是组件。组件是应用程序的一个独立部分，可以像HTML元素一样作为虚拟DOM树的一部分进行渲染。你可以将组件视为函数调用：两者都是允许代码重用和间接调用的机制。
+
+为了说明这一点，让我们创建一个简单的组件，名为`MyButton`，它返回一个描述HTML`<button>`元素的虚拟DOM树：
+
+```jsx
+function MyButton(props) {
+  return <button class="my-button">{props.text}</button>
+}
+```
+
+我们可以通过在JSX中引用它来在应用程序中使用这个组件：
+
+```js
+let vdom = <MyButton text="点击我！" />
+
+// 还记得createElement吗？上面那行代码会被编译成：
+let vdom = createElement(MyButton, { text: "点击我！" })
+```
+
+在任何使用JSX描述HTML树的地方，你也可以描述组件树。区别在于组件在JSX中使用大写字母开头的名称来描述，该名称对应于组件的名称（一个JavaScript变量）。
+
+当Preact渲染由JSX描述的虚拟DOM树时，它遇到的每个组件函数都将在树中的那个位置被调用。例如，我们可以通过将描述该组件的JSX元素传递给`render()`，将我们的`MyButton`组件渲染到网页的主体中：
+
+```jsx
+import { render } from 'preact';
+
+render(<MyButton text="点击我！" />, document.body)
+```
+
+### 嵌套组件
+
+组件可以在它们返回的虚拟DOM树中引用其他组件。这创建了一个组件树：
+
+```jsx
+function MediaPlayer() {
+  return (
+    <div>
+      <MyButton text="播放" />
+      <MyButton text="停止" />
+    </div>
+  )
+}
+
+render(<MediaPlayer />, document.body)
+```
+
+我们可以使用这种技术为不同的场景渲染不同的组件树。让我们让`MediaPlayer`在没有声音播放时显示"播放"按钮，在有声音播放时显示"停止"按钮：
+
+```jsx
+function MediaPlayer(props) {
+  return (
+    <div>
+      {props.playing ? (
+        <MyButton text="停止" />
+      ) : (
+        <MyButton text="播放" />
+      )}
+    </div>
+  )
+}
+
+render(<MediaPlayer playing={false} />, document.body)
+// 渲染 <button>播放</button>
+
+render(<MediaPlayer playing={true} />, document.body)
+// 渲染 <button>停止</button>
+```
+
+> **记住：** JSX中的`{花括号}`让我们可以回到普通JavaScript。
+> 这里我们使用[三元]表达式根据`playing` prop的值显示不同的按钮。
+
+
+### 组件子元素
+
+组件也可以像HTML元素一样嵌套。组件之所以是一个强大的原语，原因之一是它们让我们可以应用自定义逻辑来控制组件内嵌套的虚拟DOM元素应该如何渲染。
+
+这种工作方式简单得令人难以置信：在JSX中嵌套在组件内的任何虚拟DOM元素都会以特殊的`children` prop传递给该组件。组件可以选择在何处放置其子元素，方法是在JSX中使用`{children}`表达式引用它们。或者，组件可以简单地返回`children`值，Preact将在组件在虚拟DOM树中的位置渲染这些虚拟DOM元素。
+
+```jsx
+<Foo>
+  <a />
+  <b />
+</Foo>
+
+function Foo(props) {
+  return props.children  // [<a />, <b />]
+}
+```
+
+回想一下前面的例子，我们的`MyButton`组件需要一个`text` prop，作为它的显示文本插入到`<button>`元素中。如果我们想显示一个图像而不是文本呢？
+
+让我们重写`MyButton`以允许使用`children` prop进行嵌套：
+
+```jsx
+function MyButton(props) {
+  return <button class="my-button">{props.children}</button>
+}
+
+function App() {
+  return (
+    <MyButton>
+      <img src="icon.png" />
+      点击我！
+    </MyButton>
+  )
+}
+
+render(<App />, document.body)
+```
+
+现在我们已经看到了一些组件渲染其他组件的例子，希望嵌套组件如何让我们从许多更小的单独部分组装复杂应用程序的概念已经开始变得清晰。
+
+---
+
+### 组件类型
+
+到目前为止，我们看到的组件都是函数。函数组件将`props`作为输入，并返回虚拟DOM树作为输出。组件也可以写成JavaScript类，由Preact实例化并提供一个`render()`方法，该方法的工作方式很像函数组件。
+
+类组件是通过扩展Preact的`Component`基类创建的。在下面的例子中，注意`render()`如何将`props`作为输入并返回虚拟DOM树作为输出 - 就像函数组件一样！
+
+```jsx
+import { Component } from 'preact';
+
+class MyButton extends Component {
+  render(props) {
+    return <button class="my-button">{props.children}</button>
+  }
+}
+
+render(<MyButton>点击我！</MyButton>, document.body)
+```
+
+我们可能使用类来定义组件的原因是为了跟踪组件的_生命周期_。每次Preact在渲染虚拟DOM树时遇到组件，它都会创建我们类的新实例（`new MyButton()`）。
+
+然而，如果你还记得第一章的内容 - Preact可以重复接收新的虚拟DOM树。每次我们给Preact一个新树，它都会与前一个树进行比较，以确定两者之间的变化，并将这些变化应用到页面上。
+
+当组件使用类定义时，树中对该组件的任何_更新_都将重用相同的类实例。这意味着可以在类组件内部存储数据，这些数据在下次调用其`render()`方法时将可用。
+
+类组件还可以实现许多[生命周期方法]，Preact将在响应虚拟DOM树中的变化时调用这些方法：
+
+```jsx
+class MyButton extends Component {
+  componentDidMount() {
+    console.log('你好，来自新的<MyButton>组件！')
+  }
+  componentDidUpdate() {
+    console.log('<MyButton>组件已更新！')
+  }
+  render(props) {
+    return <button class="my-button">{props.children}</button>
+  }
+}
+
+render(<MyButton>点击我！</MyButton>, document.body)
+// 日志："你好，来自新的<MyButton>组件！"
+
+render(<MyButton>点击我！</MyButton>, document.body)
+// 日志："<MyButton>组件已更新！"
+```
+
+类组件的生命周期使它们成为构建应用程序中响应变化的部分的有用工具，而不仅仅是严格地将`props`映射到树。它们还提供了一种方法，可以在虚拟DOM树中放置它们的每个位置分别存储信息。在下一章中，我们将看到组件如何在想要更改树时更新它们的部分。
+
+---
+
+## 试一试！
+
+为了练习，让我们将我们学到的关于组件的知识与前两章的事件技能结合起来！
+
+创建一个`MyButton`组件，它接受`style`、`children`和`onClick` props，并返回一个应用了这些props的HTML `<button>`元素。
+
+<solution>
+  <h4>🎉 恭喜你！</h4>
+  <p>你正在成为组件专家的路上！</p>
+</solution>
+
+
+```js:setup
+useRealm(function (realm) {
+  var options = require('preact').options;
+  var win = realm.globalThis;
+  var prevConsoleLog = win.console.log;
+  var hasComponent = false;
+  var check = false;
+
+  win.console.log = function() {
+    if (hasComponent && check) {
+      solutionCtx.setSolved(true);
+    }
+    return prevConsoleLog.apply(win.console, arguments);
+  };
+
+  var e = options.event;
+  options.event = function(e) {
+    if (e.type === 'click') {
+      check = true;
+      setTimeout(() => check = false);
+    }
+  };
+
+  var r = options.__r;
+  options.__r = function(vnode) {
+    if (typeof vnode.type === 'function' && /MyButton/.test(vnode.type)) {
+      hasComponent = true;
+    }
+  }
+
+  return function () {
+    options.event = e;
+    options.__r = r;
+    win.console.log = prevConsoleLog;
+  };
+}, []);
+```
+
+
+```jsx:repl-initial
+import { render } from "preact";
+
+function MyButton(props) {
+  // start here!
+}
+
+function App() {
+  const clicked = () => {
+    console.log('Hello!')
+  }
+
+  return (
+    <div>
+      <p class="count">Count:</p>
+      <button style={{ color: 'purple' }} onClick={clicked}>Click me</button>
+    </div>
+  )
+}
+
+render(<App />, document.getElementById("app"));
+```
+
+```jsx:repl-final
+import { render } from "preact";
+
+function MyButton(props) {
+  return <button style={props.style} onClick={props.onClick}>{props.children}</button>
+}
+
+function App() {
+  const clicked = () => {
+    console.log('Hello!')
+  }
+
+  return (
+    <div>
+      <p class="count">Count:</p>
+      <MyButton style={{ color: 'purple' }} onClick={clicked}>Click me</MyButton>
+    </div>
+  )
+}
+
+render(<App />, document.getElementById("app"));
+```
+
+[ternary]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Conditional_Operator
+[lifecycle methods]: /guide/v10/components#lifecycle-methods

--- a/content/zh/tutorial/04-state.md
+++ b/content/zh/tutorial/04-state.md
@@ -1,0 +1,186 @@
+---
+title: State
+prev: /tutorial/03-components
+next: /tutorial/05-refs
+solvable: true
+---
+
+# 状态
+
+现在我们已经知道如何创建HTML元素和组件，以及如何使用JSX向两者传递props和事件处理程序，是时候学习如何更新虚拟DOM树了。
+
+正如我们在上一章中提到的，函数组件和类组件都可以有**状态**——组件存储的用于更改其虚拟DOM树的数据。当组件更新其状态时，Preact使用更新后的状态值重新渲染该组件。对于函数组件，这意味着Preact将重新调用该函数，而对于类组件，它只会重新调用类的`render()`方法。让我们看看每种情况的例子。
+
+### 类组件中的状态
+
+类组件有一个`state`属性，它是一个对象，存储组件在调用其`render()`方法时可以使用的数据。组件可以调用`this.setState()`来更新其`state`属性并请求Preact重新渲染它。
+
+```jsx
+class MyButton extends Component {
+  state = { clicked: false }
+
+  handleClick = () => {
+    this.setState({ clicked: true })
+  }
+
+  render() {
+    return (
+      <button onClick={this.handleClick}>
+        {this.state.clicked ? '已点击' : '尚未点击'}
+      </button>
+    )
+  }
+}
+```
+
+点击按钮调用`this.setState()`，这会导致Preact再次调用类的`render()`方法。现在`this.state.clicked`是`true`，`render()`方法返回包含文本"已点击"而不是"尚未点击"的虚拟DOM树，导致Preact更新DOM中按钮的文本。
+
+### 使用钩子的函数组件中的状态
+
+函数组件也可以有状态！虽然它们没有像类组件那样的`this.state`属性，但Preact包含了一个小型附加模块，提供了在函数组件内存储和处理状态的函数，称为"钩子"。
+
+钩子是可以从函数组件内部调用的特殊函数。它们之所以特殊，是因为它们**在渲染之间记住信息**，有点像类上的属性和方法。例如，`useState`钩子返回一个数组，包含一个值和一个"设置器"函数，可以调用该函数来更新那个值。当一个组件被多次调用（重新渲染）时，它所做的任何`useState()`调用每次都会返回完全相同的数组。
+
+> ℹ️ **_钩子实际上是如何工作的？_**
+>
+> 在幕后，像`setState`这样的钩子函数通过存储与虚拟DOM树中的每个组件相关联的一系列"插槽"中的数据来工作。调用钩子函数会使用一个插槽，并增加内部"插槽编号"计数器，以便下一次调用使用下一个插槽。Preact在调用每个组件之前重置这个计数器，所以当一个组件被多次渲染时，每个钩子调用都与相同的插槽相关联。
+>
+> ```js
+> function User() {
+>   const [name, setName] = useState("Bob")    // 插槽 0
+>   const [age, setAge] = useState(42)         // 插槽 1
+>   const [online, setOnline] = useState(true) // 插槽 2
+> }
+> ```
+>
+> 这被称为调用站点排序，这就是为什么钩子必须始终在组件内以相同的顺序调用，并且不能在条件语句或循环内调用的原因。
+
+让我们看一个`useState`钩子的实际例子：
+
+```jsx
+import { useState } from 'preact/hooks'
+
+const MyButton = () => {
+  const [clicked, setClicked] = useState(false)
+
+  const handleClick = () => {
+    setClicked(true)
+  }
+
+  return (
+    <button onClick={handleClick}>
+      {clicked ? '已点击' : '尚未点击'}
+    </button>
+  )
+}
+```
+
+点击按钮调用`setClicked(true)`，这会更新由我们的`useState()`调用创建的状态字段，从而导致Preact重新渲染此组件。当组件第二次被渲染（调用）时，`clicked`状态字段的值将为`true`，返回的虚拟DOM将具有文本"已点击"而不是"尚未点击"。这将导致Preact更新DOM中按钮的文本。
+
+---
+
+## 试一试！
+
+让我们尝试创建一个计数器，从我们在上一章中编写的代码开始。我们需要在状态中存储一个`count`数字，并在点击按钮时将其值增加`1`。
+
+由于我们在上一章中使用了函数组件，使用钩子可能是最简单的，尽管你可以选择你喜欢的任何存储状态的方法。
+
+<solution>
+  <h4>🎉 恭喜你！</h4>
+  <p>你学会了如何使用状态！</p>
+</solution>
+
+
+```js:setup
+useResult(function () {
+  var options = require('preact').options;
+
+  var oe = options.event;
+  options.event = function(e) {
+    if (oe) oe.apply(this, arguments);
+
+    if (e.currentTarget.localName !== 'button') return;
+    var root = e.currentTarget.parentNode.parentNode;
+    var text = root.innerText.match(/Count:\s*([\w.-]*)/i);
+    if (!text) return;
+    if (!text[1].match(/^-?\d+$/)) {
+      return console.warn('提示：看起来你没有在任何地方渲染{count}。');
+    }
+    setTimeout(function() {
+      var text2 = root.innerText.match(/Count:\s*([\w.-]*)/i);
+      if (!text2) {
+        return console.warn('提示：你记得渲染{count}了吗？');
+      }
+      if (text2[1] == text[1]) {
+        return console.warn('提示：记得调用"设置器"函数来更改`count`的值。');
+      }
+      if (!text2[1].match(/^-?\d+$/)) {
+        return console.warn('提示：看起来`count`被设置为了数字以外的东西。');
+      }
+
+      if (Number(text2[1]) === Number(text[1]) + 1) {
+        solutionCtx.setSolved(true);
+      }
+    }, 10);
+  }
+
+  return function () {
+    options.event = oe;
+  };
+}, []);
+```
+
+
+```jsx:repl-initial
+import { render } from 'preact';
+import { useState } from 'preact/hooks';
+
+function MyButton(props) {
+  return <button style={props.style} onClick={props.onClick}>{props.children}</button>
+}
+
+function App() {
+  const clicked = () => {
+    // 在这里将count加1
+  }
+
+  return (
+    <div>
+      <p class="count">计数：</p>
+      <MyButton style={{ color: 'purple' }} onClick={clicked}>点击我</MyButton>
+    </div>
+  )
+}
+
+render(<App />, document.getElementById("app"));
+```
+
+```jsx:repl-final
+import { render } from 'preact';
+import { useState } from 'preact/hooks';
+
+function MyButton(props) {
+  return <button style={props.style} onClick={props.onClick}>{props.children}</button>
+}
+
+function App() {
+  const [count, setCount] = useState(0)
+
+  const clicked = () => {
+    setCount(count + 1)
+  }
+
+  return (
+    <div>
+      <p class="count">计数：{count}</p>
+      <MyButton style={{ color: 'purple' }} onClick={clicked}>点击我</MyButton>
+    </div>
+  )
+}
+
+render(<App />, document.getElementById("app"));
+```
+
+[ternary]: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Operators/Conditional_Operator
+[lifecycle methods]: /guide/v10/components#lifecycle-methods
+</rewritten_file> 

--- a/content/zh/tutorial/05-refs.md
+++ b/content/zh/tutorial/05-refs.md
@@ -1,0 +1,183 @@
+---
+title: Refs
+prev: /tutorial/04-state
+next: /tutorial/06-context
+solvable: true
+---
+
+# Refs
+
+正如我们在第一章中学到的，DOM提供了一个命令式API，它允许我们通过调用元素上的函数来进行更改。从Preact组件访问命令式DOM API的一个例子是自动将焦点移动到输入元素。
+
+`autoFocus`属性（或`autofocus`属性）可以用来在第一次渲染输入时聚焦它，但在某些情况下，我们希望在特定时间或响应特定事件时将焦点移动到输入框。
+
+对于这些需要直接与DOM元素交互的情况，我们可以使用一个称为"refs"的功能。ref是一个普通的JavaScript对象，它有一个`current`属性，可以指向任何值。JavaScript对象是按引用传递的，这意味着任何有权访问ref对象的函数都可以使用`current`属性获取或设置其值。Preact不跟踪ref对象的变化，因此它们可以用于在渲染期间存储信息，然后任何有权访问ref对象的函数都可以稍后访问这些信息。
+
+我们可以看看不渲染任何内容的ref功能的直接使用是什么样子：
+
+```js
+import { createRef } from 'preact'
+
+// 创建一个ref:
+const ref = createRef('初始值')
+// { current: '初始值' }
+
+// 读取ref的当前值:
+ref.current === '初始值'
+
+// 更新ref的当前值:
+ref.current = '新值'
+
+// 传递refs:
+console.log(ref) // { current: '新值' }
+```
+
+在Preact中使refs有用的是，可以在渲染期间将ref对象传递给虚拟DOM元素，Preact将设置ref的值（其`current`属性）为相应的HTML元素。设置后，我们可以使用ref的当前值来访问和修改HTML元素：
+
+```jsx
+import { createRef } from 'preact';
+
+// 创建一个ref:
+const input = createRef()
+
+// 将ref作为prop传递给虚拟DOM元素:
+render(<input ref={input} />, document.body)
+
+// 访问关联的DOM元素:
+input.current // 一个HTML <input>元素
+input.current.focus() // 聚焦输入框！
+```
+
+不建议全局使用`createRef()`，因为多次渲染会覆盖ref的当前值。相反，最好将refs存储为类属性：
+
+```jsx
+import { createRef, Component } from 'preact';
+
+export default class App extends Component {
+  input = createRef()
+
+  // 这个函数在<App>渲染后运行
+  componentDidMount() {
+    // 访问关联的DOM元素:
+    this.input.current.focus();
+  }
+
+  render() {
+    return <input ref={this.input} />
+  }
+}
+```
+
+对于函数组件，`useRef()`钩子提供了一种方便的方式来创建ref并在后续渲染中访问相同的ref。下面的例子还展示了如何使用`useEffect()`钩子在组件渲染后调用回调，此时我们的ref的当前值将被设置为HTML输入元素：
+
+```jsx
+import { useRef, useEffect } from 'preact/hooks';
+
+export default function App() {
+  // 创建或获取我们的ref:（钩子插槽0）
+  const input = useRef()
+
+  // 这里的回调将在<App>渲染后运行:
+  useEffect(() => {
+    // 访问关联的DOM元素:
+    input.current.focus()
+  }, [])
+
+  return <input ref={input} />
+}
+```
+
+记住，refs不限于只存储DOM元素。它们可以用于在组件的多次渲染之间存储信息，而无需设置会导致额外渲染的状态。我们将在后面的章节中看到一些这方面的用途。
+
+
+## 试一试！
+
+现在让我们通过创建一个按钮来实践这一点，当点击该按钮时，通过使用ref访问输入字段并使其获得焦点。
+
+<solution>
+  <h4>🎉 恭喜你！</h4>
+  <p><code>pro = createRef()</code> → <code>pro.current = 'you'</code></p>
+</solution>
+
+
+```js:setup
+function patch(input) {
+  if (input.__patched) return;
+  input.__patched = true;
+  var old = input.focus;
+  input.focus = function() {
+    solutionCtx.setSolved(true);
+    return old.call(this);
+  };
+}
+
+useResult(function (result) {
+  var expectedInput;
+  var timer;
+  [].forEach.call(result.output.querySelectorAll('input'), patch);
+
+  var options = require('preact').options;
+
+  var oe = options.event;
+  options.event = function(e) {
+    if (e.currentTarget.localName !== 'button') return;
+    clearTimeout(timer);
+    var input = e.currentTarget.parentNode.parentNode.querySelector('input');
+    expectedInput = input;
+    if (input) patch(input);
+    timer = setTimeout(function() {
+      if (expectedInput === input) {
+        expectedInput = null;
+      }
+    }, 10);
+    if (oe) return oe.apply(this, arguments);
+  }
+
+  return function () {
+    options.event = oe;
+  };
+}, []);
+```
+
+
+```jsx:repl-initial
+import { render } from 'preact';
+import { useRef } from 'preact/hooks';
+
+function App() {
+  function onClick() {
+
+  }
+
+  return (
+    <div>
+      <input defaultValue="你好，世界！" />
+      <button onClick={onClick}>聚焦输入框</button>
+    </div>
+  );
+}
+
+render(<App />, document.getElementById("app"));
+```
+
+```jsx:repl-final
+import { render } from 'preact';
+import { useRef } from 'preact/hooks';
+
+function App() {
+  const input = useRef();
+
+  function onClick() {
+    input.current.focus();
+  }
+
+  return (
+    <div>
+      <input ref={input} defaultValue="你好，世界！" />
+      <button onClick={onClick}>聚焦输入框</button>
+    </div>
+  );
+}
+
+render(<App />, document.getElementById("app"));
+``` 

--- a/content/zh/tutorial/06-context.md
+++ b/content/zh/tutorial/06-context.md
@@ -43,7 +43,7 @@ export default function App() {
 
 在实际使用中，context很少在同一个组件中提供和消费 - 组件状态通常是这种情况的最佳解决方案。
 
-### Usage with hooks
+### 使用hooks
 
 context的`<Consumer>`API对于大多数用例来说已经足够了，但由于它依赖于嵌套函数来实现作用域，所以写起来可能有点繁琐。函数组件可以选择使用Preact的`useContext()`钩子，它返回组件在虚拟DOM树中位置的`Context`的值。
 

--- a/content/zh/tutorial/06-context.md
+++ b/content/zh/tutorial/06-context.md
@@ -1,0 +1,358 @@
+---
+title: Context
+prev: /tutorial/05-refs
+next: /tutorial/07-side-effects
+solvable: true
+---
+
+# Context
+
+随着应用程序变得越来越大，其虚拟DOM树通常变得深度嵌套并由许多不同的组件组成。树中各个位置的组件有时需要访问共同的数据 - 通常是应用程序状态的片段，如身份验证、用户资料信息、缓存、存储等。虽然可以通过组件props将所有这些信息向下传递，但这意味着每个组件都需要了解所有这些状态 - 即使它只是将其转发到树中。
+
+Context是一种让我们能够自动地将值向下传递的功能，组件不需要知道任何事情。这是通过Provider/Consumer方法实现的：
+
+- `<Provider>` sets the context's value within a <abbr title="The Virtual DOM tree within <Provider>...</Provider>, including all children">subtree</abbr>
+- `<Consumer>`获取由最近的父Provider设置的context值
+
+
+首先，让我们看一个只有一个组件的简单例子。在这个例子中，我们提供"Username"context值并消费该值：
+
+```jsx
+import { createContext } from 'preact'
+
+const Username = createContext()
+
+export default function App() {
+  return (
+    // provide the username value to our subtree:
+    <Username.Provider value="Bob">
+      <div>
+        <p>
+          <Username.Consumer>
+            {username => (
+              // access the current username from context:
+              <span>{username}</span>
+            )}
+          </Username.Consumer>
+        </p>
+      </div>
+    </Username.Provider>
+  )
+}
+```
+
+在实际使用中，context很少在同一个组件中提供和消费 - 组件状态通常是这种情况的最佳解决方案。
+
+### Usage with hooks
+
+context的`<Consumer>`API对于大多数用例来说已经足够了，但由于它依赖于嵌套函数来实现作用域，所以写起来可能有点繁琐。函数组件可以选择使用Preact的`useContext()`钩子，它返回组件在虚拟DOM树中位置的`Context`的值。
+
+这里再次展示前面的例子，这次分成了两个组件，并使用`useContext()`获取context的当前值：
+
+```jsx
+import { createContext } from 'preact'
+import { useContext } from 'preact/hooks'
+
+const Username = createContext()
+
+export default function App() {
+  return (
+    <Username.Provider value="Bob">
+      <div>
+        <p>
+          <User />
+        </p>
+      </div>
+    </Username.Provider>
+  )
+}
+
+function User() {
+  // access the current username from context:
+  const username = useContext(Username) // "Bob"
+  return <span>{username}</span>
+}
+```
+
+如果你能想象`User`需要访问多个Context值的情况，更简单的`useContext()`API仍然更容易理解。
+
+### 实际用法
+
+Context的一个更实际的用法是存储应用程序的认证状态（用户是否已登录）。
+
+为此，我们可以创建一个存储信息的context，我们称之为`AuthContext`。AuthContext的值将是一个对象，其中包含一个`user`属性，包含我们已登录的用户，以及一个`setUser`方法来修改该状态。
+
+```jsx
+import { createContext } from 'preact'
+import { useState, useMemo, useContext } from 'preact/hooks'
+
+const AuthContext = createContext()
+
+export default function App() {
+  const [user, setUser] = useState(null)
+
+  const auth = useMemo(() => {
+    return { user, setUser }
+  }, [user])
+
+  return (
+    <AuthContext.Provider value={auth}>
+      <div class="app">
+        {auth.user && <p>Welcome {auth.user.name}!</p>}
+        <Login />
+      </div>
+    </AuthContext.Provider>
+  )
+}
+
+function Login() {
+  const { user, setUser } = useContext(AuthContext)
+
+  if (user) return (
+    <div class="logged-in">
+      Logged in as {user.name}.
+      <button onClick={() => setUser(null)}>
+        Log Out
+      </button>
+    </div>
+  )
+
+  return (
+    <div class="logged-out">
+      <button onClick={() => setUser({ name: 'Bob' })}>
+        Log In
+      </button>
+    </div>
+  )
+}
+```
+
+### Nested context
+
+### 嵌套context
+
+Context有一个隐藏的超能力，在大型应用程序中非常有用：context提供者可以嵌套，以在虚拟DOM子树中"覆盖"它们的值。想象一个基于网络的电子邮件应用程序，其中用户界面的各个部分基于URL路径显示：
+
+> - `/inbox`：显示收件箱
+> - `/inbox/compose`：显示收件箱和新消息
+> - `/settings`：显示设置
+> - `/settings/forwarding`：显示转发设置
+
+我们可以创建一个`<Route path=".."`组件，只有当当前路径匹配给定的路径段时才渲染虚拟DOM树。为了简化嵌套路由的定义，每个匹配的路由可以在其子树中覆盖"当前路径"context值，以排除已匹配的路径部分。
+
+```jsx
+import { createContext } from 'preact'
+import { useContext } from 'preact/hooks'
+
+const Path = createContext(location.pathname)
+
+function Route(props) {
+  const path = useContext(Path) // the current path
+  const isMatch = path.startsWith(props.path)
+  const innerPath = path.substring(props.path.length)
+  return isMatch && (
+    <Path.Provider value={innerPath}>
+      {props.children}
+    </Path.Provider>
+  )
+}
+```
+
+现在我们可以使用这个新的`Route`组件来定义电子邮件应用程序的界面。注意`Inbox`组件不需要知道自己的路径，就可以为其子组件定义`<Route path="..">`匹配：
+
+```jsx
+export default function App() {
+  return (
+    <div class="app">
+      <Route path="/inbox">
+        <Inbox />
+      </Route>
+      <Route path="/settings">
+        <Settings />
+      </Route>
+    </div>
+  )
+}
+
+function Inbox() {
+  return (
+    <div class="inbox">
+      <div class="messages"> ... </div>
+      <Route path="/compose">
+        <Compose />
+      </Route>
+    </div>
+  )
+}
+
+function Settings() {
+  return (
+    <div class="settings">
+      <h1>Settings</h1>
+      <Route path="/forwarding">
+        <Forwarding />
+      </Route>
+    </div>
+  )
+}
+```
+
+### 默认context值
+
+嵌套context是一个强大的功能，我们经常在不知不觉中使用它。例如，在本章的第一个说明性示例中，我们使用`<Provider value="小明">`在树中定义了一个`Username`的context值。
+
+然而，这实际上是在覆盖`Username`context的默认值。所有context都有一个默认值，该值是作为第一个参数传递给`createContext()`的值。在示例中，我们没有向`createContext`传递任何参数，所以默认值是`undefined`。
+
+下面是第一个例子使用默认context值而不是Provider的样子：
+
+```jsx
+import { createContext } from 'preact'
+import { useContext } from 'preact/hooks'
+
+const Username = createContext('Bob')
+
+export default function App() {
+  const username = useContext(Username) // returns "Bob"
+
+  return <span>{username}</span>
+}
+```
+
+
+## 试一试！
+
+在本练习中，我们将使用Context在应用程序的不同部分之间共享一个主题。
+我们已经创建了`ThemeContext`，它可以是`"light"`或`"dark"`。我们已经创建了
+`ThemeContext.Provider`，它使用`theme`状态变量。
+现在我们需要修改按钮组件，使其根据设置的主题改变其外观。
+
+提示：你需要使用`useContext`钩子从`ThemeContext`获取当前主题，并使用它来
+决定按钮的`className`。
+
+<solution>
+  <h4>🎉 恭喜你！</h4>
+  <p>你已经成功地使用Context在组件树中传递信息！</p>
+</solution>
+
+
+```js:setup
+var output = useRef();
+
+function getCounts() {
+  var counts = [];
+  var text = output.current.innerText;
+  var r = /Count:\s*([\w.-]*)/gi;
+  while (t = r.exec(text)) {
+    var num = Number(t[1]);
+    counts.push(isNaN(num) ? t[1] : num);
+  }
+  return counts;
+}
+
+useResult(function (result) {
+  output.current = result.output;
+
+  if (getCounts().length !== 3) {
+    console.warn('It looks like you haven\'t initialized the `count` value to 0.');
+  }
+  
+  var timer;
+  var count = 0;
+  var options = require('preact').options;
+
+  var oe = options.event;
+  options.event = function(e) {
+    if (e.currentTarget.localName !== 'button') return;
+    clearTimeout(timer);
+    timer = setTimeout(function() {
+      var counts = getCounts();
+      if (counts.length !== 3) {
+        return console.warn('We seem to be missing one of the counters.');
+      }
+      if (counts[0] !== counts[2] || counts[0] !== counts[1]) {
+        return console.warn('It looks like the counters aren\'t in sync.');
+      }
+      var solved = counts[0] === ++count;
+      store.setState({ solved: solved });
+    }, 10);
+    if (oe) return oe.apply(this, arguments);
+  }
+
+  return function () {
+    options.event = oe;
+  };
+}, []);
+```
+
+
+```jsx:repl-initial
+import { render, createContext } from 'preact';
+import { useState, useContext, useMemo } from 'preact/hooks';
+
+const CounterContext = createContext(null);
+
+function Counter() {
+  return (
+    <div style={{ background: '#eee', padding: '10px' }}>
+      <p>Count: {'MISSING'}</p>
+      <button>Add</button>
+    </div>
+  );
+}
+
+function App() {
+  const [count, setCount] = useState(0);
+
+  return (
+    <div style={{ display: 'flex', gap: '20px' }}>
+      <Counter />
+      <Counter />
+      <Counter />
+    </div>
+  )
+}
+
+render(<App />, document.getElementById("app"));
+```
+
+```jsx:repl-final
+import { render, createContext } from 'preact';
+import { useState, useContext, useMemo } from 'preact/hooks';
+
+const CounterContext = createContext(null);
+
+function Counter() {
+  const { count, increment } = useContext(CounterContext);
+
+  return (
+    <div style={{ background: '#eee', padding: '10px' }}>
+      <p>Count: {count}</p>
+      <button onClick={increment}>Add</button>
+    </div>
+  );
+}
+
+function App() {
+  const [count, setCount] = useState(0);
+
+  function increment() {
+    setCount(count + 1);
+  }
+
+  const counter = useMemo(() => {
+    return { count, increment };
+  }, [count]);
+
+  return (
+    <CounterContext.Provider value={counter}>
+      <div style={{ display: 'flex', gap: '20px' }}>
+        <Counter />
+        <Counter />
+        <Counter />
+      </div>
+    </CounterContext.Provider>
+  )
+}
+
+render(<App />, document.getElementById("app"));
+```

--- a/content/zh/tutorial/07-side-effects.md
+++ b/content/zh/tutorial/07-side-effects.md
@@ -1,5 +1,5 @@
 ---
-title: Side Effects
+title: 副作用
 prev: /tutorial/06-context
 next: /tutorial/08-keys
 solvable: true

--- a/content/zh/tutorial/07-side-effects.md
+++ b/content/zh/tutorial/07-side-effects.md
@@ -1,0 +1,166 @@
+---
+title: Side Effects
+prev: /tutorial/06-context
+next: /tutorial/08-keys
+solvable: true
+---
+
+# 副作用
+
+副作用是在虚拟DOM树中发生变化时运行的代码片段。它们不遵循接受`props`并返回新虚拟DOM树的标准方法，并且经常伸出树外去改变状态或调用命令式代码，比如调用DOM API。副作用也经常被用作触发数据获取的方式。
+
+### Effects：函数组件中的副作用
+
+在前一章学习refs和`useRef()`钩子时，我们已经看到了一个副作用实际运行的例子。一旦我们的ref被填充了一个指向DOM元素的`current`属性，我们需要一种方法来"触发"与该元素交互的代码。
+
+为了在渲染后触发代码，我们使用了`useEffect()`钩子，这是从函数组件创建副作用的最常见方式：
+
+```jsx
+import { useRef, useEffect } from 'preact/hooks';
+
+export default function App() {
+  const input = useRef()
+
+  // 这里的回调将在<App>渲染后运行：
+  useEffect(() => {
+    // 访问关联的DOM元素：
+    input.current.focus()
+  }, [])
+
+  return <input ref={input} />
+}
+```
+
+注意作为`useEffect()`第二个参数传递的空数组。当该"依赖项"数组中的任何值从一次渲染到下一次渲染发生变化时，Effect回调就会运行。例如，组件第一次渲染时，所有effect回调都会运行，因为没有之前的"依赖项"数组值可以比较。
+
+我们可以在"依赖项"数组中添加值，根据条件触发effect回调，而不仅仅是在组件首次渲染时。这通常用于响应数据变化运行代码，或者当组件从页面中移除（"卸载"）时。
+
+让我们看一个例子：
+
+```js
+import { useEffect, useState } from 'preact/hooks';
+
+export default function App() {
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    console.log('<App>刚刚第一次被渲染')
+  }, [])
+
+  useEffect(() => {
+    console.log('count值改变为：', count)
+  }, [count])
+  //  ^ 每当`count`改变时运行这个，以及在第一次渲染时
+
+  return <button onClick={() => setCount(count+1)}>{count}</button>
+}
+```
+
+### 生命周期方法：类组件中的副作用
+
+类组件也可以定义副作用，通过实现Preact提供的任何可用[生命周期方法]。以下是一些最常用的生命周期方法：
+
+| 生命周期方法 | 何时运行： |
+|:-----------------|:--------------|
+| `componentWillMount` | 组件首次渲染之前
+| `componentDidMount` | 组件首次渲染之后
+| `componentWillReceiveProps` | 组件重新渲染之前
+| `componentDidUpdate` | 组件重新渲染之后
+
+在类组件中使用副作用的最常见例子之一是在组件首次渲染时获取数据，然后将该数据存储在状态中。以下示例显示了一个组件，它在首次渲染后从JSON API请求用户信息，然后显示该信息。
+
+```jsx
+import { Component } from 'preact';
+
+export default class App extends Component {
+  // 这在组件首次渲染后被调用：
+  componentDidMount() {
+    // 获取JSON用户信息，存储在`state.user`中：
+    fetch('/api/user')
+      .then(response => response.json())
+      .then(user => {
+        this.setState({ user })
+      })
+  }
+
+  render(props, state) {
+    const { user } = state;
+
+    // 如果我们还没有收到数据，显示一个加载指示器：
+    if (!user) return <div>加载中...</div>
+
+    // 我们有数据！显示我们从API得到的用户名：
+    return (
+      <div>
+        <h2>你好，{user.username}！</h2>
+      </div>
+    )
+  }
+}
+```
+
+## 试一试！
+
+我们保持这个练习简单：修改右边的代码示例，使其在每次`count`改变时进行日志记录，而不仅仅是在`<App>`首次渲染时。
+
+<solution>
+  <h4>🎉 恭喜你！</h4>
+  <p>你学会了如何在Preact中使用副作用。</p>
+</solution>
+
+
+```js:setup
+useRealm(function (realm) {
+  var win = realm.globalThis;
+  var prevConsoleLog = win.console.log;
+  win.console.log = function(m, s) {
+    if (/Count is now/.test(m) && s === 1) {
+      solutionCtx.setSolved(true);
+    }
+    return prevConsoleLog.apply(win.console, arguments);
+  };
+
+  return function () {
+    win.console.log = prevConsoleLog;
+  };
+}, []);
+```
+
+
+```jsx:repl-initial
+import { render } from 'preact';
+import { useEffect, useState } from 'preact/hooks';
+
+function App() {
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    console.log('Count is now: ', count)
+  }, []);
+  // ^^ start here!
+
+  return <button onClick={() => setCount(count+1)}>{count}</button>
+}
+
+render(<App />, document.getElementById("app"));
+```
+
+```jsx:repl-final
+import { render } from 'preact';
+import { useEffect, useState } from 'preact/hooks';
+
+function App() {
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    console.log('Count is now: ', count)
+  }, [count]);
+  // ^^ start here!
+
+  return <button onClick={() => setCount(count+1)}>{count}</button>
+}
+
+render(<App />, document.getElementById("app"));
+```
+
+[lifecycle methods]: /guide/v10/components#lifecycle-methods

--- a/content/zh/tutorial/08-keys.md
+++ b/content/zh/tutorial/08-keys.md
@@ -1,5 +1,5 @@
 ---
-title: Keys
+title: 键
 prev: /tutorial/07-side-effects
 next: /tutorial/09-error-handling
 solvable: true

--- a/content/zh/tutorial/08-keys.md
+++ b/content/zh/tutorial/08-keys.md
@@ -1,0 +1,330 @@
+---
+title: Keys
+prev: /tutorial/07-side-effects
+next: /tutorial/09-error-handling
+solvable: true
+---
+
+# 键
+
+在第一章中，我们看到了Preact如何使用虚拟DOM来计算我们的JSX描述的两棵树之间的变化，然后将这些变化应用到HTML DOM上以更新页面。这在大多数情况下都能很好地工作，但有时需要Preact"猜测"树的形状在两次渲染之间是如何变化的。
+
+Preact的猜测可能与我们的意图不同的最常见场景是比较列表时。考虑一个简单的待办事项列表组件：
+
+```jsx
+export default function TodoList() {
+  const [todos, setTodos] = useState(['起床', '整理床铺'])
+
+  function wakeUp() {
+    setTodos(['整理床铺'])
+  }
+
+  return (
+    <div>
+      <ul>
+        {todos.map(todo => (
+          <li>{todo}</li>
+        ))}
+      </ul>
+      <button onClick={wakeUp}>我醒了！</button>
+    </div>
+  )
+}
+```
+
+这个组件第一次渲染时，将绘制两个`<li>`列表项。点击__"我醒了！"__按钮后，我们的`todos`状态数组更新为只包含第二项，`"整理床铺"`。
+
+以下是Preact在第一次和第二次渲染时"看到"的内容：
+
+<table><thead><tr>
+  <th>第一次渲染</th>
+  <th>第二次渲染</th>
+</tr></thead><tbody><tr><td>
+
+```jsx
+<div>
+  <ul>
+    <li>起床</li>
+    <li>整理床铺</li>
+  </ul>
+  <button>我醒了！</button>
+</div>
+```
+
+</td><td>
+
+```jsx
+<div>
+  <ul>
+    <li>整理床铺</li>
+
+  </ul>
+  <button>我醒了！</button>
+</div>
+```
+
+</td></tr></tbody></table>
+
+注意到问题了吗？虽然对我们来说很明显是移除了_第一个_列表项（"起床"），但Preact不知道这一点。Preact只看到之前有两个项目，现在只有一个。在应用这个更新时，它实际上会移除第二个项目（`<li>整理床铺</li>`），然后将第一个项目的文本从`起床`更新为`整理床铺`。
+
+结果在技术上是正确的 - 一个带有文本"整理床铺"的单个项目 - 但我们达到这个结果的方式是次优的。想象一下，如果有1000个列表项，而我们移除了第一个项目：Preact不会仅移除一个`<li>`，而是会更新其他999个项目的文本并移除最后一个。
+
+
+### 列表渲染的**key**
+
+在像前面例子那样的情况下，项目的_顺序_正在改变。我们需要一种方法来帮助Preact知道哪些项目是哪些，这样它就可以检测到每个项目何时被添加、移除或替换。为此，我们可以向每个项目添加一个`key`属性。
+
+`key`属性是给定元素的标识符。Preact在比较两棵树之间的元素时，不是比较元素的_顺序_，而是通过查找具有相同`key`属性值的前一个元素来比较带有`key`属性的元素。`key`可以是任何类型的值，只要它在渲染之间是"稳定的"：同一项目的重复渲染应该具有完全相同的`key`属性值。
+
+让我们在前面的例子中添加键。由于我们的待办事项列表是一个简单的不会改变的字符串数组，我们可以使用这些字符串作为键：
+
+```jsx
+export default function TodoList() {
+  const [todos, setTodos] = useState(['起床', '整理床铺'])
+
+  function wakeUp() {
+    setTodos(['整理床铺'])
+  }
+
+  return (
+    <div>
+      <ul>
+        {todos.map(todo => (
+          <li key={todo}>{todo}</li>
+          //  ^^^^^^^^^^ 添加key属性
+        ))}
+      </ul>
+      <button onClick={wakeUp}>我醒了！</button>
+    </div>
+  )
+}
+```
+
+第一次渲染这个新版本的`<TodoList>`组件时，将绘制两个`<li>`项目。当点击"我醒了！"按钮时，我们的`todos`状态数组更新为只包含第二项，`"整理床铺"`。
+
+以下是我们添加了`key`到列表项后Preact看到的内容：
+
+<table><thead><tr>
+  <th>第一次渲染</th>
+  <th>第二次渲染</th>
+</tr></thead><tbody><tr><td>
+
+```jsx
+<div>
+  <ul>
+    <li key="起床">起床</li>
+    <li key="整理床铺">整理床铺</li>
+  </ul>
+  <button>我醒了！</button>
+</div>
+```
+
+</td><td>
+
+```jsx
+<div>
+  <ul>
+
+    <li key="整理床铺">整理床铺</li>
+  </ul>
+  <button>我醒了！</button>
+</div>
+```
+
+</td></tr></tbody></table>
+
+这次，Preact可以看到第一项被移除了，因为第二棵树中缺少一个带有`key="起床"`的项目。它将移除第一项，并保持第二项不变。
+
+
+### 何时**不**使用键
+
+开发者遇到的最常见的一个陷阱是无意中选择了在渲染之间_不稳定_的键。在我们的例子中，想象一下，如果我们使用`map()`的索引参数作为我们的`key`值，而不是`item`字符串本身：
+
+`items.map((item, index) => <li key={index}>{item}</li>`
+
+这将导致Preact在第一次和第二次渲染时看到以下树：
+
+<table><thead><tr>
+  <th>第一次渲染</th>
+  <th>第二次渲染</th>
+</tr></thead><tbody><tr><td>
+
+```jsx
+<div>
+  <ul>
+    <li key={0}>起床</li>
+    <li key={1}>整理床铺</li>
+  </ul>
+  <button>我醒了！</button>
+</div>
+```
+
+</td><td>
+
+```jsx
+<div>
+  <ul>
+
+    <li key={0}>整理床铺</li>
+  </ul>
+  <button>我醒了！</button>
+</div>
+```
+
+</td></tr></tbody></table>
+
+问题是`index`实际上并不标识列表中的一个_**值**_，它标识的是一个_**位置**_。这种方式的渲染实际上_强制_Preact按顺序匹配项目，这与没有key存在时它会做的事情相同。当应用于具有不同类型的列表项时，使用索引键甚至可能导致昂贵或错误的输出，因为键不能匹配具有不同类型的元素。
+
+> 🚙 **类比时间！** 想象你把车留给代客泊车。
+>
+> 当你回来取车时，你告诉代客你开的是一辆灰色SUV。不幸的是，停车场里有一半以上的车都是灰色SUV，你最终得到了别人的车。下一个灰色SUV的车主也拿到了错误的车，依此类推。
+>
+> 如果你告诉代客你开的是一辆带有车牌"PR3ACT"的灰色SUV，你可以确定会拿回自己的车。
+
+<!--
+> 🍫 **巧克力类比：** 想象一个朋友拿着一盒巧克力，问你是否愿意尝试一个。你看中了薄荷松露巧克力。
+>
+> 如果你回答"第四个"，那么如果巧克力被调换或重新排序，你可能会拿到错误的巧克力。（惊讶！）
+>
+> 如果你回答"薄荷松露巧克力"，无论顺序如何，都很清楚你对哪个巧克力感兴趣。
+-->
+
+作为一般经验法则，永远不要使用数组或循环索引作为`key`。使用列表项值本身，或为项目生成唯一ID并使用它：
+
+```jsx
+const todos = [
+  { id: 1, text: '起床' },
+  { id: 2, text: '整理床铺' }
+]
+
+export default function ToDos() {
+  const [todos, setTodos] = useState([
+    { id: 1, text: '起床' },
+    { id: 2, text: '整理床铺' }
+  ])
+
+  function wakeUp() {
+    setTodos([
+      { id: 2, text: '整理床铺' }
+    ])
+  }
+
+  return (
+    <div>
+      <ul>
+        {todos.map(todo => (
+          <li key={todo.id}>{todo.text}</li>
+        ))}
+      </ul>
+      <button onClick={wakeUp}>我醒了！</button>
+    </div>
+  )
+}
+```
+
+## 试一试！
+
+下面的示例显示了一个ToDo列表，你可以通过点击复选框来完成每个项目。当前，完成一个项目会从列表中移除它，但由于我们没有使用`key`属性，Preact会更新所有待办事项的文本并移除最后一个，而不是移除被点击的那个。
+
+添加一个`key`属性到`<li>`元素，使Preact可以正确识别哪个todo被点击并从列表中移除。
+
+<solution>
+  <h4>🎉 恭喜你！</h4>
+  <p>你学会了如何使用键进行高效的列表渲染！</p>
+</solution>
+
+
+```js:setup
+useRealm(function (realm) {
+  // the app element
+  var out = realm.globalThis.document.body.firstElementChild;
+  var options = require('preact').options;
+
+  var oldRender = options.__r;
+  var timer;
+  options.__r = function(vnode) {
+    timer = setTimeout(check, 10);
+    if (oldRender) oldRender(vnode);
+  };
+
+  function check() {
+    timer = null;
+    var c = out.firstElementChild.children;
+    if (
+      c.length === 2 &&
+      /learn preact/i.test(c[0].textContent) &&
+      /make an awesome app/i.test(c[1].textContent)
+    ) {
+      solutionCtx.setSolved(true);
+    }
+  }
+
+  return () => {
+    options.__r = oldRender;
+  };
+});
+```
+
+
+```jsx:repl-initial
+import { render } from 'preact';
+import { useState, useEffect } from 'preact/hooks';
+
+const wait = ms => new Promise(r => setTimeout(r, ms))
+
+const getTodos = async () => {
+  await wait(500);
+  return [
+    { id: 1, text: 'learn Preact', done: false },
+    { id: 2, text: 'make an awesome app', done: false },
+  ]
+}
+
+function TodoList() {
+  const [todos, setTodos] = useState([])
+
+  return (
+    <ul>
+    </ul>
+  )
+}
+
+render(<TodoList />, document.getElementById("app"));
+```
+
+```jsx:repl-final
+import { render } from 'preact';
+import { useState, useEffect } from 'preact/hooks';
+
+const wait = ms => new Promise(r => setTimeout(r, ms))
+
+const getTodos = async () => {
+  await wait(500);
+  return [
+    { id: 1, text: 'learn Preact', done: false },
+    { id: 2, text: 'make an awesome app', done: false },
+  ]
+}
+
+function TodoList() {
+  const [todos, setTodos] = useState([])
+
+  useEffect(() => {
+    getTodos().then(todos => {
+      setTodos(todos)
+    })
+  }, [])
+
+  return (
+    <ul>
+      {todos.map(todo => (
+        <li key={todo.id}>
+          {todo.text}
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+render(<TodoList />, document.getElementById("app"));
+```

--- a/content/zh/tutorial/09-error-handling.md
+++ b/content/zh/tutorial/09-error-handling.md
@@ -1,0 +1,146 @@
+---
+title: Error Handling
+prev: /tutorial/08-keys
+next: /tutorial/10-links
+solvable: true
+---
+
+# 错误处理
+
+JavaScript是一种灵活的解释型语言，这意味着在运行时遇到错误是可能的（甚至很容易）。无论是由于意外情况还是我们编写的代码中的错误，能够监控错误并实现某种形式的恢复或优雅的错误处理都很重要。
+
+在Preact中，我们通过捕获错误并将其保存为状态来实现这一点。这使组件能够拦截意外或失败的渲染，并切换到渲染不同的内容作为后备方案。
+
+### 将错误转化为状态
+
+有两个API可用于捕获错误并将其转化为状态：`componentDidCatch`和`getDerivedStateFromError`。它们在功能上类似，都是可以在类组件上实现的方法：
+
+**componentDidCatch**获取一个`Error`参数，并可以根据具体情况决定如何响应该错误。它可以调用`this.setState()`来渲染一个后备或替代树，这将"捕获"错误并将其标记为已处理。或者，该方法可以简单地在某处记录错误，并允许其继续未处理（崩溃）。
+
+**getDerivedStateFromError**是一个静态方法，它获取一个`Error`参数，并返回一个状态更新对象，该对象通过`setState()`应用于组件。由于此方法总是产生导致其组件重新渲染的状态变化，因此它总是将错误标记为已处理。
+
+以下示例展示了如何使用这两种方法来捕获错误并显示优雅的错误消息，而不是崩溃：
+
+```jsx
+import { Component } from 'preact'
+
+class ErrorBoundary extends Component {
+  state = { error: null }
+
+  static getDerivedStateFromError(error) {
+    return { error: error.message }
+  }
+
+  componentDidCatch(error) {
+    console.error(error)
+    this.setState({ error: error.message })
+  }
+
+  render() {
+    if (this.state.error) {
+      return <p>哎呀！我们遇到了一个错误：{this.state.error}</p>
+    }
+    return this.props.children
+  }
+}
+```
+
+上面的组件是Preact应用程序中错误处理实现的一个相对常见的例子，通常被称为_错误边界_。
+
+### 嵌套和错误冒泡
+
+当Preact渲染你的虚拟DOM树时遇到的错误会"冒泡"，很像DOM事件。从遇到错误的组件开始，树中的每个父组件都有机会处理错误。
+
+因此，如果使用`componentDidCatch`实现，错误边界可以嵌套。当组件的`componentDidCatch()`方法_不_调用`setState()`时，错误将继续在虚拟DOM树中冒泡，直到到达一个带有确实调用`setState()`的`componentDidCatch`方法的组件。
+
+## 试一试！
+
+为了测试我们的错误处理知识，让我们向简单的App组件添加错误处理。App内部深处的一个组件在某些情况下可能会抛出错误，我们希望捕获这个错误，这样我们就可以显示一条友好的消息，告诉用户我们遇到了意外错误。
+
+<solution>
+  <h4>🎉 恭喜你！</h4>
+  <p>你学会了如何处理Preact代码中的错误！</p>
+</solution>
+
+
+```js:setup
+useResult(function(result) {
+  var options = require('preact').options;
+
+  var oe = options.__e;
+  options.__e = function(error, s) {
+    if (/objects are not valid/gi.test(error)) {
+      throw Error('It looks like you might be trying to render an Error object directly: try storing `error.message` instead of `error` itself.');
+    }
+    oe.apply(this, arguments);
+    setTimeout(function() {
+      if (result.output.textContent.match(/error/i)) {
+        solutionCtx.setSolved(true);
+      }
+    }, 10);
+  };
+
+  return function () {
+    options.__e = oe;
+  };
+}, []);
+```
+
+
+```jsx:repl-initial
+import { render, Component } from 'preact';
+import { useState } from 'preact/hooks';
+
+function Clicker() {
+  const [clicked, setClicked] = useState(false);
+
+  if (clicked) {
+    throw new Error('I am erroring');
+  }
+
+  return <button onClick={() => setClicked(true)}>Click Me</button>;
+}
+
+class App extends Component {
+  state = { error: null };
+
+  render() {
+    return <Clicker />;
+  }
+}
+
+render(<App />, document.getElementById("app"));
+```
+
+```jsx:repl-final
+import { render, Component } from 'preact';
+import { useState } from 'preact/hooks';
+
+function Clicker() {
+  const [clicked, setClicked] = useState(false);
+
+  if (clicked) {
+    throw new Error('I am erroring');
+  }
+
+  return <button onClick={() => setClicked(true)}>Click Me</button>;
+}
+
+class App extends Component {
+  state = { error: null };
+
+  componentDidCatch(error) {
+    this.setState({ error: error.message });
+  }
+
+  render() {
+    const { error } = this.state;
+    if (error) {
+      return <p>Oh no! There was an error: {error}</p>
+    }
+    return <Clicker />;
+  }
+}
+
+render(<App />, document.getElementById("app"));
+```

--- a/content/zh/tutorial/09-error-handling.md
+++ b/content/zh/tutorial/09-error-handling.md
@@ -1,5 +1,5 @@
 ---
-title: Error Handling
+title: 错误处理
 prev: /tutorial/08-keys
 next: /tutorial/10-links
 solvable: true


### PR DESCRIPTION
## What does this PR do?
This PR adds translated Chinese versions of several tutorial files in the Preact documentation. By providing these translated materials, it makes it easier for Chinese - speaking users to learn Preact through step - by step

## Problem Being Solved
Previously, the Chinese documentation might have lacked detailed and up - to - date tutorial content, which could be a barrier for Chinese users to quickly understand and master Preact. This PR addresses this issue by adding Chinese translations of key tutorial sections, helping Chinese users to learn Preact more effectively without having to rely solely on the English documentation.

## Changes Made
File Addition: Added seven new Markdown files in the directory. These files are translations of the corresponding English tutorial files, including step tutorials 03-09.

Translation Work: Translated all the content in these files from English to Chinese, ensuring that the translated text accurately conveys the original meaning and is easy for Chinese users to understand.
Verification: Followed the contributor guidelines and conducted local builds to verify that the new files are integrated correctly into the documentation system and that there are no formatting or link - related issues.