### PR TITLE
Fix:Remove hidden visibility from current menu item

### DIFF
--- a/src/components/header/style.module.css
+++ b/src/components/header/style.module.css
@@ -141,10 +141,6 @@
 					padding: 0;
 				}
 
-				&.current {
-					visibility: hidden;
-				}
-
 				svg {
 					position: relative;
 					padding-right: 5px;


### PR DESCRIPTION
I personally believe that the current performance of the website on mobile devices is not optimal, and it would be better if improvements are made.

before:

<img width="1242" height="1139" alt="before-1" src="https://github.com/user-attachments/assets/d90970ea-0200-483f-abf7-ad563741f0ff" />
<img width="639" height="1023" alt="before-2" src="https://github.com/user-attachments/assets/ce8580e0-3936-4c1e-832b-b6985dfd4472" />

after:
<img width="1350" height="1102" alt="after-2" src="https://github.com/user-attachments/assets/4ae9179b-7d06-4ddb-8f80-54a201da4da9" />

<img width="647" height="1015" alt="after-1" src="https://github.com/user-attachments/assets/db8a4d27-3246-483e-978e-c893eeb6bbfe" />
