### PR TITLE
fix: Ensure REPL splitter remains set between renders

### DIFF
--- a/src/components/splitter/index.jsx
+++ b/src/components/splitter/index.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'preact/hooks';
+import { useCallback, useEffect, useState, useLayoutEffect, useRef } from 'preact/hooks';
 import cx from '../../lib/cx';
 import s from './splitter.module.css';
 
@@ -76,9 +76,14 @@ export function Splitter({
 		addEventListener('pointercancel', cancel);
 	}, [splitterOrientation]);
 
+	const ref = useRef(null);
+	useLayoutEffect(() => {
+		ref.current?.style.setProperty('--size', force || initial);
+	}, [force, initial]);
+
 	return (
 		<div
-			ref={(n) => n?.style.setProperty('--size', force || initial)}
+			ref={ref}
 			class={cx(
 				s.container,
 				splitterOrientation === 'horizontal' ? s.horizontal : s.vertical


### PR DESCRIPTION
Revert of #1149 (sort of)

At the time that change was fine (I think), but since then, the splitter will rerender when the user interacts with the code editor and so this callback ref is very bad. Splitter won't remain set after any interactions.

Only difference to pre-1149 is the use of `useLayoutEffect`. I couldn't spot any pop in today, which is what that change was made to correct, but figure a layout effect should fix that just as well if it still exists and won't be problematic here.