### PR TITLE
docs: Remove unnecessary ref & JSX namespace mentions in v11 upgrade guide

### DIFF
--- a/content/en/guide/v11/upgrade-guide.md
+++ b/content/en/guide/v11/upgrade-guide.md
@@ -103,9 +103,9 @@ function Modal({ children }) {
 }
 ```
 
-### React 19 compatibility
+### React compatibility
 
-`preact/compat` now reports React version `19.0.0` and includes several APIs introduced by newer React releases:
+`preact/compat` includes several APIs introduced by newer React releases:
 
 - `use()` for reading Promises and Context
 - `useEffectEvent()`

--- a/content/en/guide/v11/upgrade-guide.md
+++ b/content/en/guide/v11/upgrade-guide.md
@@ -215,20 +215,6 @@ Similar to the change made in React 19, we've changed the `useRef` type signatur
 
 `RefObject<T>` now describes a ref whose `current` value is `T`. Include `null` in the type argument where applicable, such as `RefObject<HTMLElement | null>`.
 
-#### Removed deprecated ref types
-
-The deprecated `PropRef` and `ForwardFn` types have been removed. Use `Ref` and `ForwardRefRenderFunction` instead. Note that `ForwardFn` accepted its prop type first, whereas `ForwardRefRenderFunction` accepts its ref type first:
-
-```ts
-import type * as React from 'preact/compat';
-
-// Preact 10
-const Component: React.ForwardFn<Props, Handle> = render;
-
-// Preact 11
-const Component: React.ForwardRefRenderFunction<Handle, Props> = render;
-```
-
 #### Reduction in `JSX` namespace
 
 TypeScript uses the special `JSX` namespace to alter how JSX is typed and interpreted. In v10, we greatly expanded this namespace to include a variety of useful types, but many of these are better implemented in the `preact` namespace instead.
@@ -246,5 +232,3 @@ import { ButtonHTMLAttributes } from 'preact';
 
 type MyCustomButtonProps = ButtonHTMLAttributes & { ... }
 ```
-
-If you augment Preact's JSX types, target the `preact` module or the `preact.JSX` namespace instead of the global `JSX` namespace. See [Extending built-in JSX types](/guide/v11/typescript#extending-built-in-jsx-types) for examples.


### PR DESCRIPTION
Just a couple follow-up comments to #1386

- Types
  - `PropRef`
    - Lived in `/hooks`, but private. Was only publicly available through `/compat`.
    - I see 0 usage on GitHub, it's been known broken for years, and it's unlikely people are reaching into compat for a non-React type.
  - `ForwardFn`
    - Basically a typo'd & backwards version of `ForwardRefRenderFunction` that goes back to when types were initially added.
    - It too has 0 use and was only available from compat.
  - `JSX` namespace augmentation
    - Nothing's changed here between 10 & 11. As such, I don't think we should mention this here on the upgrade guide.
- Version
  - It's better if we try to avoid referencing specific versions of React going forward. We support particular APIs where they're appropriate, we don't match versions as a whole.
  - People got super confused in the v10 docs that referenced v15-19, but it was super blurry as we obviously skipped some 18 & 19 features but included others.

