### PR TITLE
docs: clarify Component.render() timing guidance

### DIFF
--- a/content/en/guide/v10/api-reference.md
+++ b/content/en/guide/v10/api-reference.md
@@ -48,6 +48,8 @@ class MyComponent extends Component {
 }
 ```
 
+`render()` describes the component's Virtual DOM output for its current props and state. When code needs to run at a specific point in the mounting or update cycle, class components can use [lifecycle methods](/guide/v10/components#lifecycle-methods). The [Side Effects tutorial](/tutorial/07-side-effects) shows examples using lifecycle methods and `useEffect()`.
+
 To learn more about components and how they can be used, check out the [Components Documentation](/guide/v10/components).
 
 ### render()

--- a/content/en/guide/v10/api-reference.md
+++ b/content/en/guide/v10/api-reference.md
@@ -48,7 +48,7 @@ class MyComponent extends Component {
 }
 ```
 
-`render()` describes the component's Virtual DOM output for its current props and state. When code needs to run at a specific point in the mounting or update cycle, class components can use [lifecycle methods](/guide/v10/components#lifecycle-methods). The [Side Effects tutorial](/tutorial/07-side-effects) shows examples using lifecycle methods and `useEffect()`.
+When code needs to run at a specific point in the mounting or update cycle, class components can use [lifecycle methods](/guide/v10/components#lifecycle-methods) and function components can use [`useEffect()`](/guide/v10/hooks#useeffect). Examples for both can be found in the [Side Effects tutorial](/tutorial/07-side-effects).
 
 To learn more about components and how they can be used, check out the [Components Documentation](/guide/v10/components).
 

--- a/content/en/guide/v11/api-reference.md
+++ b/content/en/guide/v11/api-reference.md
@@ -48,7 +48,7 @@ class MyComponent extends Component {
 }
 ```
 
-`render()` describes the component's Virtual DOM output for its current props and state. When code needs to run at a specific point in the mounting or update cycle, class components can use [lifecycle methods](/guide/v11/components#lifecycle-methods). The [Side Effects tutorial](/tutorial/07-side-effects) shows examples using lifecycle methods and `useEffect()`.
+When code needs to run at a specific point in the mounting or update cycle, class components can use [lifecycle methods](/guide/v11/components#lifecycle-methods) and function components can use [`useEffect()`](/guide/v11/hooks#useeffect). Examples for both can be found in the [Side Effects tutorial](/tutorial/07-side-effects).
 
 To learn more about components and how they can be used, check out the [Components Documentation](/guide/v11/components).
 

--- a/content/en/guide/v11/api-reference.md
+++ b/content/en/guide/v11/api-reference.md
@@ -48,6 +48,8 @@ class MyComponent extends Component {
 }
 ```
 
+`render()` describes the component's Virtual DOM output for its current props and state. When code needs to run at a specific point in the mounting or update cycle, class components can use [lifecycle methods](/guide/v11/components#lifecycle-methods). The [Side Effects tutorial](/tutorial/07-side-effects) shows examples using lifecycle methods and `useEffect()`.
+
 To learn more about components and how they can be used, check out the [Components Documentation](/guide/v11/components).
 
 ### render()


### PR DESCRIPTION
Adds direct links from `Component.render()` to lifecycle methods and `useEffect()` in the v10 and v11 docs, with examples in the existing Side Effects tutorial.

Disclosure: I used AI assistance to draft the original PR description and documentation wording.

Closes #1392.