### PR TITLE
revert: #1329 as it's a symptom of another issue

### DIFF
--- a/src/lib/frontmatter.js
+++ b/src/lib/frontmatter.js
@@ -7,8 +7,7 @@ import yaml from 'yaml';
  * @returns {{title: string, description: string, body: string, meta: object}}
  */
 export function parseFrontmatter(content, path = '') {
-	// Accept both LF and CRLF line endings so frontmatter is detected on Windows
-	const FRONT_MATTER_REG = /^\s*---\r?\n\s*([\s\S]*?)\s*\r?\n---\r?\n/i;
+	const FRONT_MATTER_REG = /^\s*---\n\s*([\s\S]*?)\s*\n---\n/i;
 
 	const matches = content.match(FRONT_MATTER_REG);
 	if (!matches) {


### PR DESCRIPTION
Allowing CRLF line endings was the wrong move, we should not have them to begin with in the project:

https://github.com/preactjs/preact-www/blob/6bd66fbca9331e3ef4274f47e50e855fab41dd69/.editorconfig#L5

#1329 was just one of a handful of symptoms (#1331, #1332, #1333, #1334) stemming from the user's editor not adhering to our `.editorconfig`, causing a whole number of features to break apart at the seams. Reverting & requiring use of the config is the better path, IMO.