### PR TITLE
refactor: Don't redirect json/content 404's to 404 page

### DIFF
--- a/src/assets/_redirects
+++ b/src/assets/_redirects
@@ -10,5 +10,7 @@
 /guide/unit-testing-with-enzyme /guide/v10/unit-testing-with-enzyme
 /guide/progressive-web-apps     /guide/v8/progressive-web-apps
 /guide/v10/tutorial             /tutorial
+
+# Return a smaller asset than the prerendered 404 page for failed "guess-and-check" translation fetches
 /content/*                      /content/en/404.json                   404
 /*                              /404/index.html                        404

--- a/src/assets/_redirects
+++ b/src/assets/_redirects
@@ -1,13 +1,13 @@
-/guide/getting-started /guide/v10/getting-started
-/guide/differences-to-react /guide/v10/differences-to-react
-/guide/switching-to-preact /guide/v10/switching-to-preact
-/guide/types-of-components /guide/v10/components
-/guide/api-reference /guide/v10/api-reference
-/guide/forms /guide/v10/forms
-/guide/linked-state /guide/v8/linked-state
-/guide/external-dom-mutations /guide/v10/external-dom-mutations
-/guide/extending-component /guide/v8/extending-component
+/guide/getting-started          /guide/v10/getting-started
+/guide/differences-to-react     /guide/v10/differences-to-react
+/guide/switching-to-preact      /guide/v10/switching-to-preact
+/guide/types-of-components      /guide/v10/components
+/guide/api-reference            /guide/v10/api-reference
+/guide/forms                    /guide/v10/forms
+/guide/linked-state             /guide/v8/linked-state
+/guide/external-dom-mutations   /guide/v10/external-dom-mutations
+/guide/extending-component      /guide/v8/extending-component
 /guide/unit-testing-with-enzyme /guide/v10/unit-testing-with-enzyme
-/guide/progressive-web-apps /guide/v8/progressive-web-apps
-/guide/v10/tutorial /tutorial
-/* /404/index.html 404
+/guide/progressive-web-apps     /guide/v8/progressive-web-apps
+/guide/v10/tutorial             /tutorial
+/*                              /404/index.html                        404

--- a/src/assets/_redirects
+++ b/src/assets/_redirects
@@ -10,5 +10,5 @@
 /guide/unit-testing-with-enzyme /guide/v10/unit-testing-with-enzyme
 /guide/progressive-web-apps     /guide/v8/progressive-web-apps
 /guide/v10/tutorial             /tutorial
-/*.json                         /content/en/404.json                   404
+/content/*                      /content/en/404.json                   404
 /*                              /404/index.html                        404

--- a/src/assets/_redirects
+++ b/src/assets/_redirects
@@ -10,4 +10,5 @@
 /guide/unit-testing-with-enzyme /guide/v10/unit-testing-with-enzyme
 /guide/progressive-web-apps     /guide/v8/progressive-web-apps
 /guide/v10/tutorial             /tutorial
+/*.json                         /content/en/404.json                   404
 /*                              /404/index.html                        404

--- a/src/assets/_redirects
+++ b/src/assets/_redirects
@@ -5,7 +5,7 @@
 /guide/api-reference            /guide/v10/api-reference
 /guide/forms                    /guide/v10/forms
 /guide/linked-state             /guide/v8/linked-state
-/guide/external-dom-mutations   /guide/v10/external-dom-mutations
+/guide/external-dom-mutations   /guide/v8/external-dom-mutations
 /guide/extending-component      /guide/v8/extending-component
 /guide/unit-testing-with-enzyme /guide/v10/unit-testing-with-enzyme
 /guide/progressive-web-apps     /guide/v8/progressive-web-apps


### PR DESCRIPTION
Netlify, via our config here, is set up to redirect all 404'ing requests to `/404/index.html`, which isn't unreasonable for most pages but our "guess and check" method of fetching translated content makes this a bit wasteful. In the event of a missing translation file, all we do is read the status code & discard the response body, which is the prerendered 404 page (~3kb w/ gzip):

https://github.com/preactjs/preact-www/blob/4cf9283f21d364902d8a4aec492f0d399485dcdb/src/lib/content.js#L16-L18

We could (and perhaps should) build a content manifest to skip some of these needless fetches, in the meantime, we can return a smaller asset at the very least. Reduces data egress & is likely faster for Netlify to respond with.