### PR TITLE
docs: Add section on typing children/ReactNode

### DIFF
--- a/content/en/guide/v10/typescript.md
+++ b/content/en/guide/v10/typescript.md
@@ -210,6 +210,32 @@ class Expandable extends Component<ExpandableProps, ExpandableState> {
 
 Class components include children by default, typed as `ComponentChildren`.
 
+## Typing children
+
+`ComponentChildren` is a type that represents all valid Preact children. It includes primitive types like `string`, `number`, and `boolean`, but also Preact elements, `null`/`undefined`, and arrays of all of the above. For those familiar with React, it works in a very similar way to `ReactNode`.
+
+```tsx
+import { h, ComponentChildren } from 'preact';
+
+interface MyHeadingComponentProps {
+	children: ComponentChildren;
+}
+
+function MyHeadingComponent({ children }: MyHeadingComponentProps) {
+	return <h1>{children}</h1>;
+}
+
+<MyHeadingComponent>
+	{/* All of these are valid children */}
+	Hello World!
+	<strong>Bold Text</strong>
+	{42}
+	{true}
+	{['Array', 'of', 'strings']}
+	<OtherComponent />
+</MyHeadingComponent>
+```
+
 ## Inheriting HTML properties
 
 When we write components like `<Input />` that wrap the HTML `<input>`, most of the time we'd want to inherit


### PR DESCRIPTION
Closes #1359 

`ReactNode` keeps popping up in our Algolia search results as a miss, figure we need better docs here to catch those users. As always, wording/content feedback is welcome & appreciated.