### PR TITLE
refactor: Rebuild header components

### DIFF
--- a/content/en/guide/v8/getting-started.md
+++ b/content/en/guide/v8/getting-started.md
@@ -6,7 +6,7 @@ title: Getting Started
 
 This guide walks through building a simple "ticking clock" component. More detailed information for each topic can be found in the dedicated pages under the Guide menu.
 
-> :information*desk_person: You [don't \_have* to use ES2015 to use Preact](https://github.com/developit/preact-without-babel)... but you should. This guide assumes you have some sort of ES2015 build set up using babel and/or webpack/browserify/gulp/grunt/etc. If you don't, start with [preact-cli](https://github.com/preactjs/preact-cli) or a [CodePen Template](http://codepen.io/developit/pen/pgaROe?editors=0010).
+> :information_desk_person: You [don't _have_ to use ES2015 to use Preact](https://github.com/developit/preact-without-babel)... but you should. This guide assumes you have some sort of ES2015 build set up using babel and/or webpack/browserify/gulp/grunt/etc.  If you don't, start with [preact-cli](https://github.com/preactjs/preact-cli) or a [CodePen Template](http://codepen.io/developit/pen/pgaROe?editors=0010).
 
 ---
 

--- a/src/components/blog-overview/index.jsx
+++ b/src/components/blog-overview/index.jsx
@@ -1,6 +1,5 @@
 import config from '../../config.json';
-import { useLanguage, useTranslation } from '../../lib/i18n';
-import { getRouteName } from '../header';
+import { useLanguage, useTranslation, getRouteName } from '../../lib/i18n';
 import { Time } from '../time';
 import { prefetchContent } from '../../lib/use-content';
 import { BlogPage } from '../routes.jsx';
@@ -28,10 +27,21 @@ export default function BlogOverview() {
 								<Time value={post.date} />
 							</div>
 							<h2 class={s.title}>
-								<a href={post.path} onMouseOver={prefetchAndPreload} onTouchStart={prefetchAndPreload}>{name}</a>
+								<a
+									href={post.path}
+									onMouseOver={prefetchAndPreload}
+									onTouchStart={prefetchAndPreload}
+								>
+									{name}
+								</a>
 							</h2>
 							<p class={s.excerpt}>{excerpt}</p>
-							<a href={post.path} onMouseOver={prefetchAndPreload} onTouchStart={prefetchAndPreload} class="btn-small">
+							<a
+								href={post.path}
+								onMouseOver={prefetchAndPreload}
+								onTouchStart={prefetchAndPreload}
+								class="btn-small"
+							>
 								{continueReading} &rarr;
 							</a>
 						</article>

--- a/src/components/blog-overview/index.jsx
+++ b/src/components/blog-overview/index.jsx
@@ -27,21 +27,10 @@ export default function BlogOverview() {
 								<Time value={post.date} />
 							</div>
 							<h2 class={s.title}>
-								<a
-									href={post.path}
-									onMouseOver={prefetchAndPreload}
-									onTouchStart={prefetchAndPreload}
-								>
-									{name}
-								</a>
+								<a href={post.path} onMouseOver={prefetchAndPreload} onTouchStart={prefetchAndPreload}>{name}</a>
 							</h2>
 							<p class={s.excerpt}>{excerpt}</p>
-							<a
-								href={post.path}
-								onMouseOver={prefetchAndPreload}
-								onTouchStart={prefetchAndPreload}
-								class="btn-small"
-							>
+							<a href={post.path} onMouseOver={prefetchAndPreload} onTouchStart={prefetchAndPreload} class="btn-small">
 								{continueReading} &rarr;
 							</a>
 						</article>

--- a/src/components/header/index.jsx
+++ b/src/components/header/index.jsx
@@ -56,6 +56,7 @@ function MainNav() {
 			<NavLink
 				href="/"
 				clsx="home"
+				flair={<InvertedLogo title="Preact Logo" />}
 				onContextMenu={brandingRedirect}
 				aria-label="Home"
 			/>
@@ -214,13 +215,14 @@ function NavMenu(props) {
  * @typedef {Object} NavLinkProps
  * @property {string} props.href
  * @property {string} [props.clsx]
+ * @property {import('preact').ComponentChildren} [props.flair]
  * @property {boolean} [props.isOpen]
  */
 
 /**
  * @param {NavLinkProps & import('preact').AnchorHTMLAttributes} props
  */
-function NavLink({ href, clsx, isOpen, ...rest }) {
+function NavLink({ href, flair, clsx, isOpen, ...rest }) {
 	const { path } = useLocation();
 	const label = useNavTranslation(href);
 
@@ -244,7 +246,7 @@ function NavLink({ href, clsx, isOpen, ...rest }) {
 			class={cx(pathMatchesRoute(href, path) && style.current, clsx)}
 			{...rest}
 		>
-			{href == '/' ? <InvertedLogo title="Preact Logo" /> : null}
+			{flair}
 			{label}
 		</a>
 	);

--- a/src/components/header/index.jsx
+++ b/src/components/header/index.jsx
@@ -61,7 +61,7 @@ function MainNav() {
 			/>
 			<NavLink href="/tutorial" />
 			<NavLink href="/guide/v10/getting-started" />
-			<Menu>
+			<NavMenu>
 				{isOpen => (
 					<ExpandableNavLink isOpen={isOpen} label={about}>
 						<>
@@ -73,7 +73,7 @@ function MainNav() {
 						</>
 					</ExpandableNavLink>
 				)}
-			</Menu>
+			</NavMenu>
 			<NavLink href="/blog" />
 			<NavLink href="/repl" />
 		</nav>
@@ -118,7 +118,7 @@ function LanguagePicker() {
 
 	return (
 		<div class={style.translation}>
-			<Menu>
+			<NavMenu>
 				{isOpen => (
 					<ExpandableNavLink
 						isOpen={isOpen}
@@ -141,7 +141,7 @@ function LanguagePicker() {
 							))}
 					</ExpandableNavLink>
 				)}
-			</Menu>
+			</NavMenu>
 		</div>
 	);
 }
@@ -184,7 +184,7 @@ const HamburgerMenu = ({ open, ...props }) => (
  * @param {Object} props
  * @param {(open: boolean) => import('preact').JSX.Element} props.children
  */
-function Menu(props) {
+function NavMenu(props) {
 	const [isOpen, setIsOpen] = useState(false);
 
 	useEffect(() => {

--- a/src/components/header/index.jsx
+++ b/src/components/header/index.jsx
@@ -1,21 +1,16 @@
-import { Component } from 'preact';
 import cx from '../../lib/cx';
 import { InvertedLogo } from '../logo';
 import Search from './search';
 import style from './style.module.css';
 import config from '../../config.json';
-import { useCallback, useEffect } from 'preact/hooks';
+import { useCallback, useEffect, useState } from 'preact/hooks';
 import ReleaseLink from './gh-version';
 import Corner from './corner';
 import { useOverlayToggle } from '../../lib/toggle-overlay';
 import { useLocation } from 'preact-iso';
-import { useLanguage } from '../../lib/i18n';
+import { useLanguage, useTranslation, useNavTranslation } from '../../lib/i18n';
 import { prefetchContent } from '../../lib/use-content';
 import { ReplPage, TutorialPage, CodeEditor } from '../routes';
-
-const LINK_FLAIR = {
-	logo: InvertedLogo
-};
 
 export default function Header() {
 	const { url } = useLocation();
@@ -35,38 +30,10 @@ export default function Header() {
 			</div>
 			<div class={style.outer}>
 				<div class={style.inner}>
-					<Nav class={style.nav} routes={config.nav} current={url} />
+					<MainNav />
 					<Search />
-					<div class={style.social}>
-						<ReleaseLink class={cx(style.socialItem, style.release)} />
-						<SocialIcon
-							label="Browse the code on GitHub"
-							href="https://github.com/preactjs/preact"
-							viewbox="0 0 24 24"
-							id="github"
-						/>
-						<SocialIcon
-							label="Follow us on Twitter"
-							href="https://twitter.com/preactjs"
-							viewbox="0 0 34 27.646"
-							id="twitter"
-						/>
-						<SocialIcon
-							label="Follow us on Bluesky"
-							href="https://bsky.app/profile/preactjs.com"
-							viewbox="0 0 568 501"
-							id="bluesky"
-						/>
-						<SocialIcon
-							label="Chat with us on Slack"
-							href="http://chat.preactjs.com/"
-							viewbox="0 0 512 512"
-							id="slack"
-						/>
-					</div>
-					<div class={style.translation}>
-						<NavMenu language />
-					</div>
+					<SocialLinks />
+					<LanguagePicker />
 					<HamburgerMenu open={open} onClick={toggle} />
 				</div>
 			</div>
@@ -75,6 +42,117 @@ export default function Header() {
 	);
 }
 
+function MainNav() {
+	const { route } = useLocation();
+	const about = useNavTranslation('/about');
+
+	const brandingRedirect = e => {
+		e.preventDefault();
+		route('/branding');
+	};
+
+	return (
+		<nav class={style.nav}>
+			<NavLink
+				href="/"
+				clsx="home"
+				onContextMenu={brandingRedirect}
+				aria-label="Home"
+			/>
+			<NavLink href="/tutorial" />
+			<NavLink href="/guide/v10/getting-started" />
+			<Menu>
+				{isOpen => (
+					<ExpandableNavLink isOpen={isOpen} label={about}>
+						<>
+							<NavLink href="/about/we-are-using" />
+							<NavLink href="/about/libraries-addons" />
+							<NavLink href="/about/demos-examples" />
+							<NavLink href="/about/project-goals" />
+							<NavLink href="/about/browser-support" />
+						</>
+					</ExpandableNavLink>
+				)}
+			</Menu>
+			<NavLink href="/blog" />
+			<NavLink href="/repl" />
+		</nav>
+	);
+}
+
+function SocialLinks() {
+	return (
+		<div class={style.social}>
+			<ReleaseLink class={cx(style.socialItem, style.release)} />
+			<SocialIcon
+				label="Browse the code on GitHub"
+				href="https://github.com/preactjs/preact"
+				viewbox="0 0 24 24"
+				id="github"
+			/>
+			<SocialIcon
+				label="Follow us on Twitter"
+				href="https://twitter.com/preactjs"
+				viewbox="0 0 34 27.646"
+				id="twitter"
+			/>
+			<SocialIcon
+				label="Follow us on Bluesky"
+				href="https://bsky.app/profile/preactjs.com"
+				viewbox="0 0 568 501"
+				id="bluesky"
+			/>
+			<SocialIcon
+				label="Chat with us on Slack"
+				href="http://chat.preactjs.com/"
+				viewbox="0 0 512 512"
+				id="slack"
+			/>
+		</div>
+	);
+}
+
+function LanguagePicker() {
+	const [lang, setLang] = useLanguage();
+	const selectYourLanguage = useTranslation('selectYourLanguage');
+
+	return (
+		<div class={style.translation}>
+			<Menu>
+				{isOpen => (
+					<ExpandableNavLink
+						isOpen={isOpen}
+						label={
+							<svg aria-hidden viewBox="0 0 24 24">
+								<use href="/icons.svg#i18n" />
+							</svg>
+						}
+						ariaLabel={selectYourLanguage}
+					>
+						{typeof window !== 'undefined' &&
+							Object.keys(config.languages).map(id => (
+								<button
+									class={cx(id == lang && style.current)}
+									data-value={id}
+									onClick={e => setLang(e.currentTarget.dataset.value)}
+								>
+									{config.languages[id]}
+								</button>
+							))}
+					</ExpandableNavLink>
+				)}
+			</Menu>
+		</div>
+	);
+}
+
+/**
+ * @param {Object} props
+ * @param {string} props.label - The aria label for the social icon
+ * @param {string} props.href - The URL the icon links to
+ * @param {string} props.viewbox - The SVG viewBox attribute -- must match the SVG's viewBox
+ * @param {string} props.id - The ID of the icon in the `/icons.svg` spritesheet
+ */
 const SocialIcon = ({ label, href, viewbox, id }) => (
 	<a
 		class={style.socialItem}
@@ -89,133 +167,62 @@ const SocialIcon = ({ label, href, viewbox, id }) => (
 	</a>
 );
 
+/**
+ * @param {{ open: boolean } & import('preact').HTMLAttributes<HTMLDivElement>} props
+ */
 const HamburgerMenu = ({ open, ...props }) => (
-	<div class={style.hamburger} open={open} {...props}>
+	<div class={style.hamburger} data-open={open} {...props}>
 		<div class={style.hb1} />
 		<div class={style.hb2} />
 		<div class={style.hb3} />
 	</div>
 );
 
-// nested nav renderer
-const Nav = ({ routes, current, ...props }) => (
-	<nav {...props}>
-		{routes.map(route =>
-			route.routes ? (
-				<NavMenu
-					to={route}
-					current={current}
-					data-route={getRouteIdent(route)}
-				/>
-			) : (
-				<NavLink
-					to={route}
-					class={cx(
-						route.class,
-						(pathMatchesRoute(current, route) ||
-							(route.content === 'guide' && /^\/guide\//.test(current)) ||
-							(route.content === 'blog' && /^\/blog\//.test(current))) &&
-							style.current
-					)}
-				/>
-			)
-		)}
-	</nav>
-);
+/**
+ * Sets up event listeners to toggle submenu visibility. Takes the menu as a child function
+ *
+ * @param {Object} props
+ * @param {(open: boolean) => import('preact').JSX.Element} props.children
+ */
+function Menu(props) {
+	const [isOpen, setIsOpen] = useState(false);
 
-// nav items are really the only complex bit for menuing, since they handle click events.
-class NavMenu extends Component {
-	state = { open: false };
+	useEffect(() => {
+		// We don't actually have to check where the click occurs, as if
+		// it happens within the menu, the toggle handler will close it.
+		// Therefore, this will only catch the clicks outside the menu.
+		const handleClickOutside = () => {
+			if (isOpen) setIsOpen(false);
+		};
 
-	close = () => (this.setState({ open: false }), false);
+		addEventListener('click', handleClickOutside);
+		return () => removeEventListener('click', handleClickOutside);
+	}, [isOpen]);
 
-	toggle = () => (this.setState({ open: !this.state.open }), false);
-
-	handleClickOutside = ({ target }) => {
-		if (this.state.open) {
-			do {
-				if (target === this.__v.__e) return;
-			} while ((target = target.parentNode));
-			this.close();
-		}
-	};
-
-	componentDidMount() {
-		addEventListener('click', this.handleClickOutside);
-	}
-
-	componentWillUnmount() {
-		removeEventListener('click', this.handleClickOutside);
-	}
-
-	componentDidUpdate({ current }) {
-		if (current !== this.props.current && this.state.open) {
-			this.close();
-		}
-	}
-
-	render({ to, current, language, ...props }, { open }) {
-		return (
-			<div {...props} data-open={open} class={style.navGroup}>
-				{language ? (
-					<LanguageSelectorMenu
-						isOpen={open}
-						toggle={this.toggle}
-						close={this.close}
-						{...props}
-					/>
-				) : (
-					<>
-						<NavLink
-							to={to}
-							onClick={this.toggle}
-							aria-haspopup
-							isOpen={open}
-						/>
-						<Nav
-							routes={to.routes}
-							current={current}
-							aria-label="submenu"
-							aria-hidden={'' + !open}
-						/>
-					</>
-				)}
-			</div>
-		);
-	}
+	return (
+		<div
+			class={style.navGroup}
+			data-open={isOpen}
+			onClick={() => setIsOpen(!isOpen)}
+		>
+			{props.children(isOpen)}
+		</div>
+	);
 }
 
-// depending on the type of nav link, use <a>
-const NavLink = ({ to, isOpen, route, ...props }) => {
-	const location = useLocation();
-	const [lang] = useLanguage();
-	let Flair = to.flair && LINK_FLAIR[to.flair];
+/**
+ * @typedef {Object} NavLinkProps
+ * @property {string} props.href
+ * @property {string} [props.clsx]
+ * @property {boolean} [props.isOpen]
+ */
 
-	if (to.skipHeader) return;
-
-	if (!to.path) {
-		return (
-			<button
-				{...props}
-				aria-haspopup="true"
-				aria-expanded={isOpen}
-				data-route={route}
-			>
-				{getRouteName(to, lang)}
-			</button>
-		);
-	}
-
-	function BrandingRedirect(e) {
-		e.preventDefault();
-		location.route('/branding');
-	}
-
-	const href = to.href || to.path;
-	const homeProps =
-		to.href == '/' || to.path == '/'
-			? { onContextMenu: BrandingRedirect, 'aria-label': 'Home' }
-			: {};
+/**
+ * @param {NavLinkProps & import('preact').AnchorHTMLAttributes} props
+ */
+function NavLink({ href, clsx, isOpen, ...rest }) {
+	const { path } = useLocation();
+	const label = useNavTranslation(href);
 
 	const prefetchAndPreload = () => {
 		if (href.startsWith('/repl')) {
@@ -234,79 +241,50 @@ const NavLink = ({ to, isOpen, route, ...props }) => {
 			href={href}
 			onMouseOver={prefetchAndPreload}
 			onTouchStart={prefetchAndPreload}
-			{...props}
-			data-route={route}
-			{...homeProps}
+			class={cx(pathMatchesRoute(href, path) && style.current, clsx)}
+			{...rest}
 		>
-			{Flair && <Flair title="Preact Logo" />}
-			{getRouteName(to, lang)}
+			{href == '/' ? <InvertedLogo title="Preact Logo" /> : null}
+			{label}
 		</a>
 	);
-};
+}
 
-const LanguageSelectorMenu = ({ isOpen, toggle, close, ...props }) => {
-	const [lang, setLang] = useLanguage();
-	const onClick = useCallback(
-		e => {
-			setLang(e.target.dataset.value);
-			close();
-		},
-		[setLang]
-	);
-
+/**
+ * Button that expands into a menu when clicked. Pass in label & menu items as children.
+ *
+ * @param {Object} props
+ * @param {boolean} props.isOpen
+ * @param {string | import('preact').JSX.Element} props.label
+ * @param {string} [props.ariaLabel]
+ * @param {import('preact').ComponentChildren} props.children
+ */
+function ExpandableNavLink({ isOpen, children, label, ariaLabel }) {
 	return (
 		<>
 			<button
-				{...props}
-				onClick={toggle}
-				aria-label="Select your language"
+				aria-label={ariaLabel || null}
 				aria-haspopup
 				aria-expanded={isOpen}
 			>
-				<svg aria-hidden viewBox="0 0 24 24">
-					<use href="/icons.svg#i18n" />
-				</svg>
+				{label}
 			</button>
 			<nav aria-label="submenu" aria-hidden={!isOpen}>
-				{typeof window !== 'undefined' &&
-					Object.keys(config.languages).map(id => (
-						<span
-							class={cx(id == lang && style.current)}
-							data-value={id}
-							onClick={onClick}
-						>
-							{config.languages[id]}
-						</span>
-					))}
+				{children}
 			</nav>
 		</>
 	);
-};
-
-export function getRouteName(route, lang) {
-	return typeof route.name === 'object'
-		? route.name[lang] || route.name.en
-		: route.name || route.title;
 }
 
+/**
+ * @param {string} path
+ * @param {string} route
+ * @returns {boolean}
+ */
 function pathMatchesRoute(path, route) {
-	if (!route || !route.path) return false;
-	if (path === route.path) return true;
-	let segs = path.replace(/(^\/|\/$)/g, '').split('/');
-	let psegs = route.path.replace(/(^\/|\/$)/g, '').split('/');
-	let len = Math.max(psegs.length, segs.length);
-	for (let i = 0; i < len; i++) {
-		let p = psegs[i];
-		let s = segs[i];
-		if (!p || (p[0] !== ':' && s !== p)) return false;
-		if (!s) return /[?*]$/g.test(p);
-		if (/[*+]$/g.test(p)) return true;
-	}
-	return true;
-}
+	if (!path || !route) return false;
+	if (path === route) return true;
 
-// get a CSS-addressable identifier for a given route
-const getRouteIdent = route =>
-	(getRouteName(route, 'en') || route.url)
-		.toLowerCase()
-		.replace(/[^a-z0-9]/i, '');
+	if (path !== '/' && route.startsWith(path)) return true;
+	return false;
+}

--- a/src/components/header/style.module.css
+++ b/src/components/header/style.module.css
@@ -104,8 +104,7 @@
 		}
 
 		a,
-		button,
-		span {
+		button {
 			display: inline-block;
 			position: relative;
 			height: var(--header-height);
@@ -226,11 +225,11 @@
 			z-index: 750;
 
 			a,
-			button,
-			span {
+			button {
 				display: block;
 				padding: 10px 20px;
 				height: auto;
+				width: 100%;
 				line-height: 1.5;
 				font-size: 15px;
 				color: #444;
@@ -284,8 +283,7 @@
 					animation: menuExpand 250ms ease forwards 1;
 
 					a,
-					button,
-					span {
+					button {
 						color: #eee;
 
 						&:hover,
@@ -459,7 +457,7 @@
 		transform-origin: 0 0;
 	}
 
-	&[open] {
+	&[data-open='true'] {
 		@media (max-width: /* --header-mobile-breakpoint */ 50rem) {
 			position: absolute;
 		}

--- a/src/components/sidebar/index.jsx
+++ b/src/components/sidebar/index.jsx
@@ -3,8 +3,7 @@ import DocVersion from '../doc-version';
 import SidebarNav from './sidebar-nav';
 import config from '../../config.json';
 import { useOverlayToggle } from '../../lib/toggle-overlay';
-import { getRouteName } from '../header';
-import { useLanguage } from '../../lib/i18n';
+import { useLanguage, getRouteName } from '../../lib/i18n';
 import style from './style.module.css';
 
 export default function Sidebar() {
@@ -36,8 +35,10 @@ export default function Sidebar() {
 		}
 	}
 
-	// TODO: use URL match instead of .content
-	const guide = config.nav.filter(item => item.content === 'guide')[0];
+	// TODO: Need to entirely disassociate nav labels from URLs
+	const guide = config.nav.find(
+		item => item.path === '/guide/v10/getting-started'
+	);
 	const sectionName = getRouteName(guide, lang);
 
 	return (

--- a/src/config.json
+++ b/src/config.json
@@ -53,6 +53,9 @@
 			"ru": "Продолжить чтение",
 			"zh": "继续阅读"
 		},
+		"selectYourLanguage": {
+			"en": "Select your language"
+		},
 		"tutorial": {
 			"begin": {
 				"en": "Begin Tutorial",
@@ -78,20 +81,16 @@
 	"nav": [
 		{
 			"path": "/",
-			"name": "Preact",
-			"title": "Home",
-			"class": "home",
-			"flair": "logo",
-			"content": "index"
+			"name": "Preact"
 		},
 		{
 			"path": "/branding",
-			"title": "Branding",
-			"skipHeader": true
+			"name": {
+				"en": "Branding"
+			}
 		},
 		{
-			"path": "/tutorial/:step",
-			"href": "/tutorial",
+			"path": "/tutorial",
 			"name": {
 				"en": "Tutorial",
 				"ja": "チュートリアル",
@@ -101,6 +100,7 @@
 			}
 		},
 		{
+			"path": "/guide/v10/getting-started",
 			"name": {
 				"en": "Guide",
 				"de": "Anleitung",
@@ -110,12 +110,10 @@
 				"pt-br": "Guia",
 				"ru": "Руководство",
 				"zh": "指南"
-			},
-			"content": "guide",
-			"path": "/guide/:version?/:page?",
-			"href": "/guide/v10/getting-started"
+			}
 		},
 		{
+			"path": "/about",
 			"name": {
 				"en": "About",
 				"de": "Mehr",
@@ -126,7 +124,6 @@
 				"ru": "Разное",
 				"zh": "关于"
 			},
-			"content": "about",
 			"routes": [
 				{
 					"path": "/about/we-are-using",

--- a/src/config.json
+++ b/src/config.json
@@ -84,10 +84,7 @@
 			"name": "Preact"
 		},
 		{
-			"path": "/branding",
-			"name": {
-				"en": "Branding"
-			}
+			"path": "/branding"
 		},
 		{
 			"path": "/tutorial",

--- a/src/lib/cx.js
+++ b/src/lib/cx.js
@@ -6,5 +6,5 @@ export default function cx() {
 		if (out) out += ' ';
 		if (x) out += x;
 	}
-	return out;
+	return out || null;
 }

--- a/src/lib/i18n.jsx
+++ b/src/lib/i18n.jsx
@@ -1,6 +1,7 @@
 import { createContext } from 'preact';
 import { useContext, useEffect, useState } from 'preact/hooks';
 import { useLocation } from 'preact-iso';
+
 import { localStorageGet, localStorageSet } from './localstorage';
 import config from '../config.json';
 
@@ -49,7 +50,7 @@ export function LanguageProvider({ children }) {
 		document.documentElement.lang = userLang;
 	}, []);
 
-	const setAndUpdateHtmlAttr = (lang) => {
+	const setAndUpdateHtmlAttr = lang => {
 		localStorageSet('lang', lang);
 		setLang(lang);
 		document.documentElement.lang = lang;
@@ -72,11 +73,44 @@ export function useLanguage() {
 }
 
 /**
- * Get the translation of a key. Defaults to english if no translation is found
+ * Get the translation of a key. Defaults to English if no translation is found
  * @param {string} key
  */
 export function useTranslation(key) {
 	const [lang] = useLanguage();
 	const data = config.i18n[key];
 	return data[lang] || data.en;
+}
+
+/**
+ * Get the translated name of a path based upon the current language.
+ * @param {string} path
+ */
+export function useNavTranslation(path) {
+	const [lang] = useLanguage();
+
+	for (const route in config.nav) {
+		if (config.nav[route].path === path) {
+			return getRouteName(config.nav[route], lang);
+		} else if (config.nav[route].routes) {
+			for (const subRoute of config.nav[route].routes) {
+				if (subRoute.path === path) {
+					return getRouteName(subRoute, lang);
+				}
+			}
+		}
+	}
+
+	return null;
+}
+
+/**
+ * @param {{ name: Record<string, string> | string }} route
+ * @param {string} lang
+ * @return {string}
+ */
+export function getRouteName(route, lang) {
+	return typeof route.name === 'object'
+		? route.name[lang] || route.name.en
+		: route.name;
 }


### PR DESCRIPTION
Forewarning, sorry, this is fairly big.

Refactors most of the header to make everything a bit more fit for purpose but there are no real functional changes. It corrects a few (IMO) minor grievances that have popped up whilst making other edits:

- Our usage / needs have drifted over the years compared to when most of components were built. Plenty of this is my doing, but for example:
  - Whilst we had a `<NavMenu>` for the "About" routes, we later added a language drop down. This overlapped somewhat with the drop-down menu, but not completely, so there's this [awkward ternary](https://github.com/preactjs/preact-www/blob/0d52a6d9397f4ad9dda77b48c6b6f8a16690816d/src/components/header/index.jsx#L160-L182) in the component.
  - We needed to list `/branding` in `config.nav` so that it was detected as a valid route (404 detection and whatnot), but that list makes up the header items, so we [had to add a magic prop](https://github.com/preactjs/preact-www/blob/0d52a6d9397f4ad9dda77b48c6b6f8a16690816d/src/components/header/index.jsx#L194)
  - The "About" menu is sorta a link, sorta not, so we add [an additional conditional](https://github.com/preactjs/preact-www/blob/0d52a6d9397f4ad9dda77b48c6b6f8a16690816d/src/components/header/index.jsx#L196-L207) to give it special handling too. As such, sometimes `<NavLink>` returns an actual link, sometimes it's just a button that triggers no navigation whatsoever. A bit weird.
  - We have a [`pathMatchesRoute` function](https://github.com/preactjs/preact-www/blob/0d52a6d9397f4ad9dda77b48c6b6f8a16690816d/src/components/header/index.jsx#L290-L304) to apply the "selected" header style, but then have added [additional conditionals](https://github.com/preactjs/preact-www/blob/0d52a6d9397f4ad9dda77b48c6b6f8a16690816d/src/components/header/index.jsx#L116-L117) outside of that because the function doesn't actually cover the cases we need.
  - TLDR: We've quickly appended stuff over the years. Happens in every project, but this should hopefully be a bit better for us & easier to adjust in the future when needed.
- Starts to break up `config.json`'s responsibilities
  - Our `config.json` is a bit of a weird god-file, in that it controls templating (`config.nav` -> header links), route definitions (used in `/lib/route-utils.js` for 404 detection & prerendering), and internationalization, all at once.
  - As such, if you wanted to add a class name to the "Home" link in the header, [you're doing it via JSON properties](https://github.com/preactjs/preact-www/blob/0d52a6d9397f4ad9dda77b48c6b6f8a16690816d/src/config.json#L83), not the JSX. Until you need to use variables/components, that is, then you're left [matching routes](https://github.com/preactjs/preact-www/blob/0d52a6d9397f4ad9dda77b48c6b6f8a16690816d/src/components/header/index.jsx#L215-L217).
- Language picker is inaccessible
  - My bad, the picker items are spans missing tabindexes, not that tabindexes there would be preferable over the alternatives anyhow. Can't select language via tabbing through the doc.
  - Swapped the spans for buttons, easy fix at least. Dunno what I was thinking there.

The responsibilities of `config.json` is still a problem that still needs work, but this has at least gotten the templating out for the most part -- no where else are we really passing props via JSON. Ideally, I'll get routes split out from the internationalization in a sane way and then write a plugin to split the i18n file per language, should be about ~5kb of savings there. You'll only need 1 locale at a time of course.

This ships a tiny bit less JS, but nothing stellar. ~1kb less.