### PR TITLE
[fix]Add validation for Time component value prop

### DIFF
--- a/src/components/time/index.jsx
+++ b/src/components/time/index.jsx
@@ -1,13 +1,32 @@
 import s from './time.module.css';
 
 export function Time({ value }) {
-	const date = new Date(value + 'T00:00');
-	const day = date.toLocaleDateString
-		? date.toLocaleDateString()
-		: date.toDateString();
-	return (
-		<time class={s.time} dateTime={date.toISOString()}>
-			{day}
-		</time>
-	);
+  if (!value || typeof value !== 'string') {
+    console.warn('Time component received invalid "value" prop:', value);
+    return null;
+  }
+
+  const trimmedValue = value.trim();
+  if (trimmedValue === '') {
+    console.warn('"value" prop of Time component becomes empty after trim');
+    return null;
+  }
+
+  const dateStr = trimmedValue + 'T00:00';
+  const date = new Date(dateStr);
+
+  if (isNaN(date.getTime())) {
+    console.warn('Time component failed to parse date string:', dateStr);
+    return null;
+  }
+
+  const day = date.toLocaleDateString 
+    ? date.toLocaleDateString() 
+    : date.toDateString();
+
+  return (
+    <time class={s.time} dateTime={date.toISOString()}>
+      {day}
+    </time>
+  );
 }


### PR DESCRIPTION
The Time component now checks if the 'value' prop is a non-empty string and logs warnings for invalid or unparsable values. This prevents rendering with invalid dates and improves error handling.