### PR TITLE
Fix syntax error / typo in JS code snippet

### DIFF
--- a/content/en/guide/v11/upgrade-guide.md
+++ b/content/en/guide/v11/upgrade-guide.md
@@ -121,7 +121,7 @@ options.vnode = (vnode) => {
         delete vnode.props.ref;
     }
 
-	if oldVNode) oldVNode(vnode);
+	if (oldVNode) oldVNode(vnode);
 }
 ```
 


### PR DESCRIPTION
Fix syntax error / typo in JS code snippet by adding missing open parens in `oldVNode` condition

Feel more than free to close and fix elsewhere -- this was just the easiest way to flag.