### PR TITLE
refactor: Lazily load docsearch only on intent to interact

### DIFF
--- a/src/components/header/search.jsx
+++ b/src/components/header/search.jsx
@@ -69,15 +69,13 @@ export default function Search() {
 	const root = useRef(null);
 	const rendered = useRef(false);
 	const interactedWith = useRef(false);
+	const loadingBar =
+		typeof window !== 'undefined'
+			? document.querySelector('loading-bar')
+			: null;
 
 	const loadDocSearch = () => {
 		if (!rendered.current) {
-			// The <loading-bar> is sat alongside the router & has it's state controlled by it,
-			// so while we could create a new context to be able to set it here, direct DOM
-			// manipulation is a heck of a lot simpler.
-			const loadingBar = document.querySelector('loading-bar');
-			loadingBar.setAttribute('showing', 'true');
-
 			injectDocsearchCSS();
 			render(
 				<ErrorBoundary>
@@ -92,18 +90,25 @@ export default function Search() {
 			);
 
 			waitForDocsearch(root.current).then(docsearchButton => {
+				rendered.current = true;
 				loadingBar.removeAttribute('showing');
 				if (interactedWith.current) {
 					docsearchButton.click();
 				}
 			});
-			rendered.current = true;
 		}
 	};
 
 	// Is `onClick` the only one we need? Enter key will trigger `click` events too on buttons
 	const onInteraction = () => {
 		interactedWith.current = true;
+
+		if (!rendered.current) {
+			// The <loading-bar> is sat alongside the router & has it's state controlled by it,
+			// so while we could create a new context to be able to set it here, direct DOM
+			// manipulation is a heck of a lot simpler.
+			loadingBar.setAttribute('showing', 'true');
+		}
 	};
 
 	return (

--- a/src/components/header/search.jsx
+++ b/src/components/header/search.jsx
@@ -1,31 +1,75 @@
+import { render } from 'preact';
+import { useRef } from 'preact/hooks';
 import { lazy, ErrorBoundary } from 'preact-iso';
 import style from './style.module.css';
 import config from '../../config.json';
 
 const DocSearch = lazy(() => import('@docsearch/react').then(m => m.DocSearch));
+const DocSearchStylesURL = new URL(
+	'@docsearch/css/dist/style.css',
+	import.meta.url
+).href;
+
+// Inject DocSearch styles into the document head *before* app styles
+function injectDocsearchCSS() {
+	if (document.querySelector(`link[href="${DocSearchStylesURL}"]`)) return;
+
+	const link = document.createElement('link');
+	link.rel = 'stylesheet';
+	link.crossOrigin = '';
+	link.href = DocSearchStylesURL;
+	document.head.insertAdjacentElement('afterbegin', link);
+}
 
 // Might be a problem with the Algolia data, but it seemingly
 // appends `#app` to all URLs without a hash fragment.
 //
 // It also returns the full prod URL, which isn't ideal for dev/staging
-const transformItems = (items) =>
+const transformItems = items =>
 	items.map(i => {
-			const url = new URL(i.url);
-			return Object.assign(i, { url: url.pathname + url.hash.replace(/#app$/, '') });
-		}
-	);
+		const url = new URL(i.url);
+		return Object.assign(i, {
+			url: url.pathname + url.hash.replace(/#app$/, '')
+		});
+	});
 
 export default function Search() {
+	const ref = useRef(null);
+	const rendered = useRef(false);
+
+	const loadDocSearch = () => {
+		if (ref.current && !rendered.current) {
+			injectDocsearchCSS();
+			render(
+				<ErrorBoundary>
+					<DocSearch
+						apiKey={config.docsearch.apiKey}
+						indexName={config.docsearch.indexName}
+						appId={config.docsearch.appId}
+						transformItems={transformItems}
+					/>
+				</ErrorBoundary>,
+				ref.current
+			);
+			rendered.current = true;
+		}
+	};
+
 	return (
-		<div class={style.search}>
-			<ErrorBoundary>
-				<DocSearch
-					apiKey={config.docsearch.apiKey}
-					indexName={config.docsearch.indexName}
-					appId={config.docsearch.appId}
-					transformItems={transformItems}
-				/>
-			</ErrorBoundary>
+		<div class={style.search} ref={ref}>
+			{/* Copy/paste of the HTML DocSearch normally generates, used as a placeholder */}
+			<button
+				type="button"
+				aria-label="Search"
+				class="DocSearch DocSearch-Button"
+				onMouseOver={loadDocSearch}
+				onTouchStart={loadDocSearch}
+				onFocus={loadDocSearch}
+			>
+				<span class="DocSearch-Button-Container">
+					<span class="DocSearch-Button-Placeholder">Search</span>
+				</span>
+			</button>
 		</div>
 	);
 }

--- a/src/components/header/search.jsx
+++ b/src/components/header/search.jsx
@@ -72,6 +72,12 @@ export default function Search() {
 
 	const loadDocSearch = () => {
 		if (!rendered.current) {
+			// The <loading-bar> is sat alongside the router & has it's state controlled by it,
+			// so while we could create a new context to be able to set it here, direct DOM
+			// manipulation is a heck of a lot simpler.
+			const loadingBar = document.querySelector('loading-bar');
+			loadingBar.setAttribute('showing', 'true');
+
 			injectDocsearchCSS();
 			render(
 				<ErrorBoundary>
@@ -86,6 +92,7 @@ export default function Search() {
 			);
 
 			waitForDocsearch(root.current).then(docsearchButton => {
+				loadingBar.removeAttribute('showing');
 				if (interactedWith.current) {
 					docsearchButton.click();
 				}

--- a/src/style/docsearch.css
+++ b/src/style/docsearch.css
@@ -1,5 +1,3 @@
-/*@import '@docsearch/css';*/
-
 .DocSearch-Button {
 	display: flex;
 	justify-content: space-between;

--- a/src/style/docsearch.css
+++ b/src/style/docsearch.css
@@ -1,9 +1,13 @@
-@import '@docsearch/css';
+/*@import '@docsearch/css';*/
 
 .DocSearch-Button {
+	display: flex;
+	justify-content: space-between;
 	width: 60px;
+	height: 36px;
 	margin: 10px 5px;
 	padding: 8px 4px 8px 32px;
+	color: var(--docsearch-muted-color);
 	background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 490 490" width="16" height="16"><path fill="none" stroke="%238c68cf" stroke-width="36" stroke-linecap="round" d="m280,278a153,153 0 1,0-2,2l170,170m-91-117 110,110-26,26-110-110"/></svg>');
 	background-position: 10px center;
 	background-repeat: no-repeat;
@@ -13,6 +17,9 @@
 	border-radius: 5px;
 	box-shadow: inset 0 2px 5px rgba(0, 0, 0, 0.2);
 	font-size: 100%;
+	font-weight: 500;
+	cursor: pointer;
+	user-select: none;
 
 	@media (max-width: /* --header-mobile-breakpoint */ 50rem) {
 		width: 100%;
@@ -34,7 +41,17 @@
 		background-position: 10px center;
 		background-repeat: no-repeat;
 		background-color: #58319d !important; /* --color-brand 7% darker */
+		box-shadow: inset 0 0 0 2px var(--docsearch-primary-color);
 	}
+}
+
+.DocSearch-Button-Container {
+	align-items: center;
+	display: flex;
+}
+
+.DocSearch-Button-Placeholder {
+	padding: 0 12px 0 6px;
 }
 
 /* Uses 'muted' color by default, which is fine for the modal,


### PR DESCRIPTION
Instead of lazily loading Docsearch (which offers only a momentary delay in downloading the chunk as it's used in the header), let's lazily load it only upon intent to interact, i.e., upon focus, mouse over, touch start, etc. If they user interacts with the docsearch button prior to mount, we'll show a loading bar & trigger a click imperatively once it's loaded, getting around any "jank" issues where the user will need to submit another click/enter key (if tabbing), etc.

Cuts the initial JS load by about 47% or 28kb. Couple kbs less of CSS too, as that'll lazy load now as well.