### PR TITLE
docs: Add TypeScript note for Symbol.dispose in models

### DIFF
--- a/content/en/guide/v10/signals.md
+++ b/content/en/guide/v10/signals.md
@@ -591,6 +591,8 @@ todoList.addTodo('Walk the dog');
 todoList[Symbol.dispose]();
 ```
 
+> **TypeScript:** If you call `model[Symbol.dispose]()` directly, add `"ESNext.Disposable"` (or `"ESNext"`) to the `lib` array in your `tsconfig.json` so that `Symbol.dispose` is typed.
+
 ### Recommended Patterns
 
 #### Explicit ReadonlySignal Pattern
@@ -807,6 +809,8 @@ console.log(counter.doubled.value); // 12
 // Clean up all effects when done
 counter[Symbol.dispose]();
 ```
+
+> **TypeScript:** Calling `model[Symbol.dispose]()` requires `"ESNext.Disposable"` (or `"ESNext"`) in your `tsconfig.json` `lib` array.
 
 ### action(fn)
 

--- a/content/en/guide/v11/signals.md
+++ b/content/en/guide/v11/signals.md
@@ -591,6 +591,8 @@ todoList.addTodo('Walk the dog');
 todoList[Symbol.dispose]();
 ```
 
+> **TypeScript:** If you call `model[Symbol.dispose]()` directly, add `"ESNext.Disposable"` (or `"ESNext"`) to the `lib` array in your `tsconfig.json` so that `Symbol.dispose` is typed.
+
 ### Recommended Patterns
 
 #### Explicit ReadonlySignal Pattern
@@ -807,6 +809,8 @@ console.log(counter.doubled.value); // 12
 // Clean up all effects when done
 counter[Symbol.dispose]();
 ```
+
+> **TypeScript:** Calling `model[Symbol.dispose]()` requires `"ESNext.Disposable"` (or `"ESNext"`) in your `tsconfig.json` `lib` array.
 
 ### action(fn)
 


### PR DESCRIPTION
## Summary
- Adds a brief TypeScript note near each `model[Symbol.dispose]()` example in the Signals docs, advising users to include `ESNext.Disposable` in their `tsconfig.json` `lib`.
- The library typings no longer require this (fixed in preactjs/signals#911), but app code that references `Symbol.dispose` directly still needs the type.