### PR TITLE
refactor: Nest pages in llms.txt to match sidebar sections

### DIFF
--- a/src/lib/route-utils.js
+++ b/src/lib/route-utils.js
@@ -35,6 +35,14 @@ for (const k in config.docs) {
 	docRoutes[k] = flattenRoutes(config.docs[k]);
 }
 
+export const v10StructuredDocRoutes = [];
+for (const k of config.docs.v10) {
+	v10StructuredDocRoutes.push({
+		name: k.name.en,
+		routes: k.routes.map(route => route.path)
+	});
+}
+
 export const blogRoutes = flattenRoutes(config.blog);
 
 export const tutorialRoutes = flattenRoutes(config.tutorial);


### PR DESCRIPTION
Instead of listing out the pages bare and in alphabetical order like so:

```md
# Preact Documentation

...

**Description:** Learn more about all exported functions of the Preact module

## API Reference

...

## Component

...

## Components
```

this PR nests them to match the sidebar sections, creating more structure:

```md
# Preact Documentation

...

## Introduction

**Description:** How to get started with Preact. We'll learn how to setup the tooling (if any) and get going with writing an application

### Getting Started

...

#### No build tools route

...

### What's new in Preact X
```

---

This PR also corrects the heading hierarchy; whilst `#` was converted into `##`, this was the extent of the previous transformation. As you can see above, it means "API Reference" is at the same level as "Component" (that is the `Component` API, not the documentation for components) rather than nested with in.