### PR TITLE
docs: Rewrite hooks intro blurb

### DIFF
--- a/content/en/guide/v10/hooks.md
+++ b/content/en/guide/v10/hooks.md
@@ -5,9 +5,9 @@ description: Hooks in Preact allow you to compose behaviours together and re-use
 
 # Hooks
 
-The Hooks API is a new concept that allows you to compose state and side effects. Hooks allow you to reuse stateful logic between components.
+The Hooks API is an alternative way to write components in Preact. Hooks allow you to compose state and side effects, reusing stateful logic much more easily than with class components.
 
-If you've worked with Preact for a while, you may be familiar with patterns like "render props" and "higher order components" that try to solve these challenges. These solutions have tended to make code harder to follow and more abstract. The hooks API makes it possible to neatly extract the logic for state and side effects, and also simplifies unit testing that logic independently from the components that rely on it.
+If you've worked with class components in Preact for a while, you may be familiar with patterns like "render props" and "higher order components" that try to solve these challenges. These solutions have tended to make code harder to follow and more abstract. The hooks API makes it possible to neatly extract the logic for state and side effects, and also simplifies unit testing that logic independently from the components that rely on it.
 
 Hooks can be used in any component, and avoid many pitfalls of the `this` keyword relied on by the class components API. Instead of accessing properties from the component instance, hooks rely on closures. This makes them value-bound and eliminates a number of stale data problems that can occur when dealing with asynchronous state updates.
 


### PR DESCRIPTION
[Brought up in Slack earlier today](https://preact.slack.com/archives/C3NMBSJKH/p1751314634016219?thread_ts=1751311250.665439&cid=C3NMBSJKH), calling hooks "a new concept" probably isn't fitting anymore.

We might want to alter this further to better integrate w/ our story for signals, but for now, I just tried to clarify that this is in contrast to class components.