### PR TITLE
fix: Ensure user stays on same content page when switching doc versions

### DIFF
--- a/src/components/doc-version/index.jsx
+++ b/src/components/doc-version/index.jsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'preact/hooks';
 import { useLocation, useRoute } from 'preact-iso';
-import config from '../../config.json';
+import { docRoutes } from '../../lib/route-utils.js';
 import style from './style.module.css';
 
 export const LATEST_MAJOR = 'v10';
@@ -17,7 +17,7 @@ export default function DocVersion() {
 	const onChange = useCallback(
 		e => {
 			const version = e.currentTarget.value;
-			const url = config.docs[version]?.[name]
+			const url = docRoutes[version]?.[`/${name}`]
 				? path.replace(/(v\d{1,2})/, version)
 				: `/guide/${version}/getting-started`;
 			route(url);


### PR DESCRIPTION
When switching between doc versions, we're meant to keep the user on the same page if it's available, i.e., v8 Forms -> v10 Forms. However, due to a bad check in the callback, every change of the doc version would send the user to the Getting Started page instead.

`config.docs` mirrors our sidebar hierarchy and so is a list of subsections ("Introduction", "Essentials", etc) that would have to be iterated over, but we have route utils to deal with this already.