### PR TITLE
docs: Add mention of new signal utils

### DIFF
--- a/content/en/guide/v10/signals.md
+++ b/content/en/guide/v10/signals.md
@@ -520,9 +520,17 @@ Creates a new signal with the given argument as its initial value:
 const count = signal(0);
 ```
 
-When creating signals within a component, use the hook variant: `useSignal(initialValue)`.
-
 The returned signal has a `.value` property that can be get or set to read and write its value. To read from a signal without subscribing to it, use `signal.peek()`.
+
+#### useSignal(initialValue)
+
+When creating signals within a component, use the hook variant: `useSignal(initialValue)`. It functions similarly to `signal()` but is memoized to ensure that the same signal instance is used across renders of the component.
+
+```jsx
+function MyComponent() {
+  const count = useSignal(0);
+}
+```
 
 ### computed(fn)
 
@@ -535,7 +543,18 @@ const surname = signal("Doe");
 const fullName = computed(() => `${name.value} ${surname.value}`);
 ```
 
+#### useComputed(fn)
+
 When creating computed signals within a component, use the hook variant: `useComputed(fn)`.
+
+```jsx
+function MyComponent() {
+  const name = useSignal("Jane");
+  const surname = useSignal("Doe");
+
+  const fullName = useComputed(() => `${name.value} ${surname.value}`);
+}
+```
 
 ### effect(fn)
 
@@ -552,7 +571,18 @@ name.value = "John";
 // Logs: "Hello John"
 ```
 
+#### useSignalEffect(fn)
+
 When responding to signal changes within a component, use the hook variant: `useSignalEffect(fn)`.
+
+```jsx
+function MyComponent() {
+  const name = useSignal("Jane");
+
+  // Log to console when `name` changes:
+  useSignalEffect(() => console.log('Hello', name.value));
+}
+```
 
 ### batch(fn)
 

--- a/content/en/guide/v10/signals.md
+++ b/content/en/guide/v10/signals.md
@@ -613,3 +613,93 @@ effect(() => {
   })
 })
 ```
+
+## Utility Components and Hooks
+
+As of v2.1.0, the `@preact/signals/utils` package provides additional utility components and hooks to make working with signals even easier.
+
+### Show Component
+
+The `<Show>` component provides a declarative way to conditionally render content based on a signal's value.
+
+```jsx
+import { signal } from "@preact/signals";
+import { Show } from "@preact/signals/utils";
+
+const isVisible = signal(false);
+
+function App() {
+  return (
+    <Show when={isVisible} fallback={<p>Nothing to see here</p>}>
+      <p>Now you see me!</p>
+    </Show>
+  );
+}
+
+// You can also use a function to access the value
+function App() {
+  return <Show when={isVisible}>{value => <p>The value is {value}</p>}</Show>;
+}
+```
+
+### For Component
+
+The `<For>` component helps you render lists from signal arrays with automatic caching of rendered items.
+
+```jsx
+import { signal } from "@preact/signals";
+import { For } from "@preact/signals/utils";
+
+const items = signal(["A", "B", "C"]);
+
+function App() {
+  return (
+    <For each={items} fallback={<p>No items</p>}>
+      {(item, index) => <div key={index}>Item: {item}</div>}
+    </For>
+  );
+}
+```
+
+### Additional Hooks
+
+#### useLiveSignal(signal)
+
+The `useLiveSignal(signal)` hook allows you to create a local signal that stays synchronized with an external signal.
+
+```jsx
+import { signal } from "@preact/signals";
+import { useLiveSignal } from "@preact/signals/utils";
+
+const external = signal(0);
+
+function Component() {
+  const local = useLiveSignal(external);
+  // local will automatically update when external changes
+}
+```
+
+#### useSignalRef(initialValue)
+
+The `useSignalRef(initialValue)` hook creates a signal that behaves like a React ref with a `.current` property.
+
+```jsx
+import { useSignalEffect } from "@preact/signals";
+import { useSignalRef } from "@preact/signals/utils";
+
+function Component() {
+  const ref = useSignalRef(null);
+
+  useSignalEffect(() => {
+    if (ref.current) {
+      console.log("Ref has been set to:", ref.current);
+    }
+  });
+
+  return (
+    <div ref={ref}>
+      The ref has been attached to a {ref.current?.tagName} element.
+    </div>
+  );
+}
+```


### PR DESCRIPTION
Mostly a direct copy/paste of the new signal util docs with only the `useSignalRef` example getting fleshed out a bit more as I think it's useful to concretely show how it can double as both a ref (attaching to DOM nodes) and a signal (auto-tracked by `useSignalEffect`).

I also added specific sub-sections for existing hooks; we've had a lot of people over the years not realize these even existed when getting started as they were only mentioned in footnotes beneath the core APIs. Way too easy to miss. Also gives us something to link to when needed.