### PR TITLE
[fix]Support CRLF in frontmatter parsing

### DIFF
--- a/src/lib/frontmatter.js
+++ b/src/lib/frontmatter.js
@@ -7,7 +7,8 @@ import yaml from 'yaml';
  * @returns {{title: string, description: string, body: string, meta: object}}
  */
 export function parseFrontmatter(content, path = '') {
-	const FRONT_MATTER_REG = /^\s*---\n\s*([\s\S]*?)\s*\n---\n/i;
+	// Accept both LF and CRLF line endings so frontmatter is detected on Windows
+	const FRONT_MATTER_REG = /^\s*---\r?\n\s*([\s\S]*?)\s*\r?\n---\r?\n/i;
 
 	const matches = content.match(FRONT_MATTER_REG);
 	if (!matches) {


### PR DESCRIPTION
Updated the frontmatter regex to accept both LF and CRLF line endings, improving compatibility with Windows environments.