### PR TITLE
chore: Correct formatting of Demos & Libraries pages

### DIFF
--- a/content/de/about/demos-examples.md
+++ b/content/de/about/demos-examples.md
@@ -12,78 +12,77 @@ Diese Seite zeigt einige Demos und Beispiele, die zum Erlernen von Preact benutz
 
 ## Vollständige Apps
 
-[**Preact Website** _(preactjs.com)_](https://preactjs.com)  
-Natürlich ist diese Website mit Preact erstellt.
-[GitHub-Projekt](https://github.com/preactjs/preact-www)
+**[Preact Website (preactjs.com)](https://preactjs.com)**<br>
+Natürlich ist diese Website mit Preact erstellt.<br>
+[GitHub Projekt](https://github.com/preactjs/preact-www)
 
-**[ESBench](http://esbench.com)** :alarm_clock:  
+**[ESBench](http://esbench.com)** :alarm_clock:<br>
 Erstellt mit Preact & Material Design Lite.
 
-[**GuriVR**](https://gurivr.com) :eyeglasses:
-Web VR-Geschichtenersteller basierend auf natürlicher Sprache.
-_([GitHub-Projekt](https://github.com/opennewslabs/guri-vr))_
+**[GuriVR](https://gurivr.com)** :eyeglasses:<br>
+Web VR-Geschichtenersteller basierend auf natürlicher Sprache.<br>
+[GitHub Projekt](https://github.com/opennewslabs/guri-vr)
 
-[**BigWebQuiz**](https://bigwebquiz.com) :game_die:  
-Die progressive Web App für Publikumspartizipation vom Chrome Dev Summit 2016!
-([GitHub-Projekt](https://github.com/jakearchibald/big-web-quiz))
+**[BigWebQuiz](https://bigwebquiz.com)** :game_die:<br>
+Die progressive Web App für Publikumspartizipation vom Chrome Dev Summit 2016!<br>
+[GitHub Projekt](https://github.com/jakearchibald/big-web-quiz)
 
-**[Nectarine.rocks](http://nectarine.rocks)** :peach:  
-Open-Source peach.cool App.  
-[GitHub-Projekt](https://github.com/developit/nectarine)
+**[Nectarine.rocks](http://nectarine.rocks)** :peach:<br>
+Open-Source peach.cool App.<br>
+[GitHub Projekt](https://github.com/developit/nectarine)
 
-**[Dropfox](https://github.com/developit/dropfox)** :wolf:  
+**[Dropfox](https://github.com/developit/dropfox)** :wolf:<br>
 Desktop-App für Dropbox, erstellt mit Preact, Electron und Photon.
 
-**[Connectivity Index](https://cindex.co)** :iphone:  
+**[Connectivity Index](https://cindex.co)** :iphone:<br>
 Eine Seite, die das Durchsuchen von Daten, geordnet nach Land, des [Akamai State of the Internet Connectivity Report](https://content.akamai.com/PG7010-Q2-2016-SOTI-Connectivity-Report.html) ermöglicht.
 
-**[Drag & Drop file upload (webpack 2)](https://contentful-labs.github.io/file-upload-example/)** :rocket:
-Desktop App zum Hochladen auf Contentful (API based CMS)
-[GitHub-Projekt](https://github.com/contentful-labs/file-upload-example)
+**[Drag & Drop file upload (webpack 2)](https://contentful-labs.github.io/file-upload-example/)** :rocket:<br>
+Desktop App zum Hochladen auf Contentful (API based CMS)<br>
+[GitHub Projekt](https://github.com/contentful-labs/file-upload-example)
 
-**[Embed Hacker News](https://github.com/TXTPEN/hn)** :kissing_closed_eyes:
+**[Embed Hacker News](https://github.com/TXTPEN/hn)** :kissing_closed_eyes:<br>
 Kommentarbaum für die Embed Hacker News unter dem eigenen Blogeintrag.
 
-**[ColoGuessr](https://cologuessr.com)** :rainbow:
-Testen Sie, wie gut Sie Ihre Farben kennen
-[Github Project](https://github.com/jackpordi/cologuessr)
+**[ColoGuessr](https://cologuessr.com)** :rainbow:<br>
+Testen Sie, wie gut Sie Ihre Farben kennen<br>
+[GitHub Project](https://github.com/jackpordi/cologuessr)
 
 ## Vollständige Demos & Beispiele
 
-**[Documentation Viewer](https://documentation-viewer.firebaseapp.com)**  
-Onlineansicht der Ausgabe von documentation.js.
-[GitHub-Projekt](https://github.com/developit/documentation-viewer)
+**[Documentation Viewer](https://documentation-viewer.firebaseapp.com)**<br>
+Onlineansicht der Ausgabe von documentation.js.<br>
+[GitHub Projekt](https://github.com/developit/documentation-viewer)
 
-**[TodoMVC](http://developit.github.io/preact-todomvc/)**  
-Inoffiziell schnellste TodoMVC-Implementierung.  
-[GitHub-Projekt](https://github.com/developit/preact-todomvc)
+**[TodoMVC](http://developit.github.io/preact-todomvc/)**<br>
+Inoffiziell schnellste TodoMVC-Implementierung.<br>
+[GitHub Projekt](https://github.com/developit/preact-todomvc)
 
-**[TodoMVC+PouchDB](http://katopz.github.io/preact-todomvc-pouchdb/)** :floppy_disk:  
-Synchronisiere TodoMVC offline mit [PouchDB](https://pouchdb.com/).  
-[GitHub-Projekt](https://github.com/katopz/preact-todomvc-pouchdb)
+**[TodoMVC+PouchDB](http://katopz.github.io/preact-todomvc-pouchdb/)** :floppy_disk:<br>
+Synchronisiere TodoMVC offline mit [PouchDB](https://pouchdb.com/).<br>
+[GitHub Projekt](https://github.com/katopz/preact-todomvc-pouchdb)
 
-**[Hacker News Minimal](https://developit.github.io/hn_minimal/)** :newspaper:  
-Kleine Hacker News-App.  
-[GitHub-Projekt](https://github.com/developit/hn_minimal)
+**[Hacker News Minimal](https://developit.github.io/hn_minimal/)** :newspaper:<br>
+Kleine Hacker News-App.<br>
+[GitHub Projekt](https://github.com/developit/hn_minimal)
 
-**[Preact Boilerplate](https://preact-boilerplate.surge.sh)** :zap:  
-Anfängerprojekt mit zwei Befehlen. Preact + Webpack + LESS + CSS Modules.  
-[GitHub-Projekt](https://github.com/developit/preact-boilerplate)
+**[Preact Boilerplate](https://preact-boilerplate.surge.sh)** :zap:<br>
+Anfängerprojekt mit zwei Befehlen. Preact + Webpack + LESS + CSS Modules.<br>
+[GitHub Projekt](https://github.com/developit/preact-boilerplate)
 
-**[Preact Offline Starter](https://preact-starter.now.sh)** :100:  
-Vereinfachter Webpack2-Starter für progressive Web Apps mit Offlinesupport.  
-[GitHub-Projekt](https://github.com/lukeed/preact-starter)
+**[Preact Offline Starter](https://preact-starter.now.sh)** :100:<br>
+Vereinfachter Webpack2-Starter für progressive Web Apps mit Offlinesupport.<br>
+[GitHub Projekt](https://github.com/lukeed/preact-starter)
 
-**[Preact Redux Example](https://preact-redux-example.surge.sh)** :repeat:  
-Preact + Redux-Beispielprojekt, das eine einfache To-Do-Liste implementiert.
-[GitHub-Projekt](https://github.com/developit/preact-redux-example)
+**[Preact Redux Example](https://preact-redux-example.surge.sh)** :repeat:<br>
+Preact + Redux-Beispielprojekt, das eine einfache To-Do-Liste implementiert.<br>
+[GitHub Projekt](https://github.com/developit/preact-redux-example)
 
-**[Preact Without Babel](https://github.com/developit/preact-without-babel)** :horse:  
+**[Preact Without Babel](https://github.com/developit/preact-without-babel)** :horse:<br>
 Wie man Preact gänzlich ohne Babes, ES2015 oder JSX benutzt.
 
-**[preact-minimal](https://github.com/aganglada/preact-minimal)** :rocket:  
+**[preact-minimal](https://github.com/aganglada/preact-minimal)** :rocket:<br>
 Kleine Preact-Struktur mit allen nötigen Werkzeugen um direkt mit seinem Projekt zu Starten.
-
 
 ## Codepens
 
@@ -95,6 +94,6 @@ Kleine Preact-Struktur mit allen nötigen Werkzeugen um direkt mit seinem Projek
 
 ## Vorlage
 
-:zap: [**JSFiddle Template**](https://jsfiddle.net/developit/rs6zrh5f/embedded/result/)
+:zap: **[JSFiddle Template](https://jsfiddle.net/developit/rs6zrh5f/embedded/result/)**
 
-:zap: [**CodePen Template**](http://codepen.io/developit/pen/pgaROe?editors=0010)
+:zap: **[CodePen Template](http://codepen.io/developit/pen/pgaROe?editors=0010)**

--- a/content/de/about/libraries-addons.md
+++ b/content/de/about/libraries-addons.md
@@ -13,45 +13,45 @@ Eine Auswahl an Modulen, die nahtlos mit Preact funktionieren.
 
 ### Add-Ons
 
-- :raised_hands: [**preact-compat**](https://github.com/preactjs/preact-compat): Jegliche React-Bibliothek mit Preact benutzen *([Vollständiges Beispiel](https://github.com/developit/preact-compat-example))*
-- :repeat: [**preact-cycle**](https://github.com/developit/preact-cycle): Funktionalreaktives Paradigma für Preact
-- :page_facing_up: [**preact-render-to-string**](https://github.com/preactjs/preact-render-to-string): Universelles Rendering.
+- :raised_hands: **[preact-compat](https://github.com/preactjs/preact-compat)**: Jegliche React-Bibliothek mit Preact benutzen *([Vollständiges Beispiel](https://github.com/developit/preact-compat-example))*
+- :repeat: **[preact-cycle](https://github.com/developit/preact-cycle)**: Funktionalreaktives Paradigma für Preact
+- :page_facing_up: **[preact-render-to-string](https://github.com/preactjs/preact-render-to-string)**: Universelles Rendering.
 
 
 ### Komponenten
 
-- :earth_americas: [**preact-router**](https://github.com/preactjs/preact-router): URL-Routing für eigene Komponenten
-- :bookmark_tabs: [**preact-markup**](https://github.com/developit/preact-markup): HTML & eigene Elemente als JSX & Komponenten rendern
-- :satellite: [**preact-portal**](https://github.com/developit/preact-portal): Rendern von Preact-Komponenten im (Welt-)Raum :milky_way:
-- :pencil: [**preact-richtextarea**](https://github.com/developit/preact-richtextarea): Simple HTML-Editor-Komponente
-- :bookmark: [**preact-token-input**](https://github.com/developit/preact-token-input): Textfeld, dass Eingabe für Zwecke wie z.B. Tags in Tokens übersetzt
-- :card_index: [**preact-virtual-list**](https://github.com/developit/preact-virtual-list): Listen mit Millionen Reihen einfach rendern([demo](https://jsfiddle.net/developit/qqan9pdo/))
-- :triangular_ruler: [**preact-layout**](https://download.github.io/preact-layout/): Kleine und simple Layout-Bibliothek
-- :construction_worker: [**preact-helmet**](https://github.com/download/preact-helmet): Ein Dokumentenkopf-Manager für Preact
-- :floppy_disk: [**preact-boot**](https://gitlab.com/cromefire_/preact-boot): Einfache, deklarative [Bootstrap 4](https://getbootstrap.com/) Komponenten für preact ([Lies die Dokumentation!](https://preactboot.rtfd.io) (Englisch)).
+- :earth_americas: **[preact-router](https://github.com/preactjs/preact-router)**: URL-Routing für eigene Komponenten
+- :bookmark_tabs: **[preact-markup](https://github.com/developit/preact-markup)**: HTML & eigene Elemente als JSX & Komponenten rendern
+- :satellite: **[preact-portal](https://github.com/developit/preact-portal)**: Rendern von Preact-Komponenten im (Welt-)Raum :milky_way:
+- :pencil: **[preact-richtextarea](https://github.com/developit/preact-richtextarea)**: Simple HTML-Editor-Komponente
+- :bookmark: **[preact-token-input](https://github.com/developit/preact-token-input)**: Textfeld, dass Eingabe für Zwecke wie z.B. Tags in Tokens übersetzt
+- :card_index: **[preact-virtual-list](https://github.com/developit/preact-virtual-list)**: Listen mit Millionen Reihen einfach rendern([demo](https://jsfiddle.net/developit/qqan9pdo/))
+- :triangular_ruler: **[preact-layout](https://download.github.io/preact-layout/)**: Kleine und simple Layout-Bibliothek
+- :construction_worker: **[preact-helmet](https://github.com/download/preact-helmet)**: Ein Dokumentenkopf-Manager für Preact
+- :floppy_disk: **[preact-boot](https://gitlab.com/cromefire_/preact-boot)**: Einfache, deklarative [Bootstrap 4](https://getbootstrap.com/) Komponenten für preact ([Lies die Dokumentation!](https://preactboot.rtfd.io) (Englisch)).
 
 
 ### Integrationen
 
-- :thought_balloon: [**preact-socrates**](https://github.com/matthewmueller/preact-socrates): Preact-Plugin für [Socrates](http://github.com/matthewmueller/socrates)
-- :rowboat: [**preact-flyd**](https://github.com/xialvjun/preact-flyd): [flyd](https://github.com/paldepind/flyd) FRP-Streams in Preact + JSX benutzen
-- :speech_balloon: [**preact-i18nline**](https://github.com/download/preact-i18nline): Das  [i18n-js](https://github.com/everydayhero/i18n-js)-Ökosystem mit Preact mithilfe von  [i18nline](https://github.com/download/i18nline) integrieren.
+- :thought_balloon: **[preact-socrates](https://github.com/matthewmueller/preact-socrates)**: Preact-Plugin für [Socrates](http://github.com/matthewmueller/socrates)
+- :rowboat: **[preact-flyd](https://github.com/xialvjun/preact-flyd)**: [flyd](https://github.com/paldepind/flyd) FRP-Streams in Preact + JSX benutzen
+- :speech_balloon: **[preact-i18nline](https://github.com/download/preact-i18nline)**: Das  [i18n-js](https://github.com/everydayhero/i18n-js)-Ökosystem mit Preact mithilfe von  [i18nline](https://github.com/download/i18nline) integrieren.
 
 
 ### GUI Toolkits
 
-- :white_square_button: [**preact-mdl**](https://github.com/developit/preact-mdl): [MDL](https://getmdl.io) als Preact-Komponenten benutzen
-- :rocket: [**preact-photon**](https://github.com/developit/preact-photon): Schöne Desktop UIs mit [photon](http://photonkit.com) erstellen
+- :white_square_button: **[preact-mdl](https://github.com/developit/preact-mdl)**: [MDL](https://getmdl.io) als Preact-Komponenten benutzen
+- :rocket: **[preact-photon](https://github.com/developit/preact-photon)**: Schöne Desktop UIs mit [photon](http://photonkit.com) erstellen
 
 
 ### Testen
 
-- :microscope: [**preact-jsx-chai**](https://github.com/developit/preact-jsx-chai): JSX-Behauptungen testen _(kein DOM, direkt in Node)_
-- :white_check_mark: [**unexpected-preact**](https://github.com/bruderstein/unexpected-preact): JSX-Behauptungen, Ereignisse, Momentaufnahmen in Jest _(DOM, funktioniert mit Node jsdom oder direkt von der Stange mit Jest)_ - [docs](https://bruderstein.github.io/unexpected-preact/)
+- :microscope: **[preact-jsx-chai](https://github.com/developit/preact-jsx-chai)**: JSX-Behauptungen testen _(kein DOM, direkt in Node)_
+- :white_check_mark: **[unexpected-preact](https://github.com/bruderstein/unexpected-preact)**: JSX-Behauptungen, Ereignisse, Momentaufnahmen in Jest _(DOM, funktioniert mit Node jsdom oder direkt von der Stange mit Jest)_ - [docs](https://bruderstein.github.io/unexpected-preact/)
 
 
 ### Dienstprogramme
 
-- :tophat: [**preact-classless-component**](https://github.com/ld0rman/preact-classless-component): Preact-Komponenten ohne Klassenschlagwörter erstellen
-- :hammer: [**preact-hyperscript**](https://github.com/queckezz/preact-hyperscript): Hyperscript-ähnliche Syntax zum Erstellen von Elementen
-- :white_check_mark: [**shallow-compare**](https://github.com/tkh44/shallow-compare): Vereinfachtes `shouldComponentUpdate` Hilfsprogramm.
+- :tophat: **[preact-classless-component](https://github.com/ld0rman/preact-classless-component)**: Preact-Komponenten ohne Klassenschlagwörter erstellen
+- :hammer: **[preact-hyperscript](https://github.com/queckezz/preact-hyperscript)**: Hyperscript-ähnliche Syntax zum Erstellen von Elementen
+- :white_check_mark: **[shallow-compare](https://github.com/tkh44/shallow-compare)**: Vereinfachtes `shouldComponentUpdate` Hilfsprogramm.

--- a/content/en/about/demos-examples.md
+++ b/content/en/about/demos-examples.md
@@ -10,115 +10,114 @@ This pages lists a bunch of demos and examples you can use to learn Preact.
 > :information_desk_person: _Built one of your own?
 > [Add it!](https://github.com/preactjs/preact-www/blob/master/content/en/about/demos-examples.md)_
 
-
 ## Full Apps
 
-[**Preact Website** _(preactjs.com)_](https://preactjs.com)  
-Of course this website is built with Preact.  
-[Github Project](https://github.com/preactjs/preact-www)
+**[Preact Website (preactjs.com)](https://preactjs.com)**<br>
+Of course this website is built with Preact.<br>
+[GitHub Project](https://github.com/preactjs/preact-www)
 
-**[ESBench](http://esbench.com)** :alarm_clock:  
+**[ESBench](http://esbench.com)** :alarm_clock:<br>
 Built with Preact & Material Design Lite.
 
-[**GuriVR**](https://gurivr.com) :eyeglasses:
-Natural language based Web VR story creator.  
-[Github Project](https://github.com/opennewslabs/guri-vr)
+**[GuriVR](https://gurivr.com)** :eyeglasses:<br>
+Natural language based Web VR story creator.<br>
+[GitHub Project](https://github.com/opennewslabs/guri-vr)
 
-[**BigWebQuiz**](https://bigwebquiz.com) :game_die:  
-The audience participation Progressive Web App from Chrome Dev Summit 2016!  
-[Github Project](https://github.com/jakearchibald/big-web-quiz)
+**[BigWebQuiz](https://bigwebquiz.com)** :game_die:<br>
+The audience participation Progressive Web App from Chrome Dev Summit 2016!<br>
+[GitHub Project](https://github.com/jakearchibald/big-web-quiz)
 
-**[Nectarine.rocks](http://nectarine.rocks)** :peach:  
-Open-Source peach.cool app.  
-[Github Project](https://github.com/developit/nectarine)
+**[Nectarine.rocks](http://nectarine.rocks)** :peach:<br>
+Open-Source peach.cool app.<br>
+[GitHub Project](https://github.com/developit/nectarine)
 
-**[Web Maker](https://webmaker.app/)** :zap:
-Blazing fast & offline frontend playground.
-[Github Project](https://github.com/chinchang/web-maker)
+**[Web Maker](https://webmaker.app/)** :zap:<br>
+Blazing fast & offline frontend playground.<br>
+[GitHub Project](https://github.com/chinchang/web-maker)
 
-**[BitMidi](https://bitmidi.com/)** :musical_keyboard:
-Wayback machine for free MIDI files
-[Github Project](https://github.com/feross/bitmidi.com)
+**[BitMidi](https://bitmidi.com/)** :musical_keyboard:<br>
+Wayback machine for free MIDI files<br>
+[GitHub Project](https://github.com/feross/bitmidi.com)
 
-**[BBC Roasting Calculator](https://www.bbc.com/food/techniques/articles/roast-calculator)** :turkey:
+**[BBC Roasting Calculator](https://www.bbc.com/food/techniques/articles/roast-calculator)** :turkey:<br>
 Calculates cooking times for different cuts of meat.
 
-**[Dropfox](https://github.com/developit/dropfox)** :wolf:  
+**[Dropfox](https://github.com/developit/dropfox)** :wolf:<br>
 Desktop app for Dropbox, built with Preact, Electron and Photon.
 
-**[Embed Hacker News](https://github.com/TXTPEN/hn)** :kissing_closed_eyes:
+**[Embed Hacker News](https://github.com/TXTPEN/hn)** :kissing_closed_eyes:<br>
 Embed Hacker News comment tree below your blog article.
 
-**[Connectivity Index](https://cindex.co)** :iphone:  
+**[Connectivity Index](https://cindex.co)** :iphone:<br>
 A site that allows you to search through [Akamai State of the Internet Connectivity Report](https://content.akamai.com/PG7010-Q2-2016-SOTI-Connectivity-Report.html) data by country.
 
-**[Drag & Drop file upload (webpack 2)](https://contentful-labs.github.io/file-upload-example/)** :rocket:
-Desktop App for uploading assets to Contentful (API based CMS)
-[Github Project](https://github.com/contentful-labs/file-upload-example)
+**[Drag & Drop file upload (webpack 2)](https://contentful-labs.github.io/file-upload-example/)** :rocket:<br>
+Desktop App for uploading assets to Contentful (API based CMS)<br>
+[GitHub Project](https://github.com/contentful-labs/file-upload-example)
 
-**[Exchange Widget](https://sgtpep.github.io/exchange-widget/dist/)** :currency_exchange:
-The currency exchange widget inspired by a popular mobile app implemented using Preact, Meiosis, HTML tagged templates and native ES modules.
-[Github Project](https://github.com/sgtpep/exchange-widget)
+**[Exchange Widget](https://sgtpep.github.io/exchange-widget/dist/)** :currency_exchange:<br>
+The currency exchange widget inspired by a popular mobile app implemented using Preact, Meiosis, HTML tagged templates and native ES modules.<br>
+[GitHub Project](https://github.com/sgtpep/exchange-widget)
 
-**[Blaze](https://blaze.now.sh)** :zap:  
-Modern peer-to-peer file sharing Progressive Web App.  
-[Github Project](https://github.com/blenderskool/blaze)
+**[Blaze](https://blaze.now.sh)** :zap:<br>
+Modern peer-to-peer file sharing Progressive Web App.<br>
+[GitHub Project](https://github.com/blenderskool/blaze)
 
-**[1tuner](https://1tuner.com)** :radio:  
-Listen to radio and podcasts.  
-[Github Project](https://github.com/robinbakker/1tuner)
+**[1tuner](https://1tuner.com)** :radio:<br>
+Listen to radio and podcasts.<br>
+[GitHub Project](https://github.com/robinbakker/1tuner)
 
-**[ColoGuessr](https://cologuessr.com)** :rainbow:
-Test how well you know your colors
-[Github Project](https://github.com/jackpordi/cologuessr)
+**[ColoGuessr](https://cologuessr.com)** :rainbow:<br>
+Test how well you know your colors<br>
+[GitHub Project](https://github.com/jackpordi/cologuessr)
 
 ## Full Demos & Examples
 
-**[Documentation Viewer](https://documentation-viewer.firebaseapp.com)**  
-View documentation.js output online.  
-[Github Project](https://github.com/developit/documentation-viewer)
+**[Documentation Viewer](https://documentation-viewer.firebaseapp.com)**<br>
+View documentation.js output online.<br>
+[GitHub Project](https://github.com/developit/documentation-viewer)
 
-**[TodoMVC](http://developit.github.io/preact-todomvc/)**  
-Unofficial fastest TodoMVC implementation.  
-[Github Project](https://github.com/developit/preact-todomvc)
+**[TodoMVC](http://developit.github.io/preact-todomvc/)**<br>
+Unofficial fastest TodoMVC implementation.<br>
+[GitHub Project](https://github.com/developit/preact-todomvc)
 
-**[TodoMVC+PouchDB](http://katopz.github.io/preact-todomvc-pouchdb/)** :floppy_disk:  
-Offline Sync TodoMVC with [PouchDB](https://pouchdb.com/).  
-[Github Project](https://github.com/katopz/preact-todomvc-pouchdb)
+**[TodoMVC+PouchDB](http://katopz.github.io/preact-todomvc-pouchdb/)** :floppy_disk:<br>
+Offline Sync TodoMVC with [PouchDB](https://pouchdb.com/).<br>
+[GitHub Project](https://github.com/katopz/preact-todomvc-pouchdb)
 
-**[Hacker News Minimal](https://developit.github.io/hn_minimal/)** :newspaper:  
-Tiny hacker news client.  
-[Github Project](https://github.com/developit/hn_minimal)
+**[Hacker News Minimal](https://developit.github.io/hn_minimal/)** :newspaper:<br>
+Tiny hacker news client.<br>
+[GitHub Project](https://github.com/developit/hn_minimal)
 
-**[Preact Boilerplate](https://preact-boilerplate.surge.sh)** :zap:  
-2 command starter project. Preact + Webpack + LESS + CSS Modules.  
-[Github Project](https://github.com/developit/preact-boilerplate)
+**[Preact Boilerplate](https://preact-boilerplate.surge.sh)** :zap:<br>
+2 command starter project. Preact + Webpack + LESS + CSS Modules.<br>
+[GitHub Project](https://github.com/developit/preact-boilerplate)
 
-**[Preact Offline Starter](https://preact-starter.now.sh)** :100:  
-Simplified Webpack2 starter for Progressive Web Apps, with offline support.  
-[Github Project](https://github.com/lukeed/preact-starter)
+**[Preact Offline Starter](https://preact-starter.now.sh)** :100:<br>
+Simplified Webpack2 starter for Progressive Web Apps, with offline support.<br>
+[GitHub Project](https://github.com/lukeed/preact-starter)
 
-**[Preact Redux Example](https://preact-redux-example.surge.sh)** :repeat:  
-Preact + Redux example project, implementing a simple To-Do list.  
-[Github Project](https://github.com/developit/preact-redux-example)
+**[Preact Redux Example](https://preact-redux-example.surge.sh)** :repeat:<br>
+Preact + Redux example project, implementing a simple To-Do list.<br>
+[GitHub Project](https://github.com/developit/preact-redux-example)
 
-**[Preact Without Babel](https://github.com/developit/preact-without-babel)** :horse:  
+**[Preact Without Babel](https://github.com/developit/preact-without-babel)** :horse:<br>
 How to use Preact entirely without Babel, ES2015 or JSX.
 
-**[preact-minimal](https://github.com/aganglada/preact-minimal)** :rocket:  
+**[preact-minimal](https://github.com/aganglada/preact-minimal)** :rocket:<br>
 Minimal Preact structure with all the necessary tools to start your project right away.
 
-**[preact-typescript-webpack4-less](https://github.com/lexey111/preact-typescript-webpack4-boilerplate)**
+**[preact-typescript-webpack4-less](https://github.com/lexey111/preact-typescript-webpack4-boilerplate)**<br>
 Another one minimal set with Preact, Typescript and Webpack 4.
 
-**[Preact Homepage Generator](https://thomaswood.me/)** :globe_with_meridians:  
-Quickly spin up a new personal webpage by only needing to modify JSON data.
-[Github Project](https://github.com/tomasswood/preact-homepage-generator)
+**[Preact Homepage Generator](https://thomaswood.me/)** :globe_with_meridians:<br>
+Quickly spin up a new personal webpage by only needing to modify JSON data.<br>
+[GitHub Project](https://github.com/tomasswood/preact-homepage-generator)
 
-**[Parcel + Preact + Unistore Starter](https://github.com/hwclass/parcel-preact-unistore-starter)**
+**[Parcel + Preact + Unistore Starter](https://github.com/hwclass/parcel-preact-unistore-starter)**<br>
 Starter pack for lightning-fast prototyping and small/medium size project structure
 
-**[buildless-preact-starter](https://github.com/ttntm/buildless-preact-starter)** :rocket:
+**[buildless-preact-starter](https://github.com/ttntm/buildless-preact-starter)** :rocket:<br>
 A starter/template for using Preact in buildless environments
 
 ## Codepens
@@ -132,6 +131,6 @@ A starter/template for using Preact in buildless environments
 
 ## Templates
 
-:zap: [**JSFiddle Template**](https://jsfiddle.net/developit/rs6zrh5f/embedded/result/)
+:zap: **[JSFiddle Template](https://jsfiddle.net/developit/rs6zrh5f/embedded/result/)**
 
-:zap: [**CodePen Template**](http://codepen.io/developit/pen/pgaROe?editors=0010)
+:zap: **[CodePen Template](http://codepen.io/developit/pen/pgaROe?editors=0010)**

--- a/content/en/about/libraries-addons.md
+++ b/content/en/about/libraries-addons.md
@@ -12,53 +12,53 @@ A collection of modules built to work wonderfully with Preact.
 
 ## Add-Ons
 
-- :repeat: [**preact-cycle**](https://github.com/developit/preact-cycle): Functional-reactive paradigm for Preact
-- :page_facing_up: [**preact-render-to-string**](https://github.com/preactjs/preact-render-to-string): Universal rendering.
-- :timer_clock: [**relaks**](https://github.com/trambarhq/relaks): Create components with render methods that return asynchronously.
-- :nut_and_bolt: [**express-preact-views**](https://github.com/edwjusti/express-preact-views): Express View Engine.
-- :floppy_disk: [**Prefresh**](https://github.com/JoviDeCroock/prefresh): Fast-Refresh for Preact.
-- :bookmark_tabs: [**adonis-preact**](https://github.com/DonsWayo/adonis-preact): Use Preact in Adonisjs
+- :repeat: **[preact-cycle](https://github.com/developit/preact-cycle)**: Functional-reactive paradigm for Preact
+- :page_facing_up: **[preact-render-to-string](https://github.com/preactjs/preact-render-to-string)**: Universal rendering.
+- :timer_clock: **[relaks](https://github.com/trambarhq/relaks)**: Create components with render methods that return asynchronously.
+- :nut_and_bolt: **[express-preact-views](https://github.com/edwjusti/express-preact-views)**: Express View Engine.
+- :floppy_disk: **[Prefresh](https://github.com/JoviDeCroock/prefresh)**: Fast-Refresh for Preact.
+- :bookmark_tabs: **[adonis-preact](https://github.com/DonsWayo/adonis-preact)**: Use Preact in Adonisjs
 
 ## Components
 
-- :earth_americas: [**preact-router**](https://github.com/preactjs/preact-router): URL routing for your components
-- :bookmark_tabs: [**preact-markup**](https://github.com/developit/preact-markup): Render HTML & Custom Elements as JSX & Components
-- :satellite: [**preact-portal**](https://github.com/developit/preact-portal): Render Preact components into (a) SPACE :milky_way:
-- :pencil: [**preact-richtextarea**](https://github.com/developit/preact-richtextarea): Simple HTML editor component
-- :bookmark: [**preact-token-input**](https://github.com/developit/preact-token-input): Text field that tokenizes input, for things like tags
-- :card_index: [**preact-virtual-list**](https://github.com/developit/preact-virtual-list): Easily render lists with millions of rows ([demo](https://jsfiddle.net/developit/qqan9pdo/))
-- :triangular_ruler: [**preact-layout**](https://download.github.io/preact-layout/): Small and simple layout library
-- :construction_worker: [**preact-helmet**](https://github.com/download/preact-helmet): A document head manager for Preact
-- :arrow_up_down: [**preact-custom-scrollbars**](https://github.com/lucafalasco/preact-custom-scrollbars): Fully customizable scrollbars, for frictionless native browser scrolling
-- 🧱 [**@modular-forms/preact**](https://modularforms.dev/): Modular and type-safe form library
+- :earth_americas: **[preact-router](https://github.com/preactjs/preact-router)**: URL routing for your components
+- :bookmark_tabs: **[preact-markup](https://github.com/developit/preact-markup)**: Render HTML & Custom Elements as JSX & Components
+- :satellite: **[preact-portal](https://github.com/developit/preact-portal)**: Render Preact components into (a) SPACE :milky_way:
+- :pencil: **[preact-richtextarea](https://github.com/developit/preact-richtextarea)**: Simple HTML editor component
+- :bookmark: **[preact-token-input](https://github.com/developit/preact-token-input)**: Text field that tokenizes input, for things like tags
+- :card_index: **[preact-virtual-list](https://github.com/developit/preact-virtual-list)**: Easily render lists with millions of rows ([demo](https://jsfiddle.net/developit/qqan9pdo/))
+- :triangular_ruler: **[preact-layout](https://download.github.io/preact-layout/)**: Small and simple layout library
+- :construction_worker: **[preact-helmet](https://github.com/download/preact-helmet)**: A document head manager for Preact
+- :arrow_up_down: **[preact-custom-scrollbars](https://github.com/lucafalasco/preact-custom-scrollbars)**: Fully customizable scrollbars, for frictionless native browser scrolling
+- 🧱 **[@modular-forms/preact](https://modularforms.dev/)**: Modular and type-safe form library
 
 ## Integrations
 
-- :thought_balloon: [**preact-socrates**](https://github.com/matthewmueller/preact-socrates): Preact plugin for [Socrates](http://github.com/matthewmueller/socrates)
-- :rowboat: [**preact-flyd**](https://github.com/xialvjun/preact-flyd): Use [flyd](https://github.com/paldepind/flyd) FRP streams in Preact + JSX
-- :speech_balloon: [**preact-i18nline**](https://github.com/download/preact-i18nline): Integrates the ecosystem around [i18n-js](https://github.com/everydayhero/i18n-js) with Preact via [i18nline](https://github.com/download/i18nline).
-- :diamond_shape_with_a_dot_inside: [**Capacitor**](https://capacitorjs.com/solution/preact): Turn your Preact app into a Native iOS/Android App and PWA.
-- :ice_cube: [**Kretes**](https://kretes.dev/docs/howtos/preact-setup/): Build full-stack TypeScript apps using Preact and Node.js
-- 🏝: [**preact-island**](https://github.com/mwood23/preact-island): Run your Preact widget on any website with reactive props.
+- :thought_balloon: **[preact-socrates](https://github.com/matthewmueller/preact-socrates)**: Preact plugin for [Socrates](http://github.com/matthewmueller/socrates)
+- :rowboat: **[preact-flyd](https://github.com/xialvjun/preact-flyd)**: Use [flyd](https://github.com/paldepind/flyd) FRP streams in Preact + JSX
+- :speech_balloon: **[preact-i18nline](https://github.com/download/preact-i18nline)**: Integrates the ecosystem around [i18n-js](https://github.com/everydayhero/i18n-js) with Preact via [i18nline](https://github.com/download/i18nline).
+- :diamond_shape_with_a_dot_inside: **[Capacitor](https://capacitorjs.com/solution/preact)**: Turn your Preact app into a Native iOS/Android App and PWA.
+- :ice_cube: **[Kretes](https://kretes.dev/docs/howtos/preact-setup/)**: Build full-stack TypeScript apps using Preact and Node.js
+- 🏝: **[preact-island](https://github.com/mwood23/preact-island)**: Run your Preact widget on any website with reactive props.
 
 ## GUI Toolkits
 
-- 🎴 [**@mui/material**](https://github.com/mui/material-ui/tree/master/examples/material-ui-preact): the React UI library you always wanted. Follow your own design system, or start with Material Design.
-- :thumbsup: [**preact-material-components**](https://github.com/prateekbh/preact-material-components): Material Components for the Web (supersedes MDL)
-- :white_square_button: [**preact-mdl**](https://github.com/developit/preact-mdl): Use [MDL](https://getmdl.io) as Preact components
-- :rocket: [**preact-photon**](https://github.com/developit/preact-photon): build beautiful desktop UI with [photon](http://photonkit.com)
-- :penguin: [**preact-weui**](https://github.com/afeiship/preact-weui): [Weui](https://github.com/afeiship/preact-weui) for Preact
-- 💅 [**preact-fluid**](https://github.com/ajainvivek/preact-fluid): [Fluid](https://github.com/ajainvivek/preact-fluid) minimal UI kit for Preact
-- :book: [**storybook-preact**](https://github.com/storybooks/storybook/tree/next/app/preact): Storybook for Preact is a UI development environment for your Preact components
+- 🎴 **[@mui/material](https://github.com/mui/material-ui/tree/master/examples/material-ui-preact)**: the React UI library you always wanted. Follow your own design system, or start with Material Design.
+- :thumbsup: **[preact-material-components](https://github.com/prateekbh/preact-material-components)**: Material Components for the Web (supersedes MDL)
+- :white_square_button: **[preact-mdl](https://github.com/developit/preact-mdl)**: Use [MDL](https://getmdl.io) as Preact components
+- :rocket: **[preact-photon](https://github.com/developit/preact-photon)**: build beautiful desktop UI with [photon](http://photonkit.com)
+- :penguin: **[preact-weui](https://github.com/afeiship/preact-weui)**: [Weui](https://github.com/afeiship/preact-weui) for Preact
+- 💅 **[preact-fluid](https://github.com/ajainvivek/preact-fluid)**: [Fluid](https://github.com/ajainvivek/preact-fluid) minimal UI kit for Preact
+- :book: **[storybook-preact](https://github.com/storybooks/storybook/tree/next/app/preact)**: Storybook for Preact is a UI development environment for your Preact components
 
 ### Testing
 
-- :microscope: [**preact-jsx-chai**](https://github.com/developit/preact-jsx-chai): JSX assertion testing _(no DOM, right in Node)_
-- :white_check_mark: [**unexpected-preact**](https://github.com/bruderstein/unexpected-preact): JSX assertions, events, snapshots in Jest _(DOM, works under Node jsdom or out-of-the-box in Jest)_ - [docs](https://bruderstein.github.io/unexpected-preact/)
+- :microscope: **[preact-jsx-chai](https://github.com/developit/preact-jsx-chai)**: JSX assertion testing _(no DOM, right in Node)_
+- :white_check_mark: **[unexpected-preact](https://github.com/bruderstein/unexpected-preact)**: JSX assertions, events, snapshots in Jest _(DOM, works under Node jsdom or out-of-the-box in Jest)_ - [docs](https://bruderstein.github.io/unexpected-preact/)
 
 ## Utilities
 
-- :tophat: [**preact-classless-component**](https://github.com/ld0rman/preact-classless-component): create preact components without the class keyword
-- :hammer: [**preact-hyperscript**](https://github.com/queckezz/preact-hyperscript): Hyperscript-like syntax for creating elements
-- :white_check_mark: [**shallow-compare**](https://github.com/tkh44/shallow-compare): simplified `shouldComponentUpdate` helper.
-- :signal_strength: [**@deepsignal/preact**](https://github.com/EthanStandel/deepsignal/tree/main/packages/preact): Extension of `@preact/signals` for full state management
+- :tophat: **[preact-classless-component](https://github.com/ld0rman/preact-classless-component)**: create preact components without the class keyword
+- :hammer: **[preact-hyperscript](https://github.com/queckezz/preact-hyperscript)**: Hyperscript-like syntax for creating elements
+- :white_check_mark: **[shallow-compare](https://github.com/tkh44/shallow-compare)**: simplified `shouldComponentUpdate` helper.
+- :signal_strength: **[@deepsignal/preact](https://github.com/EthanStandel/deepsignal/tree/main/packages/preact)**: Extension of `@preact/signals` for full state management

--- a/content/es/about/demos-examples.md
+++ b/content/es/about/demos-examples.md
@@ -9,64 +9,62 @@ Esta página contiene una serie de demos y ejemplos que puedes utilizar para apr
 > :information_desk_person: _¿Creaste uno por tu cuenta?
 > [¡Agregalo!](https://github.com/preactjs/preact-www/blob/master/content/es/about/demos-examples.md)_
 
-
 ## Full Apps
 
-[**Preact Website** _(preactjs.com)_](https://preactjs.com)  
-Por supuesto, este sitio está construído con Preact.  
-[Github Project](https://github.com/preactjs/preact-www)
+**[Preact Website (preactjs.com)](https://preactjs.com)**<br>
+Por supuesto, este sitio está construído con Preact.<br>
+[GitHub Project](https://github.com/preactjs/preact-www)
 
-**[ESBench](http://esbench.com)** :alarm_clock:  
+**[ESBench](http://esbench.com)** :alarm_clock:<br>
 Construido con Preact y Material Design Lite.
 
-[**GuriVR**](https://gurivr.com) :eyeglasses:  
-Natural language based Web VR story creator.  
-_([Github Project](https://github.com/opennewslabs/guri-vr))_
+**[GuriVR](https://gurivr.com)** :eyeglasses:<br>
+Natural language based Web VR story creator.<br>
+[GitHub Project](https://github.com/opennewslabs/guri-vr)
 
-[**BigWebQuiz**](https://bigwebquiz.com) :game_die:  
-The audience participation Progressive Web App from Chrome Dev Summit 2016!  
-([Github Project](https://github.com/jakearchibald/big-web-quiz))
+**[BigWebQuiz](https://bigwebquiz.com)** :game_die:<br>
+The audience participation Progressive Web App from Chrome Dev Summit 2016!<br>
+[GitHub Project](https://github.com/jakearchibald/big-web-quiz)
 
-**[Nectarine.rocks](http://nectarine.rocks)** :peach:  
-Open-Source peach.cool app.  
-[Github Project](https://github.com/developit/nectarine)
+**[Nectarine.rocks](http://nectarine.rocks)** :peach:<br>
+Open-Source peach.cool app.<br>
+[GitHub Project](https://github.com/developit/nectarine)
 
-**[Dropfox](https://github.com/developit/dropfox)** :wolf:  
+**[Dropfox](https://github.com/developit/dropfox)** :wolf:<br>
 Aplicación Desktop para Dropbox, construída con Preact, Electron y Photon.
 
-**[ColoGuessr](https://cologuessr.com)** :rainbow:
-Comprueba lo bien que conoces tus colores
-[Github Project](https://github.com/jackpordi/cologuessr)
+**[ColoGuessr](https://cologuessr.com)** :rainbow:<br>
+Comprueba lo bien que conoces tus colores<br>
+[GitHub Project](https://github.com/jackpordi/cologuessr)
 
 ## Full Demos y Ejemplos
 
-**[Documentation Viewer](https://documentation-viewer.firebaseapp.com)**  
-View documentation.js output online.  
-[Github Project](https://github.com/developit/documentation-viewer)
+**[Documentation Viewer](https://documentation-viewer.firebaseapp.com)**<br>
+View documentation.js output online.<br>
+[GitHub Project](https://github.com/developit/documentation-viewer)
 
-**[TodoMVC](http://developit.github.io/preact-todomvc/)**  
-Una implementación rápida de TodoMVC (no oficial).
-[Github Project](https://github.com/developit/preact-todomvc)
+**[TodoMVC](http://developit.github.io/preact-todomvc/)**<br>
+Una implementación rápida de TodoMVC (no oficial).<br>
+[GitHub Project](https://github.com/developit/preact-todomvc)
 
-**[TodoMVC+PouchDB](http://katopz.github.io/preact-todomvc-pouchdb/)** :floppy_disk:  
-Offline Sync TodoMVC con [PouchDB](https://pouchdb.com/).  
-[Github Project](https://github.com/katopz/preact-todomvc-pouchdb)
+**[TodoMVC+PouchDB](http://katopz.github.io/preact-todomvc-pouchdb/)** :floppy_disk:<br>
+Offline Sync TodoMVC con [PouchDB](https://pouchdb.com/).<br>
+[GitHub Project](https://github.com/katopz/preact-todomvc-pouchdb)
 
-**[Hacker News Minimal](https://developit.github.io/hn_minimal/)** :newspaper:  
-Un pequeño cliente de hacker news.
-[Github Project](https://github.com/developit/hn_minimal)
+**[Hacker News Minimal](https://developit.github.io/hn_minimal/)** :newspaper:<br>
+Un pequeño cliente de hacker news.<br>
+[GitHub Project](https://github.com/developit/hn_minimal)
 
-**[Preact Boilerplate](https://preact-boilerplate.surge.sh)** :zap:  
-2 command starter project. Preact + Webpack + LESS + CSS Modules.  
-[Github Project](https://github.com/developit/preact-boilerplate)
+**[Preact Boilerplate](https://preact-boilerplate.surge.sh)** :zap:<br>
+2 command starter project. Preact + Webpack + LESS + CSS Modules.<br>
+[GitHub Project](https://github.com/developit/preact-boilerplate)
 
-**[Preact Redux Example](https://preact-redux-example.surge.sh)** :repeat:  
-Un proyecto de ejemplo con Preact + Redux, implementado una simple lista de To-Do.
-[Github Project](https://github.com/developit/preact-redux-example)
+**[Preact Redux Example](https://preact-redux-example.surge.sh)** :repeat:<br>
+Un proyecto de ejemplo con Preact + Redux, implementado una simple lista de To-Do.<br>
+[GitHub Project](https://github.com/developit/preact-redux-example)
 
-**[Preact Without Babel](https://github.com/developit/preact-without-babel)** :horse:  
+**[Preact Without Babel](https://github.com/developit/preact-without-babel)** :horse:<br>
 ¿Cómo utilizar Preact completamente sin Babel, ES2015 o JSX?
-
 
 ## Codepens
 
@@ -78,6 +76,6 @@ Un proyecto de ejemplo con Preact + Redux, implementado una simple lista de To-D
 
 ## Templates
 
-:zap: [**JSFiddle Template**](https://jsfiddle.net/developit/rs6zrh5f/embedded/result/)
+:zap: **[JSFiddle Template](https://jsfiddle.net/developit/rs6zrh5f/embedded/result/)**
 
-:zap: [**CodePen Template**](http://codepen.io/developit/pen/pgaROe?editors=0010)
+:zap: **[CodePen Template](http://codepen.io/developit/pen/pgaROe?editors=0010)**

--- a/content/es/about/libraries-addons.md
+++ b/content/es/about/libraries-addons.md
@@ -12,42 +12,42 @@ Una colección de módulos construidos para trabajar perfectamente con Preact.
 
 ### Complementos
 
-- :raised_hands: [**preact-compat**](https://github.com/preactjs/preact-compat): utilizar cualquier librería de React con Preact *([full example](https://github.com/developit/preact-compat-example))*
-- :repeat: [**preact-cycle**](https://github.com/developit/preact-cycle): Paradigma funcional-reactivo para Preact
-- :page_facing_up: [**preact-render-to-string**](https://github.com/preactjs/preact-render-to-string): Universal rendering.
+- :raised_hands: **[preact-compat](https://github.com/preactjs/preact-compat)**: utilizar cualquier librería de React con Preact *([full example](https://github.com/developit/preact-compat-example))*
+- :repeat: **[preact-cycle](https://github.com/developit/preact-cycle)**: Paradigma funcional-reactivo para Preact
+- :page_facing_up: **[preact-render-to-string](https://github.com/preactjs/preact-render-to-string)**: Universal rendering.
 
 
 ### Componentes
 
-- :earth_americas: [**preact-router**](https://github.com/preactjs/preact-router): URL routing para tus componentes
-- :bookmark_tabs: [**preact-markup**](https://github.com/developit/preact-markup): Render HTML & Custom Elements as JSX & Components
-- :satellite: [**preact-portal**](https://github.com/developit/preact-portal): Render Preact components into (a) SPACE :milky_way:
-- :pencil: [**preact-richtextarea**](https://github.com/developit/preact-richtextarea): Simple HTML editor component
-- :bookmark: [**preact-token-input**](https://github.com/developit/preact-token-input): Text field that tokenizes input, for things like tags
-- :card_index: [**preact-virtual-list**](https://github.com/developit/preact-virtual-list): Easily render lists with millions of rows ([demo](https://jsfiddle.net/developit/qqan9pdo/))
-- :triangular_ruler: [**preact-layout**](https://download.github.io/preact-layout/): Small and simple layout library
+- :earth_americas: **[preact-router](https://github.com/preactjs/preact-router)**: URL routing para tus componentes
+- :bookmark_tabs: **[preact-markup](https://github.com/developit/preact-markup)**: Render HTML & Custom Elements as JSX & Components
+- :satellite: **[preact-portal](https://github.com/developit/preact-portal)**: Render Preact components into (a) SPACE :milky_way:
+- :pencil: **[preact-richtextarea](https://github.com/developit/preact-richtextarea)**: Simple HTML editor component
+- :bookmark: **[preact-token-input](https://github.com/developit/preact-token-input)**: Text field that tokenizes input, for things like tags
+- :card_index: **[preact-virtual-list](https://github.com/developit/preact-virtual-list)**: Easily render lists with millions of rows ([demo](https://jsfiddle.net/developit/qqan9pdo/))
+- :triangular_ruler: **[preact-layout](https://download.github.io/preact-layout/)**: Small and simple layout library
 
 
 ### Integraciones
 
-- :thought_balloon: [**preact-socrates**](https://github.com/matthewmueller/preact-socrates): Preact plugin for [Socrates](http://github.com/matthewmueller/socrates)
-- :rowboat: [**preact-flyd**](https://github.com/xialvjun/preact-flyd): Use [flyd](https://github.com/paldepind/flyd) FRP streams in Preact + JSX
-- :speech_balloon: [**preact-i18nline**](https://github.com/download/preact-i18nline): Integrates the ecosystem around [i18n-js](https://github.com/everydayhero/i18n-js) with Preact via [i18nline](https://github.com/download/i18nline).
+- :thought_balloon: **[preact-socrates](https://github.com/matthewmueller/preact-socrates)**: Preact plugin for [Socrates](http://github.com/matthewmueller/socrates)
+- :rowboat: **[preact-flyd](https://github.com/xialvjun/preact-flyd)**: Use [flyd](https://github.com/paldepind/flyd) FRP streams in Preact + JSX
+- :speech_balloon: **[preact-i18nline](https://github.com/download/preact-i18nline)**: Integrates the ecosystem around [i18n-js](https://github.com/everydayhero/i18n-js) with Preact via [i18nline](https://github.com/download/i18nline).
 
 
 ### GUI Toolkits
 
-- :white_square_button: [**preact-mdl**](https://github.com/developit/preact-mdl): Usa [MDL](https://getmdl.io) como componente de Preact
-- :rocket: [**preact-photon**](https://github.com/developit/preact-photon): construye hermosas interfaces de escritorio con [photon](http://photonkit.com)
+- :white_square_button: **[preact-mdl](https://github.com/developit/preact-mdl)**: Usa [MDL](https://getmdl.io) como componente de Preact
+- :rocket: **[preact-photon](https://github.com/developit/preact-photon)**: construye hermosas interfaces de escritorio con [photon](http://photonkit.com)
 
 
 ### Testing
 
-- :microscope: [**preact-jsx-chai**](https://github.com/developit/preact-jsx-chai): JSX assertion testing _(no DOM, right in Node)_
+- :microscope: **[preact-jsx-chai](https://github.com/developit/preact-jsx-chai)**: JSX assertion testing _(no DOM, right in Node)_
 
 
 ### Utilidades
 
-- :tophat: [**preact-classless-component**](https://github.com/ld0rman/preact-classless-component): crea componentes de preact sin la palabra clave class
-- :hammer: [**preact-hyperscript**](https://github.com/queckezz/preact-hyperscript): Hyperscript-like syntax for creating elements
-- :white_check_mark: [**shallow-compare**](https://github.com/tkh44/shallow-compare): helper simplificado de `shouldComponentUpdate`.
+- :tophat: **[preact-classless-component](https://github.com/ld0rman/preact-classless-component)**: crea componentes de preact sin la palabra clave class
+- :hammer: **[preact-hyperscript](https://github.com/queckezz/preact-hyperscript)**: Hyperscript-like syntax for creating elements
+- :white_check_mark: **[shallow-compare](https://github.com/tkh44/shallow-compare)**: helper simplificado de `shouldComponentUpdate`.

--- a/content/fr/about/demos-examples.md
+++ b/content/fr/about/demos-examples.md
@@ -9,81 +9,79 @@ Cette page liste un certain nombre de démos et d'exemples utiles pour apprendre
 > :information_desk_person: _Vous avez écrit le/la vôtre ?
 > [Ajoutez le/la!](https://github.com/preactjs/preact-www/blob/master/content/fr/about/demos-examples.md)_
 
-
 ## Applications complètes
 
-[**Site web de Preact** _(preactjs.com)_](https://preactjs.com)  
-Bien sûr ce site web est construit avec Preact.
-[Projet Github](https://github.com/preactjs/preact-www)
+**[Site web de Preact (preactjs.com)](https://preactjs.com)**<br>
+Bien sûr ce site web est construit avec Preact.<br>
+[Projet GitHub](https://github.com/preactjs/preact-www)
 
-**[ESBench](http://esbench.com)** :alarm_clock:  
+**[ESBench](http://esbench.com)** :alarm_clock:<br>
 Construit avec Preact et Material Design Lite.
 
-[**GuriVR**](https://gurivr.com) :eyeglasses:
-Créateur d'histoires Web VR basé sur le langage naturel.
-_([Projet Github](https://github.com/opennewslabs/guri-vr))_
+**[GuriVR](https://gurivr.com)** :eyeglasses:<br>
+Créateur d'histoires Web VR basé sur le langage naturel.<br>
+_([Projet GitHub](https://github.com/opennewslabs/guri-vr))_
 
-[**BigWebQuiz**](https://bigwebquiz.com) :game_die:  
-La Progessive Web App de participation du public du Chrome Dev Summit 2016 !
-([Projet Github](https://github.com/jakearchibald/big-web-quiz))
+**[BigWebQuiz](https://bigwebquiz.com)** :game_die:<br>
+La Progessive Web App de participation du public du Chrome Dev Summit 2016 !<br>
+([Projet GitHub](https://github.com/jakearchibald/big-web-quiz))
 
-**[Nectarine.rocks](http://nectarine.rocks)** :peach:  
-Une application Open-Source pour peach.cool.
-[Projet Github](https://github.com/developit/nectarine)
+**[Nectarine.rocks](http://nectarine.rocks)** :peach:<br>
+Une application Open-Source pour peach.cool.<br>
+[Projet GitHub](https://github.com/developit/nectarine)
 
-**[Dropfox](https://github.com/developit/dropfox)** :wolf:  
+**[Dropfox](https://github.com/developit/dropfox)** :wolf:<br>
 Une application bureau pour Dropbox, créée avec Preact, Electron et Photon.
 
-**[Connectivity Index](https://cindex.co)** :iphone:  
+**[Connectivity Index](https://cindex.co)** :iphone:<br>
 Un site web qui vous permet de faire des recherches par pays dans les données du [Akamai State of the Internet Connectivity Report](https://content.akamai.com/PG7010-Q2-2016-SOTI-Connectivity-Report.html).
 
-**[Drag & Drop file upload (webpack 2)](https://contentful-labs.github.io/file-upload-example/)** :rocket:
-Une application bureau pour envoyer des ressources sur Contentful (un CMS basé sur une API)
-[Projet Github](https://github.com/contentful-labs/file-upload-example)
+**[Drag & Drop file upload (webpack 2)](https://contentful-labs.github.io/file-upload-example/)** :rocket:<br>
+Une application bureau pour envoyer des ressources sur Contentful (un CMS basé sur une API)<br>
+[Projet GitHub](https://github.com/contentful-labs/file-upload-example)
 
-**[Embed Hacker News](https://github.com/TXTPEN/hn)** :kissing_closed_eyes:
+**[Embed Hacker News](https://github.com/TXTPEN/hn)** :kissing_closed_eyes:<br>
 Embarquez l'arbre de commentaires de Hacker News sous votre article de blog.
 
-**[ColoGuessr](https://cologuessr.com)** :rainbow:
-Vérifiez si vous connaissez bien vos couleurs
-[Github Project](https://github.com/jackpordi/cologuessr)
+**[ColoGuessr](https://cologuessr.com)** :rainbow:<br>
+Vérifiez si vous connaissez bien vos couleurs<br>
+[GitHub Project](https://github.com/jackpordi/cologuessr)
 
 ## Démos entières et Exemples
 
-**[Documentation Viewer](https://documentation-viewer.firebaseapp.com)**
-Voir le résultat de documentation.js en ligne.
-[Projet Github](https://github.com/developit/documentation-viewer)
+**[Documentation Viewer](https://documentation-viewer.firebaseapp.com)**<br>
+Voir le résultat de documentation.js en ligne.<br>
+[Projet GitHub](https://github.com/developit/documentation-viewer)
 
-**[TodoMVC](http://developit.github.io/preact-todomvc/)**
-L'implémentation non officielle de TodoMVC la plus rapide.
-[Projet Github](https://github.com/developit/preact-todomvc)
+**[TodoMVC](http://developit.github.io/preact-todomvc/)**<br>
+L'implémentation non officielle de TodoMVC la plus rapide.<br>
+[Projet GitHub](https://github.com/developit/preact-todomvc)
 
-**[TodoMVC+PouchDB](http://katopz.github.io/preact-todomvc-pouchdb/)** :floppy_disk:  
-Synchronisez TodoMVC avec [PouchDB](https://pouchdb.com/) hors ligne.  
-[Projet Github](https://github.com/katopz/preact-todomvc-pouchdb)
+**[TodoMVC+PouchDB](http://katopz.github.io/preact-todomvc-pouchdb/)** :floppy_disk:<br>
+Synchronisez TodoMVC avec [PouchDB](https://pouchdb.com/) hors ligne.<br>
+[Projet GitHub](https://github.com/katopz/preact-todomvc-pouchdb)
 
-**[Hacker News Minimal](https://developit.github.io/hn_minimal/)** :newspaper:  
-Un client hacker news léger.
-[Projet Github](https://github.com/developit/hn_minimal)
+**[Hacker News Minimal](https://developit.github.io/hn_minimal/)** :newspaper:<br>
+Un client hacker news léger.<br>
+[Projet GitHub](https://github.com/developit/hn_minimal)
 
-**[Preact Boilerplate](https://preact-boilerplate.surge.sh)** :zap:
-Un starter de projet avec Preact, Webpack, LESS et CSS Modules.
-[Projet Github](https://github.com/developit/preact-boilerplate)
+**[Preact Boilerplate](https://preact-boilerplate.surge.sh)** :zap:<br>
+Un starter de projet avec Preact, Webpack, LESS et CSS Modules.<br>
+[Projet GitHub](https://github.com/developit/preact-boilerplate)
 
-**[Preact Offline Starter](https://preact-starter.now.sh)** :100:
-Un starter Webpack 2 simplifié pour les Progressive Web Apps, avec support du hors ligne.
-[Projet Github](https://github.com/lukeed/preact-starter)
+**[Preact Offline Starter](https://preact-starter.now.sh)** :100:<br>
+Un starter Webpack 2 simplifié pour les Progressive Web Apps, avec support du hors ligne.<br>
+[Projet GitHub](https://github.com/lukeed/preact-starter)
 
-**[Preact Redux Example](https://preact-redux-example.surge.sh)** :repeat:  
-Un exemple de To-Do list implémenté avec Preact et Redux.
-[Projet Github](https://github.com/developit/preact-redux-example)
+**[Preact Redux Example](https://preact-redux-example.surge.sh)** :repeat:<br>
+Un exemple de To-Do list implémenté avec Preact et Redux.<br>
+[Projet GitHub](https://github.com/developit/preact-redux-example)
 
-**[Preact Without Babel](https://github.com/developit/preact-without-babel)** :horse:  
+**[Preact Without Babel](https://github.com/developit/preact-without-babel)** :horse:<br>
 Comment utiliser Preact sans Babel, ES2015 ou JSX.
 
-**[preact-minimal](https://github.com/aganglada/preact-minimal)** :rocket:  
+**[preact-minimal](https://github.com/aganglada/preact-minimal)** :rocket:<br>
 Une structure minimale pour Preact, incluant tous les outils nécéssaires pour bien commencer votre projet.
-
 
 ## Codepens
 
@@ -95,6 +93,6 @@ Une structure minimale pour Preact, incluant tous les outils nécéssaires pour 
 
 ## Templates
 
-:zap: [**Modèle JSFiddle**](https://jsfiddle.net/developit/rs6zrh5f/embedded/result/)
+:zap: **[Modèle JSFiddle](https://jsfiddle.net/developit/rs6zrh5f/embedded/result/)**
 
-:zap: [**Modèle CodePen**](http://codepen.io/developit/pen/pgaROe?editors=0010)
+:zap: **[Modèle CodePen](http://codepen.io/developit/pen/pgaROe?editors=0010)**

--- a/content/fr/about/libraries-addons.md
+++ b/content/fr/about/libraries-addons.md
@@ -12,44 +12,44 @@ Une liste de modules construit pour fonctionner parfaitement avec Preact.
 
 ### Modules complémentaires
 
-- :raised_hands: [**preact-compat**](https://github.com/preactjs/preact-compat): utilisez n'importe quelle bibliothèque créée pour React avec Preact *([full example](https://github.com/developit/preact-compat-example))*
-- :repeat: [**preact-cycle**](https://github.com/developit/preact-cycle): Le paradigme de programmation fonctionnelle réactive pour Preact
-- :page_facing_up: [**preact-render-to-string**](https://github.com/preactjs/preact-render-to-string): Rendu universel.
+- :raised_hands: **[preact-compat](https://github.com/preactjs/preact-compat)**: utilisez n'importe quelle bibliothèque créée pour React avec Preact *([full example](https://github.com/developit/preact-compat-example))*
+- :repeat: **[preact-cycle](https://github.com/developit/preact-cycle)**: Le paradigme de programmation fonctionnelle réactive pour Preact
+- :page_facing_up: **[preact-render-to-string](https://github.com/preactjs/preact-render-to-string)**: Rendu universel.
 
 
 ### Composants
 
-- :earth_americas: [**preact-router**](https://github.com/preactjs/preact-router): Un routeur d'URL pour vos composants
-- :bookmark_tabs: [**preact-markup**](https://github.com/developit/preact-markup): Affichez du HTML et des Custom Elements comme du JSX et des composants
-- :satellite: [**preact-portal**](https://github.com/developit/preact-portal): Affichez des composants Preact dans l'ESPACE :milky_way:
-- :pencil: [**preact-richtextarea**](https://github.com/developit/preact-richtextarea): Un composant d'éditeur HTML simple
-- :bookmark: [**preact-token-input**](https://github.com/developit/preact-token-input): Un champ de texte qui transforme son contenu en tokens, pour créer un système de tags, par exemple
-- :card_index: [**preact-virtual-list**](https://github.com/developit/preact-virtual-list): Affichez facilement des listes de plusieurs millions de lignes ([demo](https://jsfiddle.net/developit/qqan9pdo/))
-- :triangular_ruler: [**preact-layout**](https://download.github.io/preact-layout/): Une bibliothèque de mise en page légère et simple d'utilisation
-- :construction_worker: [**preact-helmet**](https://github.com/download/preact-helmet): Une bibliothèque pour Preact permettant de gérer le head d'un document
+- :earth_americas: **[preact-router](https://github.com/preactjs/preact-router)**: Un routeur d'URL pour vos composants
+- :bookmark_tabs: **[preact-markup](https://github.com/developit/preact-markup)**: Affichez du HTML et des Custom Elements comme du JSX et des composants
+- :satellite: **[preact-portal](https://github.com/developit/preact-portal)**: Affichez des composants Preact dans l'ESPACE :milky_way:
+- :pencil: **[preact-richtextarea](https://github.com/developit/preact-richtextarea)**: Un composant d'éditeur HTML simple
+- :bookmark: **[preact-token-input](https://github.com/developit/preact-token-input)**: Un champ de texte qui transforme son contenu en tokens, pour créer un système de tags, par exemple
+- :card_index: **[preact-virtual-list](https://github.com/developit/preact-virtual-list)**: Affichez facilement des listes de plusieurs millions de lignes ([demo](https://jsfiddle.net/developit/qqan9pdo/))
+- :triangular_ruler: **[preact-layout](https://download.github.io/preact-layout/)**: Une bibliothèque de mise en page légère et simple d'utilisation
+- :construction_worker: **[preact-helmet](https://github.com/download/preact-helmet)**: Une bibliothèque pour Preact permettant de gérer le head d'un document
 
 
 ### Intégrations
 
-- :thought_balloon: [**preact-socrates**](https://github.com/matthewmueller/preact-socrates): Un module Preact pour [Socrates](http://github.com/matthewmueller/socrates)
-- :rowboat: [**preact-flyd**](https://github.com/xialvjun/preact-flyd): Utilisez les flux FRP de [flyd](https://github.com/paldepind/flyd) avec Preact et JSX
-- :speech_balloon: [**preact-i18nline**](https://github.com/download/preact-i18nline): Intègre l'écosystème autour de [i18n-js](https://github.com/everydayhero/i18n-js) avec Preact via [i18nline](https://github.com/download/i18nline).
+- :thought_balloon: **[preact-socrates](https://github.com/matthewmueller/preact-socrates)**: Un module Preact pour [Socrates](http://github.com/matthewmueller/socrates)
+- :rowboat: **[preact-flyd](https://github.com/xialvjun/preact-flyd)**: Utilisez les flux FRP de [flyd](https://github.com/paldepind/flyd) avec Preact et JSX
+- :speech_balloon: **[preact-i18nline](https://github.com/download/preact-i18nline)**: Intègre l'écosystème autour de [i18n-js](https://github.com/everydayhero/i18n-js) avec Preact via [i18nline](https://github.com/download/i18nline).
 
 
 ### Outils pour créer des interfaces graphiques
 
-- :white_square_button: [**preact-mdl**](https://github.com/developit/preact-mdl): Utilisez [MDL](https://getmdl.io) comme des composants Preact
-- :rocket: [**preact-photon**](https://github.com/developit/preact-photon): créez de belles interfaces utilisateurs pour bureau avec [photon](http://photonkit.com)
+- :white_square_button: **[preact-mdl](https://github.com/developit/preact-mdl)**: Utilisez [MDL](https://getmdl.io) comme des composants Preact
+- :rocket: **[preact-photon](https://github.com/developit/preact-photon)**: créez de belles interfaces utilisateurs pour bureau avec [photon](http://photonkit.com)
 
 
 ### Tests
 
-- :microscope: [**preact-jsx-chai**](https://github.com/developit/preact-jsx-chai): Test d'assertions en JSX _(pas de DOM, directement dans Node)_
-- :white_check_mark: [**unexpected-preact**](https://github.com/bruderstein/unexpected-preact): Assertions, événements, snapshots en JSX dans Jest _(DOM, fonctionne avec le module Node jsdom ou directement avec Jest)_ - [docs](https://bruderstein.github.io/unexpected-preact/)
+- :microscope: **[preact-jsx-chai](https://github.com/developit/preact-jsx-chai)**: Test d'assertions en JSX _(pas de DOM, directement dans Node)_
+- :white_check_mark: **[unexpected-preact](https://github.com/bruderstein/unexpected-preact)**: Assertions, événements, snapshots en JSX dans Jest _(DOM, fonctionne avec le module Node jsdom ou directement avec Jest)_ - [docs](https://bruderstein.github.io/unexpected-preact/)
 
 
 ### Utilitaires
 
-- :tophat: [**preact-classless-component**](https://github.com/ld0rman/preact-classless-component): Créez des composants Preact sans le mot-clé class
-- :hammer: [**preact-hyperscript**](https://github.com/queckezz/preact-hyperscript): Une syntaxe ressemblant à celle d'Hyperscript pour créer des éléments
-- :white_check_mark: [**shallow-compare**](https://github.com/tkh44/shallow-compare): Un assistant simplifié pour `shouldComponentUpdate`.
+- :tophat: **[preact-classless-component](https://github.com/ld0rman/preact-classless-component)**: Créez des composants Preact sans le mot-clé class
+- :hammer: **[preact-hyperscript](https://github.com/queckezz/preact-hyperscript)**: Une syntaxe ressemblant à celle d'Hyperscript pour créer des éléments
+- :white_check_mark: **[shallow-compare](https://github.com/tkh44/shallow-compare)**: Un assistant simplifié pour `shouldComponentUpdate`.

--- a/content/kr/about/demos-examples.md
+++ b/content/kr/about/demos-examples.md
@@ -10,111 +10,110 @@ description: Preact 데모 & 예제 애플리케이션 모음
 > :information_desk_person: _직접 만드셨나요?
 > [추가하기!](https://github.com/preactjs/preact-www/blob/master/content/en/about/demos-examples.md)_
 
-
 ## 완전한 앱
 
-[**Preact Website** _(preactjs.com)_](https://preactjs.com)  
-물론 이 웹사이트는 Preact로 만들어졌습니다.  
-[Github Project](https://github.com/preactjs/preact-www)
+**[Preact Website (preactjs.com)](https://preactjs.com)**<br>
+물론 이 웹사이트는 Preact로 만들어졌습니다.<br>
+[GitHub Project](https://github.com/preactjs/preact-www)
 
-**[ESBench](http://esbench.com)** :alarm_clock:  
+**[ESBench](http://esbench.com)** :alarm_clock:<br>
 Preact & Material Design Lite로 만들어진 웹사이트입니다.
 
-[**GuriVR**](https://gurivr.com) :eyeglasses:  
-자연어 기반의 Web VR 스토리 크리에이터  
-[Github Project](https://github.com/opennewslabs/guri-vr)
+**[GuriVR](https://gurivr.com)** :eyeglasses:<br>
+자연어 기반의 Web VR 스토리 크리에이터<br>
+[GitHub Project](https://github.com/opennewslabs/guri-vr)
 
-[**BigWebQuiz**](https://bigwebquiz.com) :game_die:  
-Chrome Dev Summit 2016의 관중 참여형 점진적 웹 앱!  
-[Github Project](https://github.com/jakearchibald/big-web-quiz)
+**[BigWebQuiz](https://bigwebquiz.com)** :game_die:<br>
+Chrome Dev Summit 2016의 관중 참여형 점진적 웹 앱!<br>
+[GitHub Project](https://github.com/jakearchibald/big-web-quiz)
 
-**[Nectarine.rocks](http://nectarine.rocks)** :peach:  
-오픈 소스 peach.cool 앱  
-[Github Project](https://github.com/developit/nectarine)
+**[Nectarine.rocks](http://nectarine.rocks)** :peach:<br>
+오픈 소스 peach.cool 앱<br>
+[GitHub Project](https://github.com/developit/nectarine)
 
-**[Web Maker](https://webmaker.app/)** :zap:  
-매우 빠른 오프라인 프런트엔드 플레이그라운드  
-[Github Project](https://github.com/chinchang/web-maker)
+**[Web Maker](https://webmaker.app/)** :zap:<br>
+매우 빠른 오프라인 프런트엔드 플레이그라운드<br>
+[GitHub Project](https://github.com/chinchang/web-maker)
 
-**[BitMidi](https://bitmidi.com/)** :musical_keyboard:  
-무료 MIDI 파일을 위한 웨이백 머신  
-[Github Project](https://github.com/feross/bitmidi.com)
+**[BitMidi](https://bitmidi.com/)** :musical_keyboard:<br>
+무료 MIDI 파일을 위한 웨이백 머신<br>
+[GitHub Project](https://github.com/feross/bitmidi.com)
 
-**[BBC Roasting Calculator](https://www.bbc.com/food/techniques/articles/roast-calculator)** :turkey:  
+**[BBC Roasting Calculator](https://www.bbc.com/food/techniques/articles/roast-calculator)** :turkey:<br>
 다양한 고기 부위에 대한 조리 시간을 계산합니다.
 
-**[Dropfox](https://github.com/developit/dropfox)** :wolf:  
+**[Dropfox](https://github.com/developit/dropfox)** :wolf:<br>
 Preact, Electron 및 Photon으로 만든 Dropbox용 데스크톱 앱
 
-**[Embed Hacker News](https://github.com/TXTPEN/hn)** :kissing_closed_eyes:  
+**[Embed Hacker News](https://github.com/TXTPEN/hn)** :kissing_closed_eyes:<br>
 블로그 글 아래에 Hacker News 코멘트 트리를 삽입합니다.
 
-**[Connectivity Index](https://cindex.co)** :iphone:  
+**[Connectivity Index](https://cindex.co)** :iphone:<br>
 [Akamai 인터넷 상태 보고서](https://content.akamai.com/PG7010-Q2-2016-SOTI-Connectivity-Report.html) 데이터를 국가별로 검색할 수 있는 웹사이트
 
-**[Drag & Drop file upload (webpack 2)](https://contentful-labs.github.io/file-upload-example/)** :rocket:  
-Contentful에 애셋을 업로드하는 데 사용되는 데스크톱 앱 (API 기반 CMS)  
-[Github Project](https://github.com/contentful-labs/file-upload-example)
+**[Drag & Drop file upload (webpack 2)](https://contentful-labs.github.io/file-upload-example/)** :rocket:<br>
+Contentful에 애셋을 업로드하는 데 사용되는 데스크톱 앱 (API 기반 CMS)<br>
+[GitHub Project](https://github.com/contentful-labs/file-upload-example)
 
-**[Exchange Widget](https://sgtpep.github.io/exchange-widget/dist/)** :currency_exchange:  
-인기 있는 모바일 앱에서 영감을 받은 화폐 환율 위젯을 Preact, Meiosis, HTML 태그 템플릿 및 기본 ES 모듈을 사용해 구현합니다.  
-[Github Project](https://github.com/sgtpep/exchange-widget)
+**[Exchange Widget](https://sgtpep.github.io/exchange-widget/dist/)** :currency_exchange:<br>
+인기 있는 모바일 앱에서 영감을 받은 화폐 환율 위젯을 Preact, Meiosis, HTML 태그 템플릿 및 기본 ES 모듈을 사용해 구현합니다.<br>
+[GitHub Project](https://github.com/sgtpep/exchange-widget)
 
-**[Blaze](https://blaze.now.sh)** :zap:  
-모던 P2P 파일 공유 점진적 웹 앱  
-[Github Project](https://github.com/blenderskool/blaze)
+**[Blaze](https://blaze.now.sh)** :zap:<br>
+모던 P2P 파일 공유 점진적 웹 앱<br>
+[GitHub Project](https://github.com/blenderskool/blaze)
 
-**[1tuner](https://1tuner.com)** :radio:  
-라디오와 팟캐스트를 청취할 수 있는 웹사이트  
-[Github Project](https://github.com/robinbakker/1tuner)
+**[1tuner](https://1tuner.com)** :radio:<br>
+라디오와 팟캐스트를 청취할 수 있는 웹사이트<br>
+[GitHub Project](https://github.com/robinbakker/1tuner)
 
 ## 완전한 데모 & 예제
 
-**[Documentation Viewer](https://documentation-viewer.firebaseapp.com)**  
-documentation.js 출력물을 온라인에서 확인합니다.  
-[Github Project](https://github.com/developit/documentation-viewer)
+**[Documentation Viewer](https://documentation-viewer.firebaseapp.com)**<br>
+documentation.js 출력물을 온라인에서 확인합니다.<br>
+[GitHub Project](https://github.com/developit/documentation-viewer)
 
-**[TodoMVC](http://developit.github.io/preact-todomvc/)**  
-비공식이지만 가장 빠른 TodoMVC 구현입니다.  
-[Github Project](https://github.com/developit/preact-todomvc)
+**[TodoMVC](http://developit.github.io/preact-todomvc/)**<br>
+비공식이지만 가장 빠른 TodoMVC 구현입니다.<br>
+[GitHub Project](https://github.com/developit/preact-todomvc)
 
-**[TodoMVC+PouchDB](http://katopz.github.io/preact-todomvc-pouchdb/)** :floppy_disk:  
-[PouchDB](https://pouchdb.com/)를 사용한 오프라인 동기화 TodoMVC  
-[Github Project](https://github.com/katopz/preact-todomvc-pouchdb)
+**[TodoMVC+PouchDB](http://katopz.github.io/preact-todomvc-pouchdb/)** :floppy_disk:<br>
+[PouchDB](https://pouchdb.com/)를 사용한 오프라인 동기화 TodoMVC<br>
+[GitHub Project](https://github.com/katopz/preact-todomvc-pouchdb)
 
-**[Hacker News Minimal](https://developit.github.io/hn_minimal/)** :newspaper:  
-작은 해커 뉴스 클라이언트  
-[Github Project](https://github.com/developit/hn_minimal)
+**[Hacker News Minimal](https://developit.github.io/hn_minimal/)** :newspaper:<br>
+작은 해커 뉴스 클라이언트<br>
+[GitHub Project](https://github.com/developit/hn_minimal)
 
-**[Preact Boilerplate](https://preact-boilerplate.surge.sh)** :zap:  
-두 개의 명령으로 시작하는 프로젝트. Preact + Webpack + LESS + CSS Modules  
-[Github Project](https://github.com/developit/preact-boilerplate)
+**[Preact Boilerplate](https://preact-boilerplate.surge.sh)** :zap:<br>
+두 개의 명령으로 시작하는 프로젝트. Preact + Webpack + LESS + CSS Modules<br>
+[GitHub Project](https://github.com/developit/preact-boilerplate)
 
-**[Preact Offline Starter](https://preact-starter.now.sh)** :100:  
-점진적 웹 앱을 위한 Webpack2 스타터의 간소화된 버전. 오프라인 지원 포함  
-[Github Project](https://github.com/lukeed/preact-starter)
+**[Preact Offline Starter](https://preact-starter.now.sh)** :100:<br>
+점진적 웹 앱을 위한 Webpack2 스타터의 간소화된 버전. 오프라인 지원 포함<br>
+[GitHub Project](https://github.com/lukeed/preact-starter)
 
-**[Preact Redux Example](https://preact-redux-example.surge.sh)** :repeat:  
-간단한 To-Do 리스트를 구현한 Preact + Redux 예제 프로젝트  
-[Github Project](https://github.com/developit/preact-redux-example)
+**[Preact Redux Example](https://preact-redux-example.surge.sh)** :repeat:<br>
+간단한 To-Do 리스트를 구현한 Preact + Redux 예제 프로젝트<br>
+[GitHub Project](https://github.com/developit/preact-redux-example)
 
-**[Preact Without Babel](https://github.com/developit/preact-without-babel)** :horse:  
+**[Preact Without Babel](https://github.com/developit/preact-without-babel)** :horse:<br>
 Babel, ES2015 또는 JSX 없이 Preact를 사용하는 방법
 
-**[preact-minimal](https://github.com/aganglada/preact-minimal)** :rocket:  
+**[preact-minimal](https://github.com/aganglada/preact-minimal)** :rocket:<br>
 프로젝트를 즉시 시작할 수 있는 최소한의 도구가 갖춰져 있는 Preact 구조
 
-**[preact-typescript-webpack4-less](https://github.com/lexey111/preact-typescript-webpack4-boilerplate)**  
+**[preact-typescript-webpack4-less](https://github.com/lexey111/preact-typescript-webpack4-boilerplate)**<br>
 Preact, Typescript 및 Webpack4를 사용하여 최소한의 설정으로 시작하는 프로젝트
 
-**[Preact Homepage Generator](https://thomaswood.me/)** :globe_with_meridians:  
-JSON 데이터만 수정하여 새로운 개인 웹페이지를 빠르게 만듭니다.  
-[Github Project](https://github.com/tomasswood/preact-homepage-generator)
+**[Preact Homepage Generator](https://thomaswood.me/)** :globe_with_meridians:<br>
+JSON 데이터만 수정하여 새로운 개인 웹페이지를 빠르게 만듭니다.<br>
+[GitHub Project](https://github.com/tomasswood/preact-homepage-generator)
 
-**[Parcel + Preact + Unistore Starter](https://github.com/hwclass/parcel-preact-unistore-starter)**  
+**[Parcel + Preact + Unistore Starter](https://github.com/hwclass/parcel-preact-unistore-starter)**<br>
 프로토타이핑 및 소규모/중규모 프로젝트 구조를 위한 스타터 팩
 
-**[buildless-preact-starter](https://github.com/ttntm/buildless-preact-starter)** :rocket:  
+**[buildless-preact-starter](https://github.com/ttntm/buildless-preact-starter)** :rocket:<br>
 빌드 없이 Preact를 사용하는 환경을 위한 스타터 템플릿
 
 ## Codepens
@@ -127,6 +126,6 @@ JSON 데이터만 수정하여 새로운 개인 웹페이지를 빠르게 만듭
 
 ## 템플릿
 
-:zap: [**JSFiddle 템플릿**](https://jsfiddle.net/developit/rs6zrh5f/embedded/result/)
+:zap: **[JSFiddle 템플릿](https://jsfiddle.net/developit/rs6zrh5f/embedded/result/)**
 
-:zap: [**CodePen 템플릿**](http://codepen.io/developit/pen/pgaROe?editors=0010)
+:zap: **[CodePen 템플릿](http://codepen.io/developit/pen/pgaROe?editors=0010)**

--- a/content/kr/about/libraries-addons.md
+++ b/content/kr/about/libraries-addons.md
@@ -12,53 +12,53 @@ Preact와 훌륭하게 동작하는 모듈 모음입니다.
 
 ## 애드온
 
-- :repeat: [**preact-cycle**](https://github.com/developit/preact-cycle): Preact를 위한 함수형 반응형 패러다임
-- :page_facing_up: [**preact-render-to-string**](https://github.com/preactjs/preact-render-to-string): Universal 렌더링
-- :timer_clock: [**relaks**](https://github.com/trambarhq/relaks): 비동기적으로 반환하는 렌더 메서드를 가진 컴포넌트 생성
-- :nut_and_bolt: [**express-preact-views**](https://github.com/edwjusti/express-preact-views): Express 뷰 엔진
-- :floppy_disk: [**Prefresh**](https://github.com/JoviDeCroock/prefresh): Preact를 위한 빠른 새로고침
-- :bookmark_tabs: [**adonis-preact**](https://github.com/DonsWayo/adonis-preact): Adonisjs에서 Preact 사용
+- :repeat: **[preact-cycle](https://github.com/developit/preact-cycle)**: Preact를 위한 함수형 반응형 패러다임
+- :page_facing_up: **[preact-render-to-string](https://github.com/preactjs/preact-render-to-string)**: Universal 렌더링
+- :timer_clock: **[relaks](https://github.com/trambarhq/relaks)**: 비동기적으로 반환하는 렌더 메서드를 가진 컴포넌트 생성
+- :nut_and_bolt: **[express-preact-views](https://github.com/edwjusti/express-preact-views)**: Express 뷰 엔진
+- :floppy_disk: **[Prefresh](https://github.com/JoviDeCroock/prefresh)**: Preact를 위한 빠른 새로고침
+- :bookmark_tabs: **[adonis-preact](https://github.com/DonsWayo/adonis-preact)**: Adonisjs에서 Preact 사용
 
 ## 컴포넌트
 
-- :earth_americas: [**preact-router**](https://github.com/preactjs/preact-router): 컴포넌트를 위한 URL 라우팅
-- :bookmark_tabs: [**preact-markup**](https://github.com/developit/preact-markup): HTML 및 커스텀 엘리먼트를 JSX와 컴포넌트로 렌더링
-- :satellite: [**preact-portal**](https://github.com/developit/preact-portal): Preact 컴포넌트를 임의의 공간에 렌더링 :milky_way:
-- :pencil: [**preact-richtextarea**](https://github.com/developit/preact-richtextarea): 간단한 HTML 편집기 컴포넌트
-- :bookmark: [**preact-token-input**](https://github.com/developit/preact-token-input): 태그와 같은 것을 위한 입력을 토큰화하는 텍스트 필드
-- :card_index: [**preact-virtual-list**](https://github.com/developit/preact-virtual-list): 수백만 개의 행이 있는 목록을 쉽게 렌더링 ([데모](https://jsfiddle.net/developit/qqan9pdo/))
-- :triangular_ruler: [**preact-layout**](https://download.github.io/preact-layout/): 작고 간단한 레이아웃 라이브러리
-- :construction_worker: [**preact-helmet**](https://github.com/download/preact-helmet): Preact를 위한 문서 head 관리자
-- :arrow_up_down: [**preact-custom-scrollbars**](https://github.com/lucafalasco/preact-custom-scrollbars): 완전하게 커스텀 가능한 스크롤바(네이티브 브라우저 스크롤링 원활하게 지원)
-- 🧱 [**@modular-forms/preact**](https://modularforms.dev/): 모듈화되고 타입에 안전한 폼 라이브러리
+- :earth_americas: **[preact-router](https://github.com/preactjs/preact-router)**: 컴포넌트를 위한 URL 라우팅
+- :bookmark_tabs: **[preact-markup](https://github.com/developit/preact-markup)**: HTML 및 커스텀 엘리먼트를 JSX와 컴포넌트로 렌더링
+- :satellite: **[preact-portal](https://github.com/developit/preact-portal)**: Preact 컴포넌트를 임의의 공간에 렌더링 :milky_way:
+- :pencil: **[preact-richtextarea](https://github.com/developit/preact-richtextarea)**: 간단한 HTML 편집기 컴포넌트
+- :bookmark: **[preact-token-input](https://github.com/developit/preact-token-input)**: 태그와 같은 것을 위한 입력을 토큰화하는 텍스트 필드
+- :card_index: **[preact-virtual-list](https://github.com/developit/preact-virtual-list)**: 수백만 개의 행이 있는 목록을 쉽게 렌더링 ([데모](https://jsfiddle.net/developit/qqan9pdo/))
+- :triangular_ruler: **[preact-layout](https://download.github.io/preact-layout/)**: 작고 간단한 레이아웃 라이브러리
+- :construction_worker: **[preact-helmet](https://github.com/download/preact-helmet)**: Preact를 위한 문서 head 관리자
+- :arrow_up_down: **[preact-custom-scrollbars](https://github.com/lucafalasco/preact-custom-scrollbars)**: 완전하게 커스텀 가능한 스크롤바(네이티브 브라우저 스크롤링 원활하게 지원)
+- 🧱 **[@modular-forms/preact](https://modularforms.dev/)**: 모듈화되고 타입에 안전한 폼 라이브러리
 
 ## 통합
 
-- :thought_balloon: [**preact-socrates**](https://github.com/matthewmueller/preact-socrates): [Socrates](http://github.com/matthewmueller/socrates)를 위한 Preact 플러그인
-- :rowboat: [**preact-flyd**](https://github.com/xialvjun/preact-flyd): Preact + JSX에서 [flyd](https://github.com/paldepind/flyd) FRP 스트림 사용
-- :speech_balloon: [**preact-i18nline**](https://github.com/download/preact-i18nline): [i18n-js](https://github.com/everydayhero/i18n-js) 주변의 생태계를 [i18nline](https://github.com/download/i18nline)을 통해 Preact와 통합합니다.
-- :diamond_shape_with_a_dot_inside: [**Capacitor**](https://capacitorjs.com/solution/preact): Preact 앱을 네이티브 iOS/Android 앱 및 PWA로 변환
-- :ice_cube: [**Kretes**](https://kretes.dev/docs/howtos/preact-setup/): Preact 및 Node.js를 사용하여 풀스택 TypeScript 앱 빌드
-- 🏝: [**preact-island**](https://github.com/mwood23/preact-island): 반응적인 Props를 통해 어떤 웹사이트에서든 Preact 위젯 실행
+- :thought_balloon: **[preact-socrates](https://github.com/matthewmueller/preact-socrates)**: [Socrates](http://github.com/matthewmueller/socrates)를 위한 Preact 플러그인
+- :rowboat: **[preact-flyd](https://github.com/xialvjun/preact-flyd)**: Preact + JSX에서 [flyd](https://github.com/paldepind/flyd) FRP 스트림 사용
+- :speech_balloon: **[preact-i18nline](https://github.com/download/preact-i18nline)**: [i18n-js](https://github.com/everydayhero/i18n-js) 주변의 생태계를 [i18nline](https://github.com/download/i18nline)을 통해 Preact와 통합합니다.
+- :diamond_shape_with_a_dot_inside: **[Capacitor](https://capacitorjs.com/solution/preact)**: Preact 앱을 네이티브 iOS/Android 앱 및 PWA로 변환
+- :ice_cube: **[Kretes](https://kretes.dev/docs/howtos/preact-setup/)**: Preact 및 Node.js를 사용하여 풀스택 TypeScript 앱 빌드
+- 🏝: **[preact-island](https://github.com/mwood23/preact-island)**: 반응적인 Props를 통해 어떤 웹사이트에서든 Preact 위젯 실행
 
 ## GUI 툴킷
 
-- 🎴 [**@mui/material**](https://github.com/mui/material-ui/tree/master/examples/material-ui-preact): 여러분이 늘 원하던 React UI 라이브러리. 자체 디자인 시스템을 따르거나, Material Design으로 시작하세요.
-- :thumbsup: [**preact-material-components**](https://github.com/prateekbh/preact-material-components): 웹을 위한 Material 컴포넌트 (MDL 대용)
-- :white_square_button: [**preact-mdl**](https://github.com/developit/preact-mdl): Preact 컴포넌트로 [MDL](https://getmdl.io) 사용
-- :rocket: [**preact-photon**](https://github.com/developit/preact-photon): [photon](http://photonkit.com)으로 아름다운 데스크톱 UI 빌드
-- :penguin: [**preact-weui**](https://github.com/afeiship/preact-weui): Preact용 [Weui](https://github.com/afeiship/preact-weui)
-- 💅 [**preact-fluid**](https://github.com/ajainvivek/preact-fluid): Preact용 [Fluid](https://github.com/ajainvivek/preact-fluid) 미니멀 UI 킷
-- :book: [**storybook-preact**](https://github.com/storybooks/storybook/tree/next/app/preact): Preact 컴포너트를 위한 UI 개발 환경인 Storybook
+- 🎴 **[@mui/material](https://github.com/mui/material-ui/tree/master/examples/material-ui-preact)**: 여러분이 늘 원하던 React UI 라이브러리. 자체 디자인 시스템을 따르거나, Material Design으로 시작하세요.
+- :thumbsup: **[preact-material-components](https://github.com/prateekbh/preact-material-components)**: 웹을 위한 Material 컴포넌트 (MDL 대용)
+- :white_square_button: **[preact-mdl](https://github.com/developit/preact-mdl)**: Preact 컴포넌트로 [MDL](https://getmdl.io) 사용
+- :rocket: **[preact-photon](https://github.com/developit/preact-photon)**: [photon](http://photonkit.com)으로 아름다운 데스크톱 UI 빌드
+- :penguin: **[preact-weui](https://github.com/afeiship/preact-weui)**: Preact용 [Weui](https://github.com/afeiship/preact-weui)
+- 💅 **[preact-fluid](https://github.com/ajainvivek/preact-fluid)**: Preact용 [Fluid](https://github.com/ajainvivek/preact-fluid) 미니멀 UI 킷
+- :book: **[storybook-preact](https://github.com/storybooks/storybook/tree/next/app/preact)**: Preact 컴포너트를 위한 UI 개발 환경인 Storybook
 
 ## 테스트
 
-- :microscope: [**preact-jsx-chai**](https://github.com/developit/preact-jsx-chai): JSX assertion 테스트 _(DOM 없이 Node에서 진행)_
-- :white_check_mark: [**unexpected-preact**](https://github.com/bruderstein/unexpected-preact): JSX assertions, 이벤트, Jest에서 스냅샷 _(DOM, Node jsdom 아래에서 동작하거나 Jest에서 기본적으로 작동)_ - [docs](https://bruderstein.github.io/unexpected-preact/)
+- :microscope: **[preact-jsx-chai](https://github.com/developit/preact-jsx-chai)**: JSX assertion 테스트 _(DOM 없이 Node에서 진행)_
+- :white_check_mark: **[unexpected-preact](https://github.com/bruderstein/unexpected-preact)**: JSX assertions, 이벤트, Jest에서 스냅샷 _(DOM, Node jsdom 아래에서 동작하거나 Jest에서 기본적으로 작동)_ - [docs](https://bruderstein.github.io/unexpected-preact/)
 
 ## 유틸리티
 
-- :tophat: [**preact-classless-component**](https://github.com/ld0rman/preact-classless-component): class 키워드 없이 Preact 컴포넌트 생성
-- :hammer: [**preact-hyperscript**](https://github.com/queckezz/preact-hyperscript): 엘리먼트 생성을 위한 Hyperscript와 같은 문법
-- :white_check_mark: [**shallow-compare**](https://github.com/tkh44/shallow-compare): 단순화된 `shouldComponentUpdate` 헬퍼
-- :signal_strength: [**@deepsignal/preact**](https://github.com/EthanStandel/deepsignal/tree/main/packages/preact): 전체 상태 관리를 위한 `@preact/signals`의 확장
+- :tophat: **[preact-classless-component](https://github.com/ld0rman/preact-classless-component)**: class 키워드 없이 Preact 컴포넌트 생성
+- :hammer: **[preact-hyperscript](https://github.com/queckezz/preact-hyperscript)**: 엘리먼트 생성을 위한 Hyperscript와 같은 문법
+- :white_check_mark: **[shallow-compare](https://github.com/tkh44/shallow-compare)**: 단순화된 `shouldComponentUpdate` 헬퍼
+- :signal_strength: **[@deepsignal/preact](https://github.com/EthanStandel/deepsignal/tree/main/packages/preact)**: 전체 상태 관리를 위한 `@preact/signals`의 확장

--- a/content/pt-br/about/demos-examples.md
+++ b/content/pt-br/about/demos-examples.md
@@ -6,77 +6,74 @@ title: Demonstrações & Exemplos
 
 Essa página lista diversos <i>demos</i> e exemplos que você pode utilizar para aprender Preact.
 
-
 > :information_desk_person: _Criou algo com Preact?
 > [Adicione aqui!](https://github.com/preactjs/preact-www/blob/master/content/pt-br/about/demos-examples.md)_
 
-
 ## Aplicações completos
 
-[**Webiste do Preact ** _(preactjs.com)_](https://preactjs.com)
-Logicamente, esse <i>website</i> é construído com Preact.
-[Github Project](https://github.com/preactjs/preact-www)
+**[Webiste do Preact (preactjs.com)](https://preactjs.com)**<br>
+Logicamente, esse <i>website</i> é construído com Preact.<br>
+[GitHub Project](https://github.com/preactjs/preact-www)
 
-**[ESBench](http://esbench.com)** :alarm_clock:
+**[ESBench](http://esbench.com)** :alarm_clock:<br>
 Construído com Preact & Material Design Lite.
 
-[**GuriVR**](https://gurivr.com) :eyeglasses:
-Criador de histórias Web VR baseado em linguagens naturais.
-_([Github Project](https://github.com/opennewslabs/guri-vr))_
+**[GuriVR](https://gurivr.com)** :eyeglasses:<br>
+Criador de histórias Web VR baseado em linguagens naturais.<br>
+[GitHub Project](https://github.com/opennewslabs/guri-vr)
 
-[**BigWebQuiz**](https://bigwebquiz.com) :game_die:
-O <i>Progressive Web App</i> para participação do público na Chrome Dev Summit 2016!
-([Github Project](https://github.com/jakearchibald/big-web-quiz))
+**[BigWebQuiz](https://bigwebquiz.com)** :game_die:<br>
+O <i>Progressive Web App</i> para participação do público na Chrome Dev Summit 2016!<br>
+[GitHub Project](https://github.com/jakearchibald/big-web-quiz)
 
-**[Nectarine.rocks](http://nectarine.rocks)** :peach:  
-Uma aplicação similar ao 'peach.cool' de código aberto!  
-[Github Project](https://github.com/developit/nectarine)
+**[Nectarine.rocks](http://nectarine.rocks)** :peach:<br>
+Uma aplicação similar ao 'peach.cool' de código aberto!<br>
+[GitHub Project](https://github.com/developit/nectarine)
 
-**[Dropfox](https://github.com/developit/dropfox)** :wolf:
+**[Dropfox](https://github.com/developit/dropfox)** :wolf:<br>
 Aplicação desktop para Dropbox, criado com Preact, Electron e Photon.
 
-**[Connectivity Index](https://cindex.co)** :iphone:  
-Um site que permite que você pesquise através dos  [dados de conectividade Akamai](https://content.akamai.com/PG7010-Q2-2016-SOTI-Connectivity-Report.html) por país.
+**[Connectivity Index](https://cindex.co)** :iphone:<br>
+Um site que permite que você pesquise através dos [dados de conectividade Akamai](https://content.akamai.com/PG7010-Q2-2016-SOTI-Connectivity-Report.html) por país.
 
-**[Drag & Drop file upload (webpack 2)](https://contentful-labs.github.io/file-upload-example/)** :rocket:
-Desktop App for uploading assets to Contentful (API based CMS)
-Aplicativo de Desktop para upload de assets para o Contentful (CMS com base em API)
-[Github Project](https://github.com/contentful-labs/file-upload-example)
+**[Drag & Drop file upload (webpack 2)](https://contentful-labs.github.io/file-upload-example/)** :rocket:<br>
+Desktop App for uploading assets to Contentful (API based CMS) Aplicativo de Desktop para upload de assets para o Contentful (CMS com base em API)<br>
+[GitHub Project](https://github.com/contentful-labs/file-upload-example)
 
-**[ColoGuessr](https://cologuessr.com)** :rainbow:
-Teste o quão bem você conhece suas cores
-[Github Project](https://github.com/jackpordi/cologuessr)
+**[ColoGuessr](https://cologuessr.com)** :rainbow:<br>
+Teste o quão bem você conhece suas cores<br>
+[GitHub Project](https://github.com/jackpordi/cologuessr)
 
 ## Demos completos & Exemplos
 
-**[Documentation Viewer](https://documentation-viewer.firebaseapp.com)**  
-Visualize o <i>output</i> do documentation.js online.
-[Github Project](https://github.com/developit/documentation-viewer)
+**[Documentation Viewer](https://documentation-viewer.firebaseapp.com)**<br>
+Visualize o <i>output</i> do documentation.js online.<br>
+[GitHub Project](https://github.com/developit/documentation-viewer)
 
-**[TodoMVC](http://developit.github.io/preact-todomvc/)**  
-A mais rápida implementação (não-oficial) do TodoMVC.
-[Github Project](https://github.com/developit/preact-todomvc)
+**[TodoMVC](http://developit.github.io/preact-todomvc/)**<br>
+A mais rápida implementação (não-oficial) do TodoMVC.<br>
+[GitHub Project](https://github.com/developit/preact-todomvc)
 
-**[TodoMVC+PouchDB](http://katopz.github.io/preact-todomvc-pouchdb/)** :floppy_disk:  
-TodoMVC com sincronização offline, com [PouchDB](https://pouchdb.com/).  
-[Github Project](https://github.com/katopz/preact-todomvc-pouchdb)
+**[TodoMVC+PouchDB](http://katopz.github.io/preact-todomvc-pouchdb/)** :floppy_disk:<br>
+TodoMVC com sincronização offline, com [PouchDB](https://pouchdb.com/).<br>
+[GitHub Project](https://github.com/katopz/preact-todomvc-pouchdb)
 
-**[Hacker News Minimal](https://developit.github.io/hn_minimal/)** :newspaper:  
-Pequeno cliente do HackerNews.
-[Github Project](https://github.com/developit/hn_minimal)
+**[Hacker News Minimal](https://developit.github.io/hn_minimal/)** :newspaper:<br>
+Pequeno cliente do HackerNews.<br>
+[GitHub Project](https://github.com/developit/hn_minimal)
 
-**[Preact Boilerplate](https://preact-boilerplate.surge.sh)** :zap:
-Iniciador de projetos Preact com 2 comandos. Preact + Webpack + LESS + CSS Modules.
-[Github Project](https://github.com/developit/preact-boilerplate)
+**[Preact Boilerplate](https://preact-boilerplate.surge.sh)** :zap:<br>
+Iniciador de projetos Preact com 2 comandos. Preact + Webpack + LESS + CSS Modules.<br>
+[GitHub Project](https://github.com/developit/preact-boilerplate)
 
-**[Preact Redux Example](https://preact-redux-example.surge.sh)** :repeat:  
-Projeto exemplo com Preact + Redux, implementando uma <i>To-Do list</i> simples.
-[Github Project](https://github.com/developit/preact-redux-example)
+**[Preact Redux Example](https://preact-redux-example.surge.sh)** :repeat:<br>
+Projeto exemplo com Preact + Redux, implementando uma <i>To-Do list</i> simples.<br>
+[GitHub Project](https://github.com/developit/preact-redux-example)
 
-**[Preact Without Babel](https://github.com/developit/preact-without-babel)** :horse:  
+**[Preact Without Babel](https://github.com/developit/preact-without-babel)** :horse:<br>
 Como usar Preact inteiramente sem Babel, ES2015 ou JSX.
 
-**[preact-minimal](https://github.com/aganglada/preact-minimal)** :rocket:  
+**[preact-minimal](https://github.com/aganglada/preact-minimal)** :rocket:<br>
 Estrutura minimalista do Preact com todas as ferramentas necessárias para iniciar o seu projeto imediatamente.
 
 ## Codepens
@@ -89,6 +86,6 @@ Estrutura minimalista do Preact com todas as ferramentas necessárias para inici
 
 ## Templates
 
-:zap: [**JSFiddle Template**](https://jsfiddle.net/developit/rs6zrh5f/embedded/result/)
+:zap: **[JSFiddle Template](https://jsfiddle.net/developit/rs6zrh5f/embedded/result/)**
 
-:zap: [**CodePen Template**](http://codepen.io/developit/pen/pgaROe?editors=0010)
+:zap: **[CodePen Template](http://codepen.io/developit/pen/pgaROe?editors=0010)**

--- a/content/pt-br/about/libraries-addons.md
+++ b/content/pt-br/about/libraries-addons.md
@@ -12,43 +12,43 @@ Uma coleção de módulos construídos para trabalhar maravilhosamente com Preac
 
 ### Add-Ons
 
-- :raised_hands: [**preact-compat**](https://github.com/preactjs/preact-compat): use qualqer biblioteca React com Preact *([exemplo completo](https://github.com/developit/preact-compat-example))*
-- :repeat: [**preact-cycle**](https://github.com/developit/preact-cycle): Paradigma funcional-reativo para Preact.
-- :page_facing_up: [**preact-render-to-string**](https://github.com/preactjs/preact-render-to-string): Renderização universal.
+- :raised_hands: **[preact-compat](https://github.com/preactjs/preact-compat)**: use qualqer biblioteca React com Preact *([exemplo completo](https://github.com/developit/preact-compat-example))*
+- :repeat: **[preact-cycle](https://github.com/developit/preact-cycle)**: Paradigma funcional-reativo para Preact.
+- :page_facing_up: **[preact-render-to-string](https://github.com/preactjs/preact-render-to-string)**: Renderização universal.
 
 
 ### Componentes
 
-- :earth_americas: [**preact-router**](https://github.com/preactjs/preact-router): Rotas de URL para seus componentes
-- :bookmark_tabs: [**preact-markup**](https://github.com/developit/preact-markup): Renderize HTML & Elementos Customizados como JSX & Componentes
-- :satellite: [**preact-portal**](https://github.com/developit/preact-portal): Renderize componentes Preact no (um) ESPAÇO :milky_way:
-- :pencil: [**preact-richtextarea**](https://github.com/developit/preact-richtextarea): Componente de edição HTML simples
-- :bookmark: [**preact-token-input**](https://github.com/developit/preact-token-input): Campo de texto que <i>tokeniza</i> a entrada, pra coisas como <i>tags</i>
-- :card_index: [**preact-virtual-list**](https://github.com/developit/preact-virtual-list): Renderize facilmente listas com milhões de linhas ([demo](https://jsfiddle.net/developit/qqan9pdo/))
-- :triangular_ruler: [**preact-layout**](https://download.github.io/preact-layout/): Biblioteca de layout simples e pequena.
-- :construction_worker: [**preact-helmet**](https://github.com/download/preact-helmet): Um gerenciador de documento para Preact
+- :earth_americas: **[preact-router](https://github.com/preactjs/preact-router)**: Rotas de URL para seus componentes
+- :bookmark_tabs: **[preact-markup](https://github.com/developit/preact-markup)**: Renderize HTML & Elementos Customizados como JSX & Componentes
+- :satellite: **[preact-portal](https://github.com/developit/preact-portal)**: Renderize componentes Preact no (um) ESPAÇO :milky_way:
+- :pencil: **[preact-richtextarea](https://github.com/developit/preact-richtextarea)**: Componente de edição HTML simples
+- :bookmark: **[preact-token-input](https://github.com/developit/preact-token-input)**: Campo de texto que <i>tokeniza</i> a entrada, pra coisas como <i>tags</i>
+- :card_index: **[preact-virtual-list](https://github.com/developit/preact-virtual-list)**: Renderize facilmente listas com milhões de linhas ([demo](https://jsfiddle.net/developit/qqan9pdo/))
+- :triangular_ruler: **[preact-layout](https://download.github.io/preact-layout/)**: Biblioteca de layout simples e pequena.
+- :construction_worker: **[preact-helmet](https://github.com/download/preact-helmet)**: Um gerenciador de documento para Preact
 
 
 ### Integrações
 
-- :thought_balloon: [**preact-socrates**](https://github.com/matthewmueller/preact-socrates): Plugin Preact para [Socrates](http://github.com/matthewmueller/socrates)
-- :rowboat: [**preact-flyd**](https://github.com/xialvjun/preact-flyd): Use [flyd](https://github.com/paldepind/flyd) <i> FRP streams</i> em Preact + JSX
-- :speech_balloon: [**preact-i18nline**](https://github.com/download/preact-i18nline): Integra o ecosistema do [i18n-js](https://github.com/everydayhero/i18n-js) com Preact via [i18nline](https://github.com/download/i18nline).
+- :thought_balloon: **[preact-socrates](https://github.com/matthewmueller/preact-socrates)**: Plugin Preact para [Socrates](http://github.com/matthewmueller/socrates)
+- :rowboat: **[preact-flyd](https://github.com/xialvjun/preact-flyd)**: Use [flyd](https://github.com/paldepind/flyd) <i> FRP streams</i> em Preact + JSX
+- :speech_balloon: **[preact-i18nline](https://github.com/download/preact-i18nline)**: Integra o ecosistema do [i18n-js](https://github.com/everydayhero/i18n-js) com Preact via [i18nline](https://github.com/download/i18nline).
 
 
 ### Ferramentas para Interfaces Gráficas (GUI)
 
-- :white_square_button: [**preact-mdl**](https://github.com/developit/preact-mdl): Use o [MDL](https://getmdl.io) como componentes Preact.
-- :rocket: [**preact-photon**](https://github.com/developit/preact-photon): crie lindas UIs para aplicações desktop com [photon](http://photonkit.com)
+- :white_square_button: **[preact-mdl](https://github.com/developit/preact-mdl)**: Use o [MDL](https://getmdl.io) como componentes Preact.
+- :rocket: **[preact-photon](https://github.com/developit/preact-photon)**: crie lindas UIs para aplicações desktop com [photon](http://photonkit.com)
 
 
 ### Testes
 
-- :microscope: [**preact-jsx-chai**](https://github.com/developit/preact-jsx-chai): Testes de <i>Assertion</i> pra JSX  _(sem DOM, direto no Node)_
+- :microscope: **[preact-jsx-chai](https://github.com/developit/preact-jsx-chai)**: Testes de <i>Assertion</i> pra JSX  _(sem DOM, direto no Node)_
 
 
 ### Utilitários
 
-- :tophat: [**preact-classless-component**](https://github.com/ld0rman/preact-classless-component): crie componentes Preact sem a _keyword_ `Class`
-- :hammer: [**preact-hyperscript**](https://github.com/queckezz/preact-hyperscript): Sintaxe similar a Hyperscript para criação de elementos.
-- :white_check_mark: [**shallow-compare**](https://github.com/tkh44/shallow-compare): _Helper_ simplificado para `shouldComponentUpdate`.
+- :tophat: **[preact-classless-component](https://github.com/ld0rman/preact-classless-component)**: crie componentes Preact sem a _keyword_ `Class`
+- :hammer: **[preact-hyperscript](https://github.com/queckezz/preact-hyperscript)**: Sintaxe similar a Hyperscript para criação de elementos.
+- :white_check_mark: **[shallow-compare](https://github.com/tkh44/shallow-compare)**: _Helper_ simplificado para `shouldComponentUpdate`.

--- a/content/ru/about/demos-examples.md
+++ b/content/ru/about/demos-examples.md
@@ -12,109 +12,109 @@ description: Коллекция демо-версий и примеров при
 
 ## Полнофункциональные приложения
 
-[**Сайт Preact** _(preactjs.com)_](https://preactjs.com)
-Конечно же, этот сайт построен с помощью Preact.
-[Проект Github](https://github.com/preactjs/preact-www)
+**[Сайт Preact (preactjs.com)](https://preactjs.com)**<br>
+Конечно же, этот сайт построен с помощью Preact.<br>
+[Проект GitHub](https://github.com/preactjs/preact-www)
 
-**[ESBench](http://esbench.com)** :alarm_clock:
+**[ESBench](http://esbench.com)** :alarm_clock:<br>
 Построен на основе Preact и Material Design Lite.
 
-[**GuriVR**](https://gurivr.com) :eyeglasses:
-Создатель Web VR историй на основе естественного языка.
-[Проект Github](https://github.com/opennewslabs/guri-vr)
+**[GuriVR](https://gurivr.com)** :eyeglasses:<br>
+Создатель Web VR историй на основе естественного языка.<br>
+[Проект GitHub](https://github.com/opennewslabs/guri-vr)
 
-[**BigWebQuiz**](https://bigwebquiz.com) :game_die:
-Прогрессивное веб-приложение с участием аудитории с Chrome Dev Summit 2016!
-[Проект Github](https://github.com/jakearchibald/big-web-quiz)
+**[BigWebQuiz](https://bigwebquiz.com)** :game_die:<br>
+Прогрессивное веб-приложение с участием аудитории с Chrome Dev Summit 2016!<br>
+[Проект GitHub](https://github.com/jakearchibald/big-web-quiz)
 
-**[Nectarine.rocks](http://nectarine.rocks)** :peach:
-Приложение peach.cool с открытым исходным кодом.
-[Проект Github](https://github.com/developit/nectarine)
+**[Nectarine.rocks](http://nectarine.rocks)** :peach:<br>
+Приложение peach.cool с открытым исходным кодом.<br>
+[Проект GitHub](https://github.com/developit/nectarine)
 
-**[Web Maker](https://webmaker.app/)** :zap:
-Удивительно быстрый и автономный фронтенд.
-[Проект Github](https://github.com/chinchang/web-maker)
+**[Web Maker](https://webmaker.app/)** :zap:<br>
+Удивительно быстрый и автономный фронтенд.<br>
+[Проект GitHub](https://github.com/chinchang/web-maker)
 
-**[BitMidi](https://bitmidi.com/)** :musical_keyboard:
-Машина обратного отсчета для бесплатных MIDI-файлов
-[Проект Github](https://github.com/feross/bitmidi.com)
+**[BitMidi](https://bitmidi.com/)** :musical_keyboard:<br>
+Машина обратного отсчета для бесплатных MIDI-файлов<br>
+[Проект GitHub](https://github.com/feross/bitmidi.com)
 
-**[BBC Roasting Calculator](https://www.bbc.com/food/techniques/articles/roast-calculator)** :turkey:
+**[BBC Roasting Calculator](https://www.bbc.com/food/techniques/articles/roast-calculator)** :turkey:<br>
 Рассчитывает время приготовления различных кусков мяса.
 
-**[Dropfox](https://github.com/developit/dropfox)** :wolf:
+**[Dropfox](https://github.com/developit/dropfox)** :wolf:<br>
 Настольное приложение для Dropbox, созданное на основе Preact, Electron и Photon.
 
-**[Embed Hacker News](https://github.com/TXTPEN/hn)** :kissing_closed_eyes:
+**[Embed Hacker News](https://github.com/TXTPEN/hn)** :kissing_closed_eyes:<br>
 Вставьте дерево комментариев Hacker News под статью в своем блоге.
 
-**[Connectivity Index](https://cindex.co)** :iphone:
+**[Connectivity Index](https://cindex.co)** :iphone:<br>
 Сайт, позволяющий осуществлять поиск данных [Akamai о состоянии подключения к Интернету](https://content.akamai.com/PG7010-Q2-2016-SOTI-Connectivity-Report.html) по странам.
 
-**[Drag & Drop file upload (webpack 2)](https://contentful-labs.github.io/file-upload-example/)** :rocket:
-Настольное приложение для загрузки ресурсов в Contentful (CMS на основе API)
-[Проект Github](https://github.com/contentful-labs/file-upload-example)
+**[Drag & Drop file upload (webpack 2)](https://contentful-labs.github.io/file-upload-example/)** :rocket:<br>
+Настольное приложение для загрузки ресурсов в Contentful (CMS на основе API)<br>
+[Проект GitHub](https://github.com/contentful-labs/file-upload-example)
 
-**[Exchange Widget](https://sgtpep.github.io/exchange-widget/dist/)** :currency_exchange:
-Виджет обмена валюты, вдохновленный популярным мобильным приложением, реализованным с использованием Preact, Meiosis, шаблонов с тегами HTML и собственных модулей ES.
-[Проект Github](https://github.com/sgtpep/exchange-widget)
+**[Exchange Widget](https://sgtpep.github.io/exchange-widget/dist/)** :currency_exchange:<br>
+Виджет обмена валюты, вдохновленный популярным мобильным приложением, реализованным с использованием Preact, Meiosis, шаблонов с тегами HTML и собственных модулей ES.<br>
+[Проект GitHub](https://github.com/sgtpep/exchange-widget)
 
-**[Blaze](https://blaze.now.sh)** :zap:
-Современный одноранговый обмен файлами Progressive Web App.
-[Проект Github](https://github.com/blenderskool/blaze)
+**[Blaze](https://blaze.now.sh)** :zap:<br>
+Современный одноранговый обмен файлами Progressive Web App.<br>
+[Проект GitHub](https://github.com/blenderskool/blaze)
 
-**[1tuner](https://1tuner.com)** :radio:
-Слушайте радио и подкасты.
-[Проект Github](https://github.com/robinbakker/1tuner)
+**[1tuner](https://1tuner.com)** :radio:<br>
+Слушайте радио и подкасты.<br>
+[Проект GitHub](https://github.com/robinbakker/1tuner)
 
-**[ColoGuessr](https://cologuessr.com)** :rainbow:
-Проверьте, насколько хорошо вы знаете свои цвета
-[Проект Github](https://github.com/jackpordi/cologuessr)
+**[ColoGuessr](https://cologuessr.com)** :rainbow:<br>
+Проверьте, насколько хорошо вы знаете свои цвета<br>
+[Проект GitHub](https://github.com/jackpordi/cologuessr)
 
 ## Полнофункциональные демонстрации и примеры
 
-**[Documentation Viewer](https://documentation-viewer.firebaseapp.com)**
-Просмотрите выходные данные document.js онлайн.
-[Проект Github](https://github.com/developit/documentation-viewer)
+**[Documentation Viewer](https://documentation-viewer.firebaseapp.com)**<br>
+Просмотрите выходные данные document.js онлайн.<br>
+[Проект GitHub](https://github.com/developit/documentation-viewer)
 
-**[TodoMVC](http://developit.github.io/preact-todomvc/)**
-Неофициальная самая быстрая реализация TodoMVC.
-[Проект Github](https://github.com/developit/preact-todomvc)
+**[TodoMVC](http://developit.github.io/preact-todomvc/)**<br>
+Неофициальная самая быстрая реализация TodoMVC.<br>
+[Проект GitHub](https://github.com/developit/preact-todomvc)
 
-**[TodoMVC+PouchDB](http://katopz.github.io/preact-todomvc-pouchdb/)** :floppy_disk:
-Автономная синхронизация TodoMVC с [PouchDB](https://pouchdb.com/).
-[Проект Github](https://github.com/katopz/preact-todomvc-pouchdb)
+**[TodoMVC+PouchDB](http://katopz.github.io/preact-todomvc-pouchdb/)** :floppy_disk:<br>
+Автономная синхронизация TodoMVC с [PouchDB](https://pouchdb.com/).<br>
+[Проект GitHub](https://github.com/katopz/preact-todomvc-pouchdb)
 
-**[Hacker News Minimal](https://developit.github.io/hn_minimal/)** :newspaper:
-Маленький хакерский новостной клиент.
-[Проект Github](https://github.com/developit/hn_minimal)
+**[Hacker News Minimal](https://developit.github.io/hn_minimal/)** :newspaper:<br>
+Маленький хакерский новостной клиент.<br>
+[Проект GitHub](https://github.com/developit/hn_minimal)
 
-**[Preact Boilerplate](https://preact-boilerplate.surge.sh)** :zap:
-2-командный стартовый проект. Preact + Webpack + LESS + модули CSS.
-[Проект Github](https://github.com/developit/preact-boilerplate)
+**[Preact Boilerplate](https://preact-boilerplate.surge.sh)** :zap:<br>
+2-командный стартовый проект. Preact + Webpack + LESS + модули CSS.<br>
+[Проект GitHub](https://github.com/developit/preact-boilerplate)
 
-**[Preact Offline Starter](https://preact-starter.now.sh)** :100:
-Упрощенный стартовый пакет Webpack2 для Progressive Web Apps с автономной поддержкой.
-[Проект Github](https://github.com/lukeed/preact-starter)
+**[Preact Offline Starter](https://preact-starter.now.sh)** :100:<br>
+Упрощенный стартовый пакет Webpack2 для Progressive Web Apps с автономной поддержкой.<br>
+[Проект GitHub](https://github.com/lukeed/preact-starter)
 
-**[Пример Preact Redux](https://preact-redux-example.surge.sh)** :repeat:
-Пример проекта Preact + Redux, реализующий простой список дел.
-[Проект Github](https://github.com/developit/preact-redux-example)
+**[Пример Preact Redux](https://preact-redux-example.surge.sh)** :repeat:<br>
+Пример проекта Preact + Redux, реализующий простой список дел.<br>
+[Проект GitHub](https://github.com/developit/preact-redux-example)
 
-**[Preact без Babel](https://github.com/developit/preact-without-babel)** :horse:
+**[Preact без Babel](https://github.com/developit/preact-without-babel)** :horse:<br>
 Как использовать Preact полностью без Babel, ES2015 или JSX.
 
-**[preact-minimal](https://github.com/aganglada/preact-minimal)** :rocket:
+**[preact-minimal](https://github.com/aganglada/preact-minimal)** :rocket:<br>
 Минимальная структура Preact со всеми необходимыми инструментами для немедленного запуска вашего проекта.
 
-**[preact-typescript-webpack4-less](https://github.com/lexey111/preact-typescript-webpack4-boilerplate)**
+**[preact-typescript-webpack4-less](https://github.com/lexey111/preact-typescript-webpack4-boilerplate)**<br>
 Ещё один минимальный набор с Preact, Typescript и Webpack 4.
 
-**[Preact Homepage Generator](https://thomaswood.me/)** :globe_with_meridians:
-Быстро создайте новую личную веб-страницу, всего лишь изменив данные JSON.
-[Проект Github](https://github.com/tomasswood/preact-homepage-generator)
+**[Preact Homepage Generator](https://thomaswood.me/)** :globe_with_meridians:<br>
+Быстро создайте новую личную веб-страницу, всего лишь изменив данные JSON.<br>
+[Проект GitHub](https://github.com/tomasswood/preact-homepage-generator)
 
-**[Parcel + Preact + Unistore Starter](https://github.com/hwclass/parcel-preact-unistore-starter)**
+**[Parcel + Preact + Unistore Starter](https://github.com/hwclass/parcel-preact-unistore-starter)**<br>
 Стартовый пакет для молниеносного прототипирования и создания структуры проекта малого/среднего размера.
 
 ## Codepens
@@ -127,6 +127,6 @@ description: Коллекция демо-версий и примеров при
 
 ## Шаблоны
 
-:zap: [**Шаблон JSFiddle**](https://jsfiddle.net/developit/rs6zrh5f/embedded/result/)
+:zap: **[Шаблон JSFiddle](https://jsfiddle.net/developit/rs6zrh5f/embedded/result/)**
 
-:zap: [**Шаблон CodePen**](http://codepen.io/developit/pen/pgaROe?editors=0010)
+:zap: **[Шаблон CodePen](http://codepen.io/developit/pen/pgaROe?editors=0010)**

--- a/content/ru/about/libraries-addons.md
+++ b/content/ru/about/libraries-addons.md
@@ -12,51 +12,51 @@ description: Коллекция библиотек и дополнений, ко
 
 ## Дополнения
 
-- :repeat: [**preact-cycle**](https://github.com/developit/preact-cycle): Функционально-реактивная парадигма для Preact
-- :page_facing_up: [**preact-render-to-string**](https://github.com/preactjs/preact-render-to-string): Универсальный рендеринг.
-- :timer_clock: [**relaks**](https://github.com/trambarhq/relaks): Создавайте компоненты с методами рендеринга, которые возвращаются асинхронно.
-- :nut_and_bolt: [**express-preact-views**](https://github.com/edwjusti/express-preact-views): Express View Engine.
-- :floppy_disk: [**Prefresh**](https://github.com/JoviDeCroock/prefresh): Fast-Refresh для Preact.
+- :repeat: **[preact-cycle](https://github.com/developit/preact-cycle)**: Функционально-реактивная парадигма для Preact
+- :page_facing_up: **[preact-render-to-string](https://github.com/preactjs/preact-render-to-string)**: Универсальный рендеринг.
+- :timer_clock: **[relaks](https://github.com/trambarhq/relaks)**: Создавайте компоненты с методами рендеринга, которые возвращаются асинхронно.
+- :nut_and_bolt: **[express-preact-views](https://github.com/edwjusti/express-preact-views)**: Express View Engine.
+- :floppy_disk: **[Prefresh](https://github.com/JoviDeCroock/prefresh)**: Fast-Refresh для Preact.
 
 ## Компоненты
 
-- :earth_americas: [**preact-router**](https://github.com/preactjs/preact-router): Маршрутизация URL-адресов для ваших компонентов
-- :bookmark_tabs: [**preact-markup**](https://github.com/developit/preact-markup): Рендеринг HTML и пользовательских элементов в виде JSX и компонентов
-- :satellite: [**preact-portal**](https://github.com/developit/preact-portal): Рендеринг компонентов Preact в SPACE :milky_way:
-- :pencil: [**preact-richtextarea**](https://github.com/developit/preact-richtextarea): Простой компонент HTML-редактора
-- :bookmark: [**preact-token-input**](https://github.com/developit/preact-token-input): Текстовое поле, в котором происходит токенизация вводимых данных, для таких вещей, как теги
-- :card_index: [**preact-virtual-list**](https://github.com/developit/preact-virtual-list): Удобное отображение списков с миллионами строк ([demo](https://jsfiddle.net/developit/qqan9pdo/))
-- :triangular_ruler: [**preact-layout**](https://download.github.io/preact-layout/): Небольшая и простая библиотека макетов
-- :construction_worker: [**preact-helmet**](https://github.com/download/preact-helmet): Главный менеджер документов для Preact
-- :arrow_up_down: [**preact-custom-scrollbars**](https://github.com/lucafalasco/preact-custom-scrollbars): Полностью настраиваемые полосы прокрутки для удобной прокрутки в браузере.
-- 🧱 [**@modular-forms/preact**](https://modularforms.dev/): Модульная и типобезопасная библиотека форм.
+- :earth_americas: **[preact-router](https://github.com/preactjs/preact-router)**: Маршрутизация URL-адресов для ваших компонентов
+- :bookmark_tabs: **[preact-markup](https://github.com/developit/preact-markup)**: Рендеринг HTML и пользовательских элементов в виде JSX и компонентов
+- :satellite: **[preact-portal](https://github.com/developit/preact-portal)**: Рендеринг компонентов Preact в SPACE :milky_way:
+- :pencil: **[preact-richtextarea](https://github.com/developit/preact-richtextarea)**: Простой компонент HTML-редактора
+- :bookmark: **[preact-token-input](https://github.com/developit/preact-token-input)**: Текстовое поле, в котором происходит токенизация вводимых данных, для таких вещей, как теги
+- :card_index: **[preact-virtual-list](https://github.com/developit/preact-virtual-list)**: Удобное отображение списков с миллионами строк ([demo](https://jsfiddle.net/developit/qqan9pdo/))
+- :triangular_ruler: **[preact-layout](https://download.github.io/preact-layout/)**: Небольшая и простая библиотека макетов
+- :construction_worker: **[preact-helmet](https://github.com/download/preact-helmet)**: Главный менеджер документов для Preact
+- :arrow_up_down: **[preact-custom-scrollbars](https://github.com/lucafalasco/preact-custom-scrollbars)**: Полностью настраиваемые полосы прокрутки для удобной прокрутки в браузере.
+- 🧱 **[@modular-forms/preact](https://modularforms.dev/)**: Модульная и типобезопасная библиотека форм.
 
 ## Интеграции
 
-- :thought_balloon: [**preact-socrates**](https://github.com/matthewmueller/preact-socrates): Плагин Preact для [Socrates](http://github.com/matthewmueller/socrates)
-- :rowboat: [**preact-flyd**](https://github.com/xialvjun/preact-flyd): Use [flyd](https://github.com/paldepind/flyd) Потоки FRP в Preact + JSX
-- :speech_balloon: [**preact-i18nline**](https://github.com/download/preact-i18nline): Интегрирует экосистему вокруг [i18n-js](https://github.com/everydayhero/i18n-js) с Preact через [i18nline](https://github.com/download/i18nline).
-- :diamond_shape_with_a_dot_inside: [**Capacitor**](https://capacitorjs.com/solution/preact): Превратите свое приложение Preact в нативное приложение для iOS/Android и PWA.
-- 🏝: [**preact-island**](https://github.com/mwood23/preact-island): Запустите виджет Preact на любом веб-сайте с реактивными реквизитами.
+- :thought_balloon: **[preact-socrates](https://github.com/matthewmueller/preact-socrates)**: Плагин Preact для [Socrates](http://github.com/matthewmueller/socrates)
+- :rowboat: **[preact-flyd](https://github.com/xialvjun/preact-flyd)**: Use [flyd](https://github.com/paldepind/flyd) Потоки FRP в Preact + JSX
+- :speech_balloon: **[preact-i18nline](https://github.com/download/preact-i18nline)**: Интегрирует экосистему вокруг [i18n-js](https://github.com/everydayhero/i18n-js) с Preact через [i18nline](https://github.com/download/i18nline).
+- :diamond_shape_with_a_dot_inside: **[Capacitor](https://capacitorjs.com/solution/preact)**: Превратите свое приложение Preact в нативное приложение для iOS/Android и PWA.
+- 🏝: **[preact-island](https://github.com/mwood23/preact-island)**: Запустите виджет Preact на любом веб-сайте с реактивными реквизитами.
 
 ## Инструментальные средства графического интерфейса
 
-- 🎴 [**@mui/material**](https://github.com/mui/material-ui/tree/master/examples/material-ui-preact): библиотека React UI, которую вы всегда хотели. Следуйте своей собственной системе дизайна или начните с Material Design.
-- :thumbsup: [**preact-material-components**](https://github.com/prateekbh/preact-material-components): Материальные компоненты для Интернета (заменяют MDL)
-- :white_square_button: [**preact-mdl**](https://github.com/developit/preact-mdl): Используйте [MDL](https://getmdl.io) в качестве компонентов Preact
-- :rocket: [**preact-photon**](https://github.com/developit/preact-photon): Создание красивых пользовательских интерфейсов на рабочем столе с помощью [photon](http://photonkit.com)
-- :penguin: [**preact-weui**](https://github.com/afeiship/preact-weui): [Weui](https://github.com/afeiship/preact-weui) для Preact
-- 💅 [**preact-fluid**](https://github.com/ajainvivek/preact-fluid): [Fluid](https://github.com/ajainvivek/preact-fluid) — минимальный набор пользовательских интерфейсов для Preact
-- :book: [**storybook-preact**](https://github.com/storybooks/storybook/tree/next/app/preact): Storybook for Preact — это среда разработки пользовательского интерфейса для компонентов Preact.
+- 🎴 **[@mui/material](https://github.com/mui/material-ui/tree/master/examples/material-ui-preact)**: библиотека React UI, которую вы всегда хотели. Следуйте своей собственной системе дизайна или начните с Material Design.
+- :thumbsup: **[preact-material-components](https://github.com/prateekbh/preact-material-components)**: Материальные компоненты для Интернета (заменяют MDL)
+- :white_square_button: **[preact-mdl](https://github.com/developit/preact-mdl)**: Используйте [MDL](https://getmdl.io) в качестве компонентов Preact
+- :rocket: **[preact-photon](https://github.com/developit/preact-photon)**: Создание красивых пользовательских интерфейсов на рабочем столе с помощью [photon](http://photonkit.com)
+- :penguin: **[preact-weui](https://github.com/afeiship/preact-weui)**: [Weui](https://github.com/afeiship/preact-weui) для Preact
+- 💅 **[preact-fluid](https://github.com/ajainvivek/preact-fluid)**: [Fluid](https://github.com/ajainvivek/preact-fluid) — минимальный набор пользовательских интерфейсов для Preact
+- :book: **[storybook-preact](https://github.com/storybooks/storybook/tree/next/app/preact)**: Storybook for Preact — это среда разработки пользовательского интерфейса для компонентов Preact.
 
 ### Тестирование
 
-- :microscope: [**preact-jsx-chai**](https://github.com/developit/preact-jsx-chai): Тестирование утверждений JSX _(без DOM, прямо в Node)_.
-- :white_check_mark: [**unexpected-preact**](https://github.com/bruderstein/unexpected-preact): JSX утверждения, события, снимки в Jest *(DOM, работает под Node jsdom или «из коробки» в Jest)* — [docs](https://bruderstein.github.io/unexpected-preact/)
+- :microscope: **[preact-jsx-chai](https://github.com/developit/preact-jsx-chai)**: Тестирование утверждений JSX _(без DOM, прямо в Node)_.
+- :white_check_mark: **[unexpected-preact](https://github.com/bruderstein/unexpected-preact)**: JSX утверждения, события, снимки в Jest *(DOM, работает под Node jsdom или «из коробки» в Jest)* — [docs](https://bruderstein.github.io/unexpected-preact/)
 
 ## Утилиты
 
-- :tophat: [**preact-classless-component**](https://github.com/ld0rman/preact-classless-component): создание компонентов preact без ключевого слова `class`
-- :hammer: [**preact-hyperscript**](https://github.com/queckezz/preact-hyperscript): Гиперскриптоподобный синтаксис для создания элементов
-- :white_check_mark: [**shallow-compare**](https://github.com/tkh44/shallow-compare): Упрощенный хэлпер `shouldComponentUpdate`.
-- :signal_strength: [**@deepsignal/preact**](https://github.com/EthanStandel/deepsignal/tree/main/packages/preact): Расширение `@preact/signals` для полного управления состояниями
+- :tophat: **[preact-classless-component](https://github.com/ld0rman/preact-classless-component)**: создание компонентов preact без ключевого слова `class`
+- :hammer: **[preact-hyperscript](https://github.com/queckezz/preact-hyperscript)**: Гиперскриптоподобный синтаксис для создания элементов
+- :white_check_mark: **[shallow-compare](https://github.com/tkh44/shallow-compare)**: Упрощенный хэлпер `shouldComponentUpdate`.
+- :signal_strength: **[@deepsignal/preact](https://github.com/EthanStandel/deepsignal/tree/main/packages/preact)**: Расширение `@preact/signals` для полного управления состояниями

--- a/content/tr/about/demos-examples.md
+++ b/content/tr/about/demos-examples.md
@@ -9,86 +9,85 @@ Bu sayfada Preact öğrenmek için kullanabileceğiniz demolar ve örnekler list
 > :information_desk_person: _Sizin de mi bir örneğiniz var ?
 > [Ekleyin!](https://github.com/preactjs/preact-www/blob/master/content/tr/about/demos-examples.md)_
 
-
 ## Tamamlanmış Uygulamalar
 
-[**Preact İnternet Sitesi** _(preactjs.com)_](https://preactjs.com)  
-Tabii ki de bu site Preact ile geliştirildi.  
-[Github Projesi](https://github.com/preactjs/preact-www)
+**[Preact İnternet Sitesi (preactjs.com)](https://preactjs.com)**<br>
+Tabii ki de bu site Preact ile geliştirildi.<br>
+[GitHub Projesi](https://github.com/preactjs/preact-www)
 
-**[ESBench](http://esbench.com)** :alarm_clock:  
+**[ESBench](http://esbench.com)** :alarm_clock:<br>
 Preact & Material Design Lite kullanarak geliştirildi.
 
-[**GuriVR**](https://gurivr.com) :eyeglasses:
-Doğal dil tabanlı Web VR hikaye yaratıcısı. 
-_([Github Projesi](https://github.com/opennewslabs/guri-vr))_
+**[GuriVR](https://gurivr.com)** :eyeglasses:<br>
+Doğal dil tabanlı Web VR hikaye yaratıcısı.<br>
+[GitHub Projesi](https://github.com/opennewslabs/guri-vr)<br>
 
-[**BigWebQuiz**](https://bigwebquiz.com) :game_die:  
-Chrome Dev Summit 2016'dan katılımcılara Progressive Web App sunumu!  
-([Github Projesi](https://github.com/jakearchibald/big-web-quiz))
+**[BigWebQuiz](https://bigwebquiz.com)** :game_die:<br>
+Chrome Dev Summit 2016'dan katılımcılara Progressive Web App sunumu!<br>
+[GitHub Projesi](https://github.com/jakearchibald/big-web-quiz)
 
-**[Nectarine.rocks](http://nectarine.rocks)** :peach:  
-Açık kaynak peach.cool uygulaması.
-[Github Projesi](https://github.com/developit/nectarine)
+**[Nectarine.rocks](http://nectarine.rocks)** :peach:<br>
+Açık kaynak peach.cool uygulaması.<br>
+[GitHub Projesi](https://github.com/developit/nectarine)
 
-**[Dropfox](https://github.com/developit/dropfox)** :wolf:  
+**[Dropfox](https://github.com/developit/dropfox)** :wolf:<br>
 Dropbox için Preact, Electron ve Photon ile oluşturulmuş masaüstü uygulaması.
 
-**[Bağlantı raporu](https://cindex.co)** :iphone:  
+**[Bağlantı raporu](https://cindex.co)** :iphone:<br>
 Arama yapmanıza izin veren bir site [Akamia şirketinin ülke verilerine göre internet bağlantı raporu](https://content.akamai.com/PG7010-Q2-2016-SOTI-Connectivity-Report.html)
 
-**[Sürükle & Bırak dosya yükleme (webpack 2)](https://contentful-labs.github.io/file-upload-example/)** :rocket:
-İçerikleri yüklemeyi sürükle bırak ile yapan bir masaüstü uygulaması. (CMS bazlı API)
-[Github Projesi](https://github.com/contentful-labs/file-upload-example)
+**[Sürükle & Bırak dosya yükleme (webpack 2)](https://contentful-labs.github.io/file-upload-example/)** :rocket:<br>
+İçerikleri yüklemeyi sürükle bırak ile yapan bir masaüstü uygulaması. (CMS bazlı API)<br>
+[GitHub Projesi](https://github.com/contentful-labs/file-upload-example)
 
-**[Embed Hacker News](https://github.com/TXTPEN/hn)** :kissing_closed_eyes:
+**[Embed Hacker News](https://github.com/TXTPEN/hn)** :kissing_closed_eyes:<br>
 Embed Hacker News ile blog yazınızın altına yorumlar bırakın
 
-**[ColoGuessr](https://cologuessr.com)** :rainbow:
-Renklerinizi ne kadar iyi tanıdığınızı test edin
-[Github Project](https://github.com/jackpordi/cologuessr)
+**[ColoGuessr](https://cologuessr.com)** :rainbow:<br>
+Renklerinizi ne kadar iyi tanıdığınızı test edin<br>
+[GitHub Project](https://github.com/jackpordi/cologuessr)
 
 ## Demolar & Örnekler
 
-**[Dökümantasyon görüntüleyici](https://documentation-viewer.firebaseapp.com)**  
-Documentation.js çıktısını çevrimiçi görüntülemenize yarar.
-[Github Projesi](https://github.com/developit/documentation-viewer)
+**[Dökümantasyon görüntüleyici](https://documentation-viewer.firebaseapp.com)**<br>
+Documentation.js çıktısını çevrimiçi görüntülemenize yarar.<br>
+[GitHub Projesi](https://github.com/developit/documentation-viewer)
 
-**[TodoMVC](http://developit.github.io/preact-todomvc/)**  
-Gayri resmi en hızlı TodoMVC uygulaması.  
-[Github Projesi](https://github.com/developit/preact-todomvc)
+**[TodoMVC](http://developit.github.io/preact-todomvc/)**<br>
+Gayri resmi en hızlı TodoMVC uygulaması.<br>
+[GitHub Projesi](https://github.com/developit/preact-todomvc)
 
-**[TodoMVC+PouchDB](http://katopz.github.io/preact-todomvc-pouchdb/)** :floppy_disk:  
-Çevrimdışı senkronizasyon destekli TodoMVC [PouchDB](https://pouchdb.com/).  
-[Github Projesi](https://github.com/katopz/preact-todomvc-pouchdb)
+**[TodoMVC+PouchDB](http://katopz.github.io/preact-todomvc-pouchdb/)** :floppy_disk:<br>
+Çevrimdışı senkronizasyon destekli TodoMVC [PouchDB](https://pouchdb.com/).<br>
+[GitHub Projesi](https://github.com/katopz/preact-todomvc-pouchdb)
 
-**[Hacker News Minimal](https://developit.github.io/hn_minimal/)** :newspaper:  
-Oldukça miminal olarak hazırlanmış hacker news web sitesi.  
-[Github Projesi](https://github.com/developit/hn_minimal)
+**[Hacker News Minimal](https://developit.github.io/hn_minimal/)** :newspaper:<br>
+Oldukça miminal olarak hazırlanmış hacker news web sitesi.<br>
+[GitHub Projesi](https://github.com/developit/hn_minimal)
 
-**[Preact Boilerplate](https://preact-boilerplate.surge.sh)** :zap:  
-Preact + Webpack + LESS + CSS paketlerinin dahil olduğu başlangıç paketi. 
-[Github Projesi](https://github.com/developit/preact-boilerplate)
+**[Preact Boilerplate](https://preact-boilerplate.surge.sh)** :zap:<br>
+Preact + Webpack + LESS + CSS paketlerinin dahil olduğu başlangıç paketi.<br>
+[GitHub Projesi](https://github.com/developit/preact-boilerplate)
 
-**[Preact Çevrimdışı Başlangıç Kiti](https://preact-starter.now.sh)** :100:  
-Webpack2 kullanan Progressive Web Apps ve çevrımdışı destekli başlangıç paketi.  
-[Github Projesi](https://github.com/lukeed/preact-starter)
+**[Preact Çevrimdışı Başlangıç Kiti](https://preact-starter.now.sh)** :100:<br>
+Webpack2 kullanan Progressive Web Apps ve çevrımdışı destekli başlangıç paketi.<br>
+[GitHub Projesi](https://github.com/lukeed/preact-starter)
 
-**[Preact Redux Örneği](https://preact-redux-example.surge.sh)** :repeat:  
-Preact + Redux örnek proje, basit bir to-do list'e uygulanması. 
-[Github Projesi](https://github.com/developit/preact-redux-example)
+**[Preact Redux Örneği](https://preact-redux-example.surge.sh)** :repeat:<br>
+Preact + Redux örnek proje, basit bir to-do list'e uygulanması.<br>
+[GitHub Projesi](https://github.com/developit/preact-redux-example)
 
-**[Babel'siz Preact](https://github.com/developit/preact-without-babel)** :horse:  
+**[Babel'siz Preact](https://github.com/developit/preact-without-babel)** :horse:<br>
 Preact'ı Babel, ES2015 veya JSX olmadan kullanan bir proje.
 
-**[preact-minimal](https://github.com/aganglada/preact-minimal)** :rocket:  
+**[preact-minimal](https://github.com/aganglada/preact-minimal)** :rocket:<br>
 Minimal Preact yapısı ile projenizi hemen başlatmak için gerekli tüm araçlar.
 
-**[Preact Kişisel Site Oluşturucu](https://thomaswood.me/)** :globe_with_meridians:  
-Yalnızca json verileri değiştirerek, oldukça hızlı bir şekilde kişisel web sitenizi oluşturun.
-[Github Projesi](https://github.com/tomasswood/preact-homepage-generator)
+**[Preact Kişisel Site Oluşturucu](https://thomaswood.me/)** :globe_with_meridians:<br>
+Yalnızca json verileri değiştirerek, oldukça hızlı bir şekilde kişisel web sitenizi oluşturun.<br>
+[GitHub Projesi](https://github.com/tomasswood/preact-homepage-generator)
 
-**[Parcel + Preact + Unistore Başlangıç](https://github.com/hwclass/parcel-preact-unistore-starter)**
+**[Parcel + Preact + Unistore Başlangıç](https://github.com/hwclass/parcel-preact-unistore-starter)**<br>
 Yıldırım hızında bir başlangıç kiti. Küçük/Orta ölçekli proje yapıları için ideal.
 
 ## Codepens
@@ -101,6 +100,6 @@ Yıldırım hızında bir başlangıç kiti. Küçük/Orta ölçekli proje yapı
 
 ## Templates
 
-:zap: [**JSFiddle Template**](https://jsfiddle.net/developit/rs6zrh5f/embedded/result/)
+:zap: **[JSFiddle Template](https://jsfiddle.net/developit/rs6zrh5f/embedded/result/)**
 
-:zap: [**CodePen Template**](http://codepen.io/developit/pen/pgaROe?editors=0010)
+:zap: **[CodePen Template](http://codepen.io/developit/pen/pgaROe?editors=0010)**

--- a/content/tr/about/libraries-addons.md
+++ b/content/tr/about/libraries-addons.md
@@ -9,40 +9,40 @@ Preact ile oluşturulmuş mükemmel modül koleksiyonu.
 > [Sende Ekle!](https://github.com/preactjs/preact-www/blob/master/content/tr/about/libraries-addons.md)_
 
 ### Eklentiler
-- :raised_hands: [**preact-compat**](https://github.com/preactjs/preact-compat): Herhangi React kütüphanesini Preact ile kullan *([tam örnek](https://github.com/developit/preact-compat-example))*
-- :repeat: [**preact-cycle**](https://github.com/developit/preact-cycle): Preact için Functional-reactive paradigma
-- :page_facing_up: [**preact-render-to-string**](https://github.com/preactjs/preact-render-to-string): Universal rendering.
+- :raised_hands: **[preact-compat](https://github.com/preactjs/preact-compat)**: Herhangi React kütüphanesini Preact ile kullan *([tam örnek](https://github.com/developit/preact-compat-example))*
+- :repeat: **[preact-cycle](https://github.com/developit/preact-cycle)**: Preact için Functional-reactive paradigma
+- :page_facing_up: **[preact-render-to-string](https://github.com/preactjs/preact-render-to-string)**: Universal rendering.
 
 ### Bileşenler
-- :earth_americas: [**preact-router**](https://github.com/preactjs/preact-router): Bileşenlerin için URL yönlendirmesi
-- :bookmark_tabs: [**preact-markup**](https://github.com/developit/preact-markup): JSX & Bileşen olarak HTML & Özel Elementler Oluştur
-- :satellite: [**preact-portal**](https://github.com/developit/preact-portal): Preact bileşenlerini (bir) SPACE içine yerleştirin :milky_way:
-- :pencil: [**preact-richtextarea**](https://github.com/developit/preact-richtextarea): Basit HTML editör bileşeni
-- :bookmark: [**preact-token-input**](https://github.com/developit/preact-token-input): Etiket gibi şeyler için token girişi yapılan metin alanı
-- :card_index: [**preact-virtual-list**](https://github.com/developit/preact-virtual-list): Milyonlarca satır ile kolayca listeler oluştur ([demo](https://jsfiddle.net/developit/qqan9pdo/))
-- :triangular_ruler: [**preact-layout**](https://download.github.io/preact-layout/): Kolay ve basit layout kütüphaneleri
-- :construction_worker: [**preact-helmet**](https://github.com/download/preact-helmet): Preact için belge yöneticisi
-- :arrow_up_down: [**preact-custom-scrollbars**](https://github.com/lucafalasco/preact-custom-scrollbars): Native tarayıcı scrolling için tam özelleştirilebilir scrollbarlar
+- :earth_americas: **[preact-router](https://github.com/preactjs/preact-router)**: Bileşenlerin için URL yönlendirmesi
+- :bookmark_tabs: **[preact-markup](https://github.com/developit/preact-markup)**: JSX & Bileşen olarak HTML & Özel Elementler Oluştur
+- :satellite: **[preact-portal](https://github.com/developit/preact-portal)**: Preact bileşenlerini (bir) SPACE içine yerleştirin :milky_way:
+- :pencil: **[preact-richtextarea](https://github.com/developit/preact-richtextarea)**: Basit HTML editör bileşeni
+- :bookmark: **[preact-token-input](https://github.com/developit/preact-token-input)**: Etiket gibi şeyler için token girişi yapılan metin alanı
+- :card_index: **[preact-virtual-list](https://github.com/developit/preact-virtual-list)**: Milyonlarca satır ile kolayca listeler oluştur ([demo](https://jsfiddle.net/developit/qqan9pdo/))
+- :triangular_ruler: **[preact-layout](https://download.github.io/preact-layout/)**: Kolay ve basit layout kütüphaneleri
+- :construction_worker: **[preact-helmet](https://github.com/download/preact-helmet)**: Preact için belge yöneticisi
+- :arrow_up_down: **[preact-custom-scrollbars](https://github.com/lucafalasco/preact-custom-scrollbars)**: Native tarayıcı scrolling için tam özelleştirilebilir scrollbarlar
 
 ### Entegrasyonlar
-- :thought_balloon: [**preact-socrates**](https://github.com/matthewmueller/preact-socrates): [Socrates](http://github.com/matthewmueller/socrates) için Preact eklentileri
-- :rowboat: [**preact-flyd**](https://github.com/xialvjun/preact-flyd): [flyd](https://github.com/paldepind/flyd) FRP stream'leri Preact + JSX'de kullanın
-- :speech_balloon: [**preact-i18nline**](https://github.com/download/preact-i18nline):[i18n-js](https://github.com/everydayhero/i18n-js) çevresindeki ekosistemi [i18nline](https://github.com/download/i18nline) yoluyla Preact ile bütünleştirir.
+- :thought_balloon: **[preact-socrates](https://github.com/matthewmueller/preact-socrates)**: [Socrates](http://github.com/matthewmueller/socrates) için Preact eklentileri
+- :rowboat: **[preact-flyd](https://github.com/xialvjun/preact-flyd)**: [flyd](https://github.com/paldepind/flyd) FRP stream'leri Preact + JSX'de kullanın
+- :speech_balloon: **[preact-i18nline](https://github.com/download/preact-i18nline)**:[i18n-js](https://github.com/everydayhero/i18n-js) çevresindeki ekosistemi [i18nline](https://github.com/download/i18nline) yoluyla Preact ile bütünleştirir.
 
 
 ### GUI Araçları
-- :white_square_button: [**preact-mdl**](https://github.com/developit/preact-mdl): Preact bileşenleri olarak [MDL](https://getmdl.io) kullanın.
-- :rocket: [**preact-photon**](https://github.com/developit/preact-photon):[photon](http://photonkit.com) ile güzel masaüstü UI'lari oluşturun.
-- :penguin: [**preact-weui**](https://github.com/afeiship/preact-weui):Preact için [Weui](https://github.com/afeiship/preact-weui)
-- 💅 [**preact-fluid**](https://github.com/ajainvivek/preact-fluid):Preact için minimal [Fluid](https://github.com/ajainvivek/preact-fluid) UI araçları.
+- :white_square_button: **[preact-mdl](https://github.com/developit/preact-mdl)**: Preact bileşenleri olarak [MDL](https://getmdl.io) kullanın.
+- :rocket: **[preact-photon](https://github.com/developit/preact-photon)**:[photon](http://photonkit.com) ile güzel masaüstü UI'lari oluşturun.
+- :penguin: **[preact-weui](https://github.com/afeiship/preact-weui)**:Preact için [Weui](https://github.com/afeiship/preact-weui)
+- 💅 **[preact-fluid](https://github.com/ajainvivek/preact-fluid)**:Preact için minimal [Fluid](https://github.com/ajainvivek/preact-fluid) UI araçları.
 
 ### Test Araçları
-- :microscope: [**preact-jsx-chai**](https://github.com/developit/preact-jsx-chai): JSX assertion testing _(no DOM, right in Node)_
-- :white_check_mark: [**unexpected-preact**](https://github.com/bruderstein/unexpected-preact): JSX assertions, events, snapshots in Jest _(DOM, works under Node jsdom or out-of-the-box in Jest)_ - [docs](https://bruderstein.github.io/unexpected-preact/)
+- :microscope: **[preact-jsx-chai](https://github.com/developit/preact-jsx-chai)**: JSX assertion testing _(no DOM, right in Node)_
+- :white_check_mark: **[unexpected-preact](https://github.com/bruderstein/unexpected-preact)**: JSX assertions, events, snapshots in Jest _(DOM, works under Node jsdom or out-of-the-box in Jest)_ - [docs](https://bruderstein.github.io/unexpected-preact/)
 
 
 ### Yardımcı Uygulamalar
 
-- :tophat: [**preact-classless-component**](https://github.com/ld0rman/preact-classless-component): Sınıf keyword olmadan preact bileşenleri yaratın.
-- :hammer: [**preact-hyperscript**](https://github.com/queckezz/preact-hyperscript): Element oluşturmak için Hyperscript-like sözdizimi.
-- :white_check_mark: [**shallow-compare**](https://github.com/tkh44/shallow-compare): Basitleştirilmiş `shouldComponentUpdate` yardımcısı.
+- :tophat: **[preact-classless-component](https://github.com/ld0rman/preact-classless-component)**: Sınıf keyword olmadan preact bileşenleri yaratın.
+- :hammer: **[preact-hyperscript](https://github.com/queckezz/preact-hyperscript)**: Element oluşturmak için Hyperscript-like sözdizimi.
+- :white_check_mark: **[shallow-compare](https://github.com/tkh44/shallow-compare)**: Basitleştirilmiş `shouldComponentUpdate` yardımcısı.

--- a/content/zh/about/demos-examples.md
+++ b/content/zh/about/demos-examples.md
@@ -9,114 +9,114 @@ title: 示例和演示
 > :information_desk_person: _构建一个你自己的模块?
 > [Add it!](https://github.com/preactjs/preact-www/blob/master/content/zh/about/demos-examples.md)_
 
-
 ## 完整的 app
 
-[**Preact Website** _(preactjs.com)_](https://preactjs.com)  
-该网站基于 Preact。
-[Github Project](https://github.com/preactjs/preact-www)
+**[Preact Website (preactjs.com)](https://preactjs.com)**<br>
+该网站基于 Preact。<br>
+[GitHub Project](https://github.com/preactjs/preact-www)
 
-**[ESBench](http://esbench.com)** :alarm_clock:  
+**[ESBench](http://esbench.com)** :alarm_clock:<br>
 基于 Preact & Material Design Lite
 
-[**GuriVR**](https://gurivr.com) :eyeglasses:
-基于自然语言的网络VR故事创造器。
-[Github Project](https://github.com/opennewslabs/guri-vr)
+**[GuriVR](https://gurivr.com)** :eyeglasses:<br>
+基于自然语言的网络VR故事创造器。<br>
+[GitHub Project](https://github.com/opennewslabs/guri-vr)
 
-[**BigWebQuiz**](https://bigwebquiz.com) :game_die:  
-2016年Chrome Dev峰会上观众参与的渐进式网络应用程序!
-[Github Project](https://github.com/jakearchibald/big-web-quiz)
+**[BigWebQuiz](https://bigwebquiz.com)** :game_die:<br>
+2016年Chrome Dev峰会上观众参与的渐进式网络应用程序!<br>
+[GitHub Project](https://github.com/jakearchibald/big-web-quiz)
 
-**[Nectarine.rocks](http://nectarine.rocks)** :peach:  
-一款开源的 peach.cool app。
-[Github Project](https://github.com/developit/nectarine)
+**[Nectarine.rocks](http://nectarine.rocks)** :peach:<br>
+一款开源的 peach.cool app。<br>
+[GitHub Project](https://github.com/developit/nectarine)
 
 **[Web Maker](https://webmaker.app/)** :zap:
-急速并支持离线的前端游乐场。
-[Github Project](https://github.com/chinchang/web-maker)
+急速并支持离线的前端游乐场。<br>
+[GitHub Project](https://github.com/chinchang/web-maker)
 
-**[BitMidi](https://bitmidi.com/)** :musical_keyboard:
-免费MIDI文件回放机
-[Github Project](https://github.com/feross/bitmidi.com)
+**[BitMidi](https://bitmidi.com/)** :musical_keyboard:<br>
+免费MIDI文件回放机<br>
+[GitHub Project](https://github.com/feross/bitmidi.com)
 
-**[BBC Roasting Calculator](https://www.bbc.com/food/techniques/articles/roast-calculator)** :turkey:
+**[BBC Roasting Calculator](https://www.bbc.com/food/techniques/articles/roast-calculator)** :turkey:<br>
 计算不同种类的肉烹饪时间。
 
-**[Dropfox](https://github.com/developit/dropfox)** :wolf:  
+**[Dropfox](https://github.com/developit/dropfox)** :wolf:<br>
 Dropbox 的桌面 app，基于 Preact、Electron 和 Photon。
 
-**[Embed Hacker News](https://github.com/TXTPEN/hn)** :kissing_closed_eyes:
+**[Embed Hacker News](https://github.com/TXTPEN/hn)** :kissing_closed_eyes:<br>
 在你的博客文章下面嵌入Hacker News评论树。
 
-**[Connectivity Index](https://cindex.co)** :iphone:  
+**[Connectivity Index](https://cindex.co)** :iphone:<br>
 一个允许您按国家搜索[Akamai互联网连接状况报告](https://content.akamai.com/PG7010-Q2-2016-SOTI-Connectivity-Report.html)数据的网站。
 
-**[Drag & Drop file upload (webpack 2)](https://contentful-labs.github.io/file-upload-example/)** :rocket:
-用于将资源上传到Contentful（基于API的CMS）的桌面应用程序
-[Github Project](https://github.com/contentful-labs/file-upload-example)
+**[Drag & Drop file upload (webpack 2)](https://contentful-labs.github.io/file-upload-example/)** :rocket:<br>
+用于将资源上传到Contentful（基于API的CMS）的桌面应用程序<br>
+[GitHub Project](https://github.com/contentful-labs/file-upload-example)
 
-**[Exchange Widget](https://sgtpep.github.io/exchange-widget/dist/)** :currency_exchange:
-货币兑换小工具,灵感来自于一个流行的移动应用程序，使用Preact、Meiosis、HTML标签模板和本地ES模块实现。
-[Github Project](https://github.com/sgtpep/exchange-widget)
+**[Exchange Widget](https://sgtpep.github.io/exchange-widget/dist/)** :currency_exchange:<br>
+货币兑换小工具,灵感来自于一个流行的移动应用程序，使用Preact、Meiosis、HTML标签模板和本地ES模块实现。<br>
+[GitHub Project](https://github.com/sgtpep/exchange-widget)
 
-**[Blaze](https://blaze.now.sh)** :zap:  
-先进的P2P文件共享的渐进式网络应用程序。
-[Github Project](https://github.com/blenderskool/blaze)
+**[Blaze](https://blaze.now.sh)** :zap:<br>
+先进的P2P文件共享的渐进式网络应用程序。<br>
+[GitHub Project](https://github.com/blenderskool/blaze)
 
-**[1tuner](https://1tuner.com)** :radio:  
-收听广播和博客
-[Github Project](https://github.com/robinbakker/1tuner)
+**[1tuner](https://1tuner.com)** :radio:<br>
+收听广播和博客<br>
+[GitHub Project](https://github.com/robinbakker/1tuner)
 
-**[ColoGuessr](https://cologuessr.com)** :rainbow:
-测试你对自己的颜色有多了解
-[Github Project](https://github.com/jackpordi/cologuessr)
+**[ColoGuessr](https://cologuessr.com)** :rainbow:<br>
+测试你对自己的颜色有多了解<br>
+[GitHub Project](https://github.com/jackpordi/cologuessr)
 
 ## 完整的示例
 
-**[Documentation Viewer](https://documentation-viewer.firebaseapp.com)**  
-在线查看 documentation.js 生成的内容。
-[Github Project](https://github.com/developit/documentation-viewer)
+**[Documentation Viewer](https://documentation-viewer.firebaseapp.com)**<br>
+在线查看 documentation.js 生成的内容。<br>
+[GitHub Project](https://github.com/developit/documentation-viewer)
 
-**[TodoMVC](http://developit.github.io/preact-todomvc/)**  
-非官方最快的 TodoMVC 实现。
-[Github Project](https://github.com/developit/preact-todomvc)
+**[TodoMVC](http://developit.github.io/preact-todomvc/)**<br>
+非官方最快的 TodoMVC 实现。<br>
+[GitHub Project](https://github.com/developit/preact-todomvc)
 
-**[TodoMVC+PouchDB](http://katopz.github.io/preact-todomvc-pouchdb/)** :floppy_disk:  
-基于 [PouchDB](https://pouchdb.com/) 离线版 TodoMVC。
-[Github Project](https://github.com/katopz/preact-todomvc-pouchdb)
+**[TodoMVC+PouchDB](http://katopz.github.io/preact-todomvc-pouchdb/)** :floppy_disk:<br>
+基于 [PouchDB](https://pouchdb.com/) 离线版 TodoMVC。<br>
+[GitHub Project](https://github.com/katopz/preact-todomvc-pouchdb)
 
-**[Hacker News Minimal](https://developit.github.io/hn_minimal/)** :newspaper:  
-小型 hacker news 客户端。
-[Github Project](https://github.com/developit/hn_minimal)
+**[Hacker News Minimal](https://developit.github.io/hn_minimal/)** :newspaper:<br>
+小型 hacker news 客户端。<br>
+[GitHub Project](https://github.com/developit/hn_minimal)
 
-**[Preact Boilerplate](https://preact-boilerplate.surge.sh)** :zap:   
-两条命令开始一个项目，Preact + Webpack + LESS + CSS Modules.。
-[Github Project](https://github.com/developit/preact-boilerplate)
+**[Preact Boilerplate](https://preact-boilerplate.surge.sh)** :zap: <br>
+两条命令开始一个项目，Preact + Webpack + LESS + CSS Modules.。<br>
+[GitHub Project](https://github.com/developit/preact-boilerplate)
 
-**[Preact Offline Starter](https://preact-starter.now.sh)** :100:  
-用于渐进式Web应用支持离线的简化Webpack2启动器，
-[Github Project](https://github.com/lukeed/preact-starter)
+**[Preact Offline Starter](https://preact-starter.now.sh)** :100:<br>
+用于渐进式Web应用支持离线的简化Webpack2启动器，<br>
+[GitHub Project](https://github.com/lukeed/preact-starter)
 
-**[Preact Redux Example](https://preact-redux-example.surge.sh)** :repeat:  
-基于 Preact + Redux 的项目，实现一个简单的 To-Do list。
-[Github Project](https://github.com/developit/preact-redux-example)
+**[Preact Redux Example](https://preact-redux-example.surge.sh)** :repeat:<br>
+基于 Preact + Redux 的项目，实现一个简单的 To-Do list。<br>
+[GitHub Project](https://github.com/developit/preact-redux-example)
 
-**[Preact Without Babel](https://github.com/developit/preact-without-babel)** :horse:  
+**[Preact Without Babel](https://github.com/developit/preact-without-babel)** :horse:<br>
 怎么在没有 Babel、ES2015 或 JSX 的情况下使用 Preact。
 
-**[preact-minimal](https://github.com/aganglada/preact-minimal)** :rocket:  
+**[preact-minimal](https://github.com/aganglada/preact-minimal)** :rocket:<br>
 一个只包含必要组件的 Preact 脚手架,让你可以马上开始你的项目
 
-**[preact-typescript-webpack4-less](https://github.com/lexey111/preact-typescript-webpack4-boilerplate)**
+**[preact-typescript-webpack4-less](https://github.com/lexey111/preact-typescript-webpack4-boilerplate)**<br>
 包含Preact、Typescript和Webpack 4的脚手架
 
-**[Preact Homepage Generator](https://thomaswood.me/)** :globe_with_meridians:  
-仅仅需要修改 JSON 文件就可以马上生成一个个人网页
-[Github Project](https://github.com/tomasswood/preact-homepage-generator)
+**[Preact Homepage Generator](https://thomaswood.me/)** :globe_with_meridians:<br>
+仅仅需要修改 JSON 文件就可以马上生成一个个人网页<br>
+[GitHub Project](https://github.com/tomasswood/preact-homepage-generator)
 
-**[Parcel + Preact + Unistore Starter](https://github.com/hwclass/parcel-preact-unistore-starter)**
+**[Parcel + Preact + Unistore Starter](https://github.com/hwclass/parcel-preact-unistore-starter)**<br>
 用于快速开发原型设计或者中小项目的启动包
-**[buildless-preact-starter](https://github.com/ttntm/buildless-preact-starter)** :rocket:
+
+**[buildless-preact-starter](https://github.com/ttntm/buildless-preact-starter)** :rocket:<br>
 一个用于在无构建环境中使用 Preact 的启动模板
 
 ## Codepens 上的例子
@@ -130,6 +130,6 @@ Dropbox 的桌面 app，基于 Preact、Electron 和 Photon。
 
 ## 模版
 
-:zap: [**JSFiddle Template**](https://jsfiddle.net/developit/rs6zrh5f/embedded/result/)
+:zap: **[JSFiddle Template](https://jsfiddle.net/developit/rs6zrh5f/embedded/result/)**
 
-:zap: [**CodePen Template**](http://codepen.io/developit/pen/pgaROe?editors=0010)
+:zap: **[CodePen Template](http://codepen.io/developit/pen/pgaROe?editors=0010)**

--- a/content/zh/about/libraries-addons.md
+++ b/content/zh/about/libraries-addons.md
@@ -12,53 +12,53 @@ description: '与 Preact 完美配合的库和扩展集合'
 
 ## 扩展
 
-- :repeat: [**preact-cycle**](https://github.com/developit/preact-cycle): Preact 的函数式响应式编程范式
-- :page_facing_up: [**preact-render-to-string**](https://github.com/preactjs/preact-render-to-string): 通用渲染
-- :timer_clock: [**relaks**](https://github.com/trambarhq/relaks): 创建具有异步返回渲染方法的组件。
-- :nut_and_bolt: [**express-preact-views**](https://github.com/edwjusti/express-preact-views): Express 视图引擎
-- :floppy_disk: [**Prefresh**](https://github.com/JoviDeCroock/prefresh): Preact 的快速刷新插件
-- :bookmark_tabs: [**adonis-preact**](https://github.com/DonsWayo/adonis-preact): 在 Adonisjs 中使用 Preact
+- :repeat: **[preact-cycle](https://github.com/developit/preact-cycle)**: Preact 的函数式响应式编程范式
+- :page_facing_up: **[preact-render-to-string](https://github.com/preactjs/preact-render-to-string)**: 通用渲染
+- :timer_clock: **[relaks](https://github.com/trambarhq/relaks)**: 创建具有异步返回渲染方法的组件。
+- :nut_and_bolt: **[express-preact-views](https://github.com/edwjusti/express-preact-views)**: Express 视图引擎
+- :floppy_disk: **[Prefresh](https://github.com/JoviDeCroock/prefresh)**: Preact 的快速刷新插件
+- :bookmark_tabs: **[adonis-preact](https://github.com/DonsWayo/adonis-preact)**: 在 Adonisjs 中使用 Preact
 
 ## 组件
 
-- :earth_americas: [**preact-router**](https://github.com/preactjs/preact-router): 为您的组件提供 URL 路由
-- :bookmark_tabs: [**preact-markup**](https://github.com/developit/preact-markup): 将 HTML 和自定义元素渲染为 JSX 和组件
-- :satellite: [**preact-portal**](https://github.com/developit/preact-portal): 将 Preact 组件渲染到（一个）空间 :milky_way:
-- :pencil: [**preact-richtextarea**](https://github.com/developit/preact-richtextarea): 简单的 HTML 编辑器组件
-- :bookmark: [**preact-token-input**](https://github.com/developit/preact-token-input): 将输入标记化的文本字段，用于标签等功能
-- :card_index: [**preact-virtual-list**](https://github.com/developit/preact-virtual-list): 轻松渲染数百万行的列表 ([演示](https://jsfiddle.net/developit/qqan9pdo/))
-- :triangular_ruler: [**preact-layout**](https://download.github.io/preact-layout/): 小巧简单的布局库
-- :construction_worker: [**preact-helmet**](https://github.com/download/preact-helmet): Preact 的文档头管理器
-- :arrow_up_down: [**preact-custom-scrollbars**](https://github.com/lucafalasco/preact-custom-scrollbars): 完全可定制的滚动条，提供无摩擦的原生浏览器滚动体验
-- 🧱 [**@modular-forms/preact**](https://modularforms.dev/): 模块化和类型安全的表单库
+- :earth_americas: **[preact-router](https://github.com/preactjs/preact-router)**: 为您的组件提供 URL 路由
+- :bookmark_tabs: **[preact-markup](https://github.com/developit/preact-markup)**: 将 HTML 和自定义元素渲染为 JSX 和组件
+- :satellite: **[preact-portal](https://github.com/developit/preact-portal)**: 将 Preact 组件渲染到（一个）空间 :milky_way:
+- :pencil: **[preact-richtextarea](https://github.com/developit/preact-richtextarea)**: 简单的 HTML 编辑器组件
+- :bookmark: **[preact-token-input](https://github.com/developit/preact-token-input)**: 将输入标记化的文本字段，用于标签等功能
+- :card_index: **[preact-virtual-list](https://github.com/developit/preact-virtual-list)**: 轻松渲染数百万行的列表 ([演示](https://jsfiddle.net/developit/qqan9pdo/))
+- :triangular_ruler: **[preact-layout](https://download.github.io/preact-layout/)**: 小巧简单的布局库
+- :construction_worker: **[preact-helmet](https://github.com/download/preact-helmet)**: Preact 的文档头管理器
+- :arrow_up_down: **[preact-custom-scrollbars](https://github.com/lucafalasco/preact-custom-scrollbars)**: 完全可定制的滚动条，提供无摩擦的原生浏览器滚动体验
+- 🧱 **[@modular-forms/preact](https://modularforms.dev/)**: 模块化和类型安全的表单库
 
 ## 集成(Integrations)
 
-- :thought_balloon: [**preact-socrates**](https://github.com/matthewmueller/preact-socrates): [Socrates](http://github.com/matthewmueller/socrates) 的 Preact 插件
-- :rowboat: [**preact-flyd**](https://github.com/xialvjun/preact-flyd): 在 Preact + JSX 中使用 [flyd](https://github.com/paldepind/flyd) FRP 流
-- :speech_balloon: [**preact-i18nline**](https://github.com/download/preact-i18nline): 通过 [i18nline](https://github.com/download/i18nline) 将 [i18n-js](https://github.com/everydayhero/i18n-js) 生态系统与 Preact 集成。
-- :diamond_shape_with_a_dot_inside: [**Capacitor**](https://capacitorjs.com/solution/preact): 将您的 Preact 应用转换为原生 iOS/Android 应用和 PWA。
-- :ice_cube: [**Kretes**](https://kretes.dev/docs/howtos/preact-setup/): 使用 Preact 和 Node.js 构建全栈 TypeScript 应用
-- 🏝: [**preact-island**](https://github.com/mwood23/preact-island): 在任何网站上运行您的 Preact 小部件，具有响应式属性。
+- :thought_balloon: **[preact-socrates](https://github.com/matthewmueller/preact-socrates)**: [Socrates](http://github.com/matthewmueller/socrates) 的 Preact 插件
+- :rowboat: **[preact-flyd](https://github.com/xialvjun/preact-flyd)**: 在 Preact + JSX 中使用 [flyd](https://github.com/paldepind/flyd) FRP 流
+- :speech_balloon: **[preact-i18nline](https://github.com/download/preact-i18nline)**: 通过 [i18nline](https://github.com/download/i18nline) 将 [i18n-js](https://github.com/everydayhero/i18n-js) 生态系统与 Preact 集成。
+- :diamond_shape_with_a_dot_inside: **[Capacitor](https://capacitorjs.com/solution/preact)**: 将您的 Preact 应用转换为原生 iOS/Android 应用和 PWA。
+- :ice_cube: **[Kretes](https://kretes.dev/docs/howtos/preact-setup/)**: 使用 Preact 和 Node.js 构建全栈 TypeScript 应用
+- 🏝: **[preact-island](https://github.com/mwood23/preact-island)**: 在任何网站上运行您的 Preact 小部件，具有响应式属性。
 
 ## GUI 工具包
 
-- 🎴 [**@mui/material**](https://github.com/mui/material-ui/tree/master/examples/material-ui-preact): 您一直想要的 React UI 库。遵循您自己的设计系统，或从 Material Design 开始。
-- :thumbsup: [**preact-material-components**](https://github.com/prateekbh/preact-material-components): Web 的 Material Components（取代 MDL）
-- :white_square_button: [**preact-mdl**](https://github.com/developit/preact-mdl): 将 [MDL](https://getmdl.io) 用作 Preact 组件
-- :rocket: [**preact-photon**](https://github.com/developit/preact-photon): 使用 [photon](http://photonkit.com) 构建美观的桌面 UI
-- :penguin: [**preact-weui**](https://github.com/afeiship/preact-weui): 适用于 Preact 的 [Weui](https://github.com/afeiship/preact-weui)
-- 💅 [**preact-fluid**](https://github.com/ajainvivek/preact-fluid): 适用于 Preact 的 [Fluid](https://github.com/ajainvivek/preact-fluid) 极简 UI 套件
-- :book: [**storybook-preact**](https://github.com/storybooks/storybook/tree/next/app/preact): Storybook for Preact 是您的 Preact 组件UI 开发环境
+- 🎴 **[@mui/material](https://github.com/mui/material-ui/tree/master/examples/material-ui-preact)**: 您一直想要的 React UI 库。遵循您自己的设计系统，或从 Material Design 开始。
+- :thumbsup: **[preact-material-components](https://github.com/prateekbh/preact-material-components)**: Web 的 Material Components（取代 MDL）
+- :white_square_button: **[preact-mdl](https://github.com/developit/preact-mdl)**: 将 [MDL](https://getmdl.io) 用作 Preact 组件
+- :rocket: **[preact-photon](https://github.com/developit/preact-photon)**: 使用 [photon](http://photonkit.com) 构建美观的桌面 UI
+- :penguin: **[preact-weui](https://github.com/afeiship/preact-weui)**: 适用于 Preact 的 [Weui](https://github.com/afeiship/preact-weui)
+- 💅 **[preact-fluid](https://github.com/ajainvivek/preact-fluid)**: 适用于 Preact 的 [Fluid](https://github.com/ajainvivek/preact-fluid) 极简 UI 套件
+- :book: **[storybook-preact](https://github.com/storybooks/storybook/tree/next/app/preact)**: Storybook for Preact 是您的 Preact 组件UI 开发环境
 
 ### 测试
 
-- :microscope: [**preact-jsx-chai**](https://github.com/developit/preact-jsx-chai): JSX 断言测试 _（无需 DOM，直接在 Node 中运行）_
-- :white_check_mark: [**unexpected-preact**](https://github.com/bruderstein/unexpected-preact): Jest 中的 JSX 断言、事件、快照 _（DOM，在 Node jsdom 下运行或在 Jest 中开箱即用）_ - [文档](https://bruderstein.github.io/unexpected-preact/)
+- :microscope: **[preact-jsx-chai](https://github.com/developit/preact-jsx-chai)**: JSX 断言测试 _（无需 DOM，直接在 Node 中运行）_
+- :white_check_mark: **[unexpected-preact](https://github.com/bruderstein/unexpected-preact)**: Jest 中的 JSX 断言、事件、快照 _（DOM，在 Node jsdom 下运行或在 Jest 中开箱即用）_ - [文档](https://bruderstein.github.io/unexpected-preact/)
 
 ## 实用工具
 
-- :tophat: [**preact-classless-component**](https://github.com/ld0rman/preact-classless-component): 无需使用 class 关键字即可创建 preact 组件
-- :hammer: [**preact-hyperscript**](https://github.com/queckezz/preact-hyperscript): 用于创建元素的类 Hyperscript 语法
-- :white_check_mark: [**shallow-compare**](https://github.com/tkh44/shallow-compare): 简化的 `shouldComponentUpdate` 辅助函数。
-- :signal_strength: [**@deepsignal/preact**](https://github.com/EthanStandel/deepsignal/tree/main/packages/preact): `@preact/signals` 的扩展，用于完整的状态管理
+- :tophat: **[preact-classless-component](https://github.com/ld0rman/preact-classless-component)**: 无需使用 class 关键字即可创建 preact 组件
+- :hammer: **[preact-hyperscript](https://github.com/queckezz/preact-hyperscript)**: 用于创建元素的类 Hyperscript 语法
+- :white_check_mark: **[shallow-compare](https://github.com/tkh44/shallow-compare)**: 简化的 `shouldComponentUpdate` 辅助函数。
+- :signal_strength: **[@deepsignal/preact](https://github.com/EthanStandel/deepsignal/tree/main/packages/preact)**: `@preact/signals` 的扩展，用于完整的状态管理


### PR DESCRIPTION
Purely just clean up/consistency issues:

- `marked` at some point stopped supporting markdown formatting within links (`**`, `__`, etc). Seems to have been years ago though as some links were formatted correctly, others were not.
  - `**Preact Website** _(preactjs.com)_` is currently displayed like this on the site
- We were using two spaces at the end of content to for a line break. This is a bit fiddly, and wasn't applied everywhere, so I've replaced with `<br>`
- Corrects capitalization of "GitHub"

Probably should go through all of these libs & examples to see which are still around, butt that's a task for another day