### PR TITLE
chore: Add 'aria-label' for all nav areas

### DIFF
--- a/src/components/header/index.jsx
+++ b/src/components/header/index.jsx
@@ -51,7 +51,7 @@ function MainNav() {
 	};
 
 	return (
-		<nav class={style.nav}>
+		<nav class={style.nav} aria-label="Main navigation">
 			<NavLink
 				href="/"
 				clsx="home"

--- a/src/components/sidebar/sidebar-nav.jsx
+++ b/src/components/sidebar/sidebar-nav.jsx
@@ -16,7 +16,10 @@ export default function SidebarNav({ items, onClick }) {
 	const { path } = useRoute();
 
 	return (
-		<nav class={cx(style.toc, !(items && items.length > 1) && style.disabled)}>
+		<nav
+			class={cx(style.toc, !(items && items.length > 1) && style.disabled)}
+			aria-label="Sidebar Navigation"
+		>
 			{items.map(({ text, level, href, routes }) => {
 				if (!href) {
 					return (

--- a/src/components/table-of-contents/index.jsx
+++ b/src/components/table-of-contents/index.jsx
@@ -20,7 +20,7 @@ export default function Toc() {
 	if (items.length === 0) return null;
 
 	return (
-		<nav>
+		<nav aria-label="Table of Contents">
 			<ul>
 				{items.map(entry => <TocItem {...entry} />)}
 			</ul>


### PR DESCRIPTION
Fiddling with Algolia and went to exclude the ToC from indexing and realized we don't have any label for it at the moment.

Potentially could add a real label, though I think it's unnecessary. We should have an `aria-label` for it though at the least

Edit: On second thought, all of our nav areas should have aria labels. Will fix.