### PR TITLE
chore: Disable formatting markdown precommit

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "pre-commit": "npx nano-staged"
   },
   "nano-staged": {
-    "**/*.{css,js,jsx,json,md}": [
+    "**/*.{css,js,jsx,json}": [
       "prettier --write"
     ]
   },


### PR DESCRIPTION
More frustrating than it's worth, we have a lot of comments that are meant to be aligned which prettier keeps trying to move.